### PR TITLE
[Refactor]Prepare for repository rename to datus-db-adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,10 @@ Plugin Adapters (Independent packages, install as needed)
 ├── datus-sqlalchemy (SQLAlchemy base layer)
 │   ├── datus-mysql
 │   ├── datus-starrocks
-│   └── datus-postgresql (coming soon)
 │
 └── Native SDK Adapters
     ├── datus-snowflake
     ├── datus-clickzetta
-    ├── datus-clickhouse (coming soon)
-    └── datus-bigquery (coming soon)
 ```
 
 ## Implemented Adapters
@@ -110,21 +107,6 @@ pip install datus-clickzetta
 
 ---
 
-## Coming Soon
-
-### datus-postgresql
-PostgreSQL database adapter (SQLAlchemy-based).
-
-### datus-clickhouse
-ClickHouse database adapter (native SDK).
-
-### datus-bigquery
-Google BigQuery adapter (cloud service SDK).
-
-### datus-oracle
-Oracle database adapter (SQLAlchemy-based).
----
-
 ## Development Guide
 
 ### Development Environment Setup
@@ -133,8 +115,8 @@ This repository uses workspace configuration to manage multiple adapter packages
 
 ```bash
 # Clone repository
-git clone https://github.com/your-org/Datus-adapters.git
-cd Datus-adapters
+git clone https://github.com/your-org/datus-db-adapters.git
+cd datus-db-adapters
 
 # Install all adapters (development mode)
 uv sync
@@ -197,27 +179,6 @@ def register():
 
 register()
 ```
-
-### Testing
-
-Each adapter should include comprehensive tests:
-
-```bash
-cd datus-<database>
-pytest tests/
-```
-
-### Publishing
-
-```bash
-# Build
-python -m build
-
-# Publish to PyPI
-python -m twine upload dist/*
-```
-
----
 
 ## Using with Datus Agent
 

--- a/datus-clickzetta/pyproject.toml
+++ b/datus-clickzetta/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datusai/Datus-adapters"
-Repository = "https://github.com/datusai/Datus-adapters"
-Issues = "https://github.com/datusai/Datus-adapters/issues"
+Homepage = "https://github.com/Datus-ai/datus-db-adapters"
+Repository = "https://github.com/Datus-ai/datus-db-adapters"
+Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
 
 [project.entry-points."datus.adapters"]
 clickzetta = "datus_clickzetta:register"

--- a/datus-mysql/pyproject.toml
+++ b/datus-mysql/pyproject.toml
@@ -24,9 +24,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datusai/Datus-adapters"
-Repository = "https://github.com/datusai/Datus-adapters"
-Issues = "https://github.com/datusai/Datus-adapters/issues"
+Homepage = "https://github.com/Datus-ai/datus-db-adapters"
+Repository = "https://github.com/Datus-ai/datus-db-adapters"
+Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
 
 [project.entry-points."datus.adapters"]
 mysql = "datus_mysql:register"

--- a/datus-sqlalchemy/pyproject.toml
+++ b/datus-sqlalchemy/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datusai/Datus-adapters"
-Repository = "https://github.com/datusai/Datus-adapters"
-Issues = "https://github.com/datusai/Datus-adapters/issues"
+Homepage = "https://github.com/Datus-ai/datus-db-adapters"
+Repository = "https://github.com/Datus-ai/datus-db-adapters"
+Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/datus-starrocks/pyproject.toml
+++ b/datus-starrocks/pyproject.toml
@@ -29,9 +29,9 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datusai/Datus-adapters"
-Repository = "https://github.com/datusai/Datus-adapters"
-Issues = "https://github.com/datusai/Datus-adapters/issues"
+Homepage = "https://github.com/Datus-ai/datus-db-adapters"
+Repository = "https://github.com/Datus-ai/datus-db-adapters"
+Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
 
 [project.entry-points."datus.adapters"]
 starrocks = "datus_starrocks:register"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # etc.
 
 [project]
-name = "datus-adapters"
+name = "datus-db-adapters"
 version = "0.1.0"
 description = "Datus database adapters workspace (development only)"
 requires-python = ">=3.12"


### PR DESCRIPTION
Update all repository references from Datus-adapters to datus-db-adapters to better reflect the scope of future adapter types beyond databases. Changes include:

- Update git clone commands and workspace name
- Update all package URLs to point to Datus-ai/datus-db-adapters
- Clean up README documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up README by removing references to upcoming database adapters and development workflow sections.

* **Chores**
  * Updated project name and repository URLs across all modules to reflect the reorganized project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->