### PR TITLE
[Refactor] Thread-safe connector: per-operation connections + ContextVar isolation

### DIFF
--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -332,7 +332,7 @@ class ClickHouseConnector(SQLAlchemyConnector):
         if database_name:
             from sqlalchemy import text
 
-            conn.execute(text(f"USE {self._quote_identifier(database_name)}"))
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
             conn.commit()
 
     # ==================== Sample Data ====================

--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -70,7 +70,6 @@ class ClickHouseConnector(SQLAlchemyConnector):
         elif not isinstance(config, ClickHouseConfig):
             raise TypeError(f"config must be ClickHouseConfig or dict, got {type(config)}")
 
-        self.config = config
         self.host = config.host
         self.port = config.port
         self.username = config.username
@@ -87,6 +86,9 @@ class ClickHouseConnector(SQLAlchemyConnector):
             dialect="clickhouse",
             timeout_seconds=config.timeout_seconds,
         )
+        # Set after super().__init__() so BaseSqlConnector doesn't overwrite
+        # with a plain ConnectionConfig (which lacks ClickHouse-specific fields)
+        self.config = config
         self._default_database = database
 
     # ==================== System Resources ====================

--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -87,7 +87,7 @@ class ClickHouseConnector(SQLAlchemyConnector):
             dialect="clickhouse",
             timeout_seconds=config.timeout_seconds,
         )
-        self.database_name = database
+        self._default_database = database
 
     # ==================== System Resources ====================
 
@@ -325,10 +325,13 @@ class ClickHouseConnector(SQLAlchemyConnector):
         return database_name or self.database_name
 
     @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch database context. Updates default database for subsequent full_name() calls."""
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply database context to a connection using USE statement."""
         if database_name:
-            self.database_name = database_name
+            from sqlalchemy import text
+
+            conn.execute(text(f"USE {self._quote_identifier(database_name)}"))
+            conn.commit()
 
     # ==================== Sample Data ====================
 

--- a/datus-clickzetta/datus_clickzetta/connector.py
+++ b/datus-clickzetta/datus_clickzetta/connector.py
@@ -401,7 +401,11 @@ class ClickZettaConnector:
     # ------------------------------------------------------------------ #
     # BaseSqlConnector abstract methods
     # ------------------------------------------------------------------ #
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             df = self._run_command(sql)
             row_count = self._extract_row_count(df)
@@ -414,15 +418,26 @@ class ClickZettaConnector:
         except DatusDbException as exc:
             return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql, sql_return="", row_count=0)
 
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
-        return self.execute_insert(sql)
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self.execute_insert(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
 
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
-        return self.execute_insert(sql)
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self.execute_insert(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
 
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             df = self._run_query(sql)
             row_count = len(df)
@@ -486,7 +501,11 @@ class ClickZettaConnector:
                 message=f"Failed to execute query to dict: {str(e)}",
             ) from e
 
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             self._run_command(sql)
             return ExecuteSQLResult(success=True, sql_query=sql, sql_return="Successful", row_count=0)

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -3,6 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 from abc import ABC, abstractmethod
+from contextvars import ContextVar
 from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple
 
 from datus_db_core.config import ConnectionConfig
@@ -14,20 +15,60 @@ from datus_db_core.sql_utils import metadata_identifier, parse_sql_type
 logger = get_logger(__name__)
 
 
+_UNSET = object()
+
+
 class BaseSqlConnector(ABC):
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls)
+        # ContextVar: works with both threading and asyncio (per-task isolation).
+        # Always initialized in __new__ so it survives mocked __init__ in tests.
+        instance._catalog_var = ContextVar(f"catalog_{id(instance)}", default=_UNSET)
+        instance._database_var = ContextVar(f"database_{id(instance)}", default=_UNSET)
+        instance._schema_var = ContextVar(f"schema_{id(instance)}", default=_UNSET)
+        instance._default_catalog = ""
+        instance._default_database = ""
+        instance._default_schema = ""
+        return instance
+
     def __init__(self, config: ConnectionConfig, dialect: str):
         self.config = config
         self.timeout_seconds = config.timeout_seconds
-        self.connection: Any = None
         self.dialect = dialect
-        self.catalog_name = ""
-        self.database_name = ""
-        self.schema_name = ""
+
+    # --- Context-isolated properties ---
+    # Each thread/async-task sees its own catalog/database/schema values.
+    # Unset contexts fall back to the defaults set during __init__.
+
+    @property
+    def catalog_name(self) -> str:
+        val = self._catalog_var.get()
+        return val if val is not _UNSET else self._default_catalog
+
+    @catalog_name.setter
+    def catalog_name(self, value: str):
+        self._catalog_var.set(value)
+
+    @property
+    def database_name(self) -> str:
+        val = self._database_var.get()
+        return val if val is not _UNSET else self._default_database
+
+    @database_name.setter
+    def database_name(self, value: str):
+        self._database_var.set(value)
+
+    @property
+    def schema_name(self) -> str:
+        val = self._schema_var.get()
+        return val if val is not _UNSET else self._default_schema
+
+    @schema_name.setter
+    def schema_name(self, value: str):
+        self._schema_var.set(value)
 
     def close(self):
-        if self.connection:
-            self.connection.close()
-            self.connection = None
+        pass
 
     def connect(self):
         return
@@ -37,11 +78,6 @@ class BaseSqlConnector(ABC):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            try:
-                self._safe_rollback()
-            except Exception as e:
-                logger.warning(f"Failed to rollback during cleanup: {e}")
         try:
             self.close()
         except Exception as e:
@@ -69,6 +105,9 @@ class BaseSqlConnector(ABC):
         self,
         input_params: Any,
         result_format: Optional[Literal["csv", "arrow", "pandas", "list"]] = None,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         self.validate_input(input_params)
         if isinstance(input_params, dict):
@@ -76,24 +115,26 @@ class BaseSqlConnector(ABC):
         sql_query = input_params.sql_query.strip()
         if result_format is None:
             result_format = getattr(input_params, "result_format", "csv") or "csv"
+        # Only pass context kwargs when explicitly set (backward compatible)
+        ctx = {k: v for k, v in [("catalog_name", catalog_name), ("database_name", database_name), ("schema_name", schema_name)] if v}
         try:
             sql_type = parse_sql_type(sql_query, self.dialect)
             if sql_type == SQLType.INSERT:
-                result = self.execute_insert(sql_query)
+                result = self._call_with_ctx(self.execute_insert, sql_query, ctx)
             elif sql_type in (SQLType.UPDATE, SQLType.MERGE):
-                result = self.execute_update(sql_query)
+                result = self._call_with_ctx(self.execute_update, sql_query, ctx)
             elif sql_type == SQLType.DELETE:
-                result = self.execute_delete(sql_query)
+                result = self._call_with_ctx(self.execute_delete, sql_query, ctx)
             elif sql_type == SQLType.CONTENT_SET:
                 result = self.execute_content_set(sql_query)
             elif sql_type == SQLType.DDL:
-                result = self.execute_ddl(sql_query)
+                result = self._call_with_ctx(self.execute_ddl, sql_query, ctx)
             elif sql_type == SQLType.SELECT:
-                result = self.execute_query(sql_query, result_format)
+                result = self._call_with_ctx(self.execute_query, sql_query, ctx, result_format)
             elif sql_type == SQLType.METADATA_SHOW:
-                result = self.execute_query(sql_query, result_format)
+                result = self._call_with_ctx(self.execute_query, sql_query, ctx, result_format)
             elif sql_type == SQLType.EXPLAIN:
-                result = self.execute_explain(sql_query, result_format)
+                result = self._call_with_ctx(self.execute_explain, sql_query, ctx, result_format)
             else:
                 return ExecuteSQLResult(
                     success=False,
@@ -236,21 +277,63 @@ class BaseSqlConnector(ABC):
     ) -> List[Dict[str, str]]:
         raise NotImplementedError()
 
+    @staticmethod
+    def _call_with_ctx(method, sql, ctx, *args, **extra_kwargs):
+        """Call an execute method with context kwargs, falling back if unsupported."""
+        if ctx:
+            try:
+                return method(sql, *args, **extra_kwargs, **ctx)
+            except TypeError:
+                pass
+        return method(sql, *args, **extra_kwargs)
+
     def switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        self.connect()
-        self.do_switch_context(
-            catalog_name=catalog_name,
-            database_name=database_name,
-            schema_name=schema_name,
-        )
+        """Update context state and apply to live session if applicable.
+
+        For SQLAlchemy connectors: context is applied per-operation via _conn().
+        For native connectors (Redshift/Snowflake): also calls _apply_live_context()
+        to execute USE/SET on the persistent connection.
+        """
         if catalog_name:
             self.catalog_name = catalog_name
         if database_name:
             self.database_name = database_name
         if schema_name:
             self.schema_name = schema_name
+        self._apply_live_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
 
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+    def _apply_live_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply context to a persistent connection (for native connectors).
+
+        Auto-detects connectors with persistent connections (e.g., Redshift,
+        Snowflake) and calls their old-style do_switch_context() to execute
+        USE/SET on the live session.
+        """
+        connection = getattr(self, "connection", None)
+        if connection is not None:
+            # Native connector with persistent connection — call old-style do_switch_context
+            import inspect as _inspect
+
+            sig = _inspect.signature(self.do_switch_context)
+            params = list(sig.parameters.keys())
+            if params and params[0] != "conn":
+                # Old signature: do_switch_context(self, catalog_name, database_name, schema_name)
+                self.do_switch_context(
+                    catalog_name=catalog_name,
+                    database_name=database_name,
+                    schema_name=schema_name,
+                )
+            else:
+                # New signature: do_switch_context(self, conn, ...)
+                self.do_switch_context(
+                    connection,
+                    catalog_name=catalog_name,
+                    database_name=database_name,
+                    schema_name=schema_name,
+                )
+
+    def do_switch_context(self, conn: Any, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply context (USE/SET CATALOG) to a given connection. Subclasses override."""
         return None
 
     def get_schema(

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -162,15 +162,21 @@ class BaseSqlConnector(ABC):
             )
 
     @abstractmethod
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         raise NotImplementedError()
 
     @abstractmethod
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         raise NotImplementedError()
 
     @abstractmethod
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         raise NotImplementedError()
 
     def validate_input(self, input_params: Any):
@@ -190,7 +196,12 @@ class BaseSqlConnector(ABC):
 
     @abstractmethod
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         raise NotImplementedError()
 
@@ -204,7 +215,9 @@ class BaseSqlConnector(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         raise NotImplementedError()
 
     @abstractmethod
@@ -283,13 +296,16 @@ class BaseSqlConnector(ABC):
 
     @staticmethod
     def _call_with_ctx(method, sql, ctx, *args, **extra_kwargs):
-        """Call an execute method with context kwargs, falling back if unsupported."""
+        """Call an execute method with context kwargs, raising if unsupported."""
         if ctx:
             try:
                 return method(sql, *args, **extra_kwargs, **ctx)
             except TypeError as e:
-                if "unexpected keyword argument" not in str(e):
-                    raise TypeError(f"{method.__qualname__} does not support per-call context overrides: {sorted(ctx)}")
+                if "unexpected keyword argument" in str(e):
+                    raise TypeError(
+                        f"{method.__qualname__} does not accept per-call context overrides: {sorted(ctx)}"
+                    ) from e
+                raise
         return method(sql, *args, **extra_kwargs)
 
     def switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -116,7 +116,11 @@ class BaseSqlConnector(ABC):
         if result_format is None:
             result_format = getattr(input_params, "result_format", "csv") or "csv"
         # Only pass context kwargs when explicitly set (backward compatible)
-        ctx = {k: v for k, v in [("catalog_name", catalog_name), ("database_name", database_name), ("schema_name", schema_name)] if v}
+        ctx = {
+            k: v
+            for k, v in [("catalog_name", catalog_name), ("database_name", database_name), ("schema_name", schema_name)]
+            if v
+        }
         try:
             sql_type = parse_sql_type(sql_query, self.dialect)
             if sql_type == SQLType.INSERT:

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -289,7 +289,7 @@ class BaseSqlConnector(ABC):
                 return method(sql, *args, **extra_kwargs, **ctx)
             except TypeError as e:
                 if "unexpected keyword argument" not in str(e):
-                    raise
+                    raise TypeError(f"{method.__qualname__} does not support per-call context overrides: {sorted(ctx)}")
         return method(sql, *args, **extra_kwargs)
 
     def switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -287,8 +287,9 @@ class BaseSqlConnector(ABC):
         if ctx:
             try:
                 return method(sql, *args, **extra_kwargs, **ctx)
-            except TypeError:
-                pass
+            except TypeError as e:
+                if "unexpected keyword argument" not in str(e):
+                    raise
         return method(sql, *args, **extra_kwargs)
 
     def switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
@@ -297,14 +298,17 @@ class BaseSqlConnector(ABC):
         For SQLAlchemy connectors: context is applied per-operation via _conn().
         For native connectors (Redshift/Snowflake): also calls _apply_live_context()
         to execute USE/SET on the persistent connection.
+
+        State is updated only after _apply_live_context succeeds, so a failed
+        live switch does not leave thread-local context out of sync.
         """
+        self._apply_live_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         if catalog_name:
             self.catalog_name = catalog_name
         if database_name:
             self.database_name = database_name
         if schema_name:
             self.schema_name = schema_name
-        self._apply_live_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
 
     def _apply_live_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         """Apply context to a persistent connection (for native connectors).

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -85,7 +85,6 @@ class TestBaseSqlConnectorInit:
         connector = ConcreteConnector()
         assert connector.dialect == "snowflake"
         assert connector.timeout_seconds == 30
-        assert connector.connection is None
         assert connector.catalog_name == ""
         assert connector.database_name == ""
         assert connector.schema_name == ""
@@ -98,18 +97,9 @@ class TestBaseSqlConnectorInit:
 
 
 class TestClose:
-    def test_close_with_connection(self):
-        connector = ConcreteConnector()
-        mock_conn = MagicMock()
-        connector.connection = mock_conn
-        connector.close()
-        mock_conn.close.assert_called_once()
-        assert connector.connection is None
-
-    def test_close_without_connection(self):
+    def test_close_no_error(self):
         connector = ConcreteConnector()
         connector.close()  # Should not raise
-        assert connector.connection is None
 
 
 class TestContextManager:
@@ -126,12 +116,11 @@ class TestContextManager:
             connector.__exit__(None, None, None)
             mock_close.assert_called_once()
 
-    def test_exit_with_exception_calls_rollback(self):
+    def test_exit_with_exception_calls_close(self):
         connector = ConcreteConnector()
-        mock_conn = MagicMock()
-        connector.connection = mock_conn
-        connector.__exit__(ValueError, ValueError("test"), None)
-        mock_conn.rollback.assert_called_once()
+        with patch.object(connector, "close") as mock_close:
+            connector.__exit__(ValueError, ValueError("test"), None)
+            mock_close.assert_called_once()
 
     def test_exit_returns_false(self):
         connector = ConcreteConnector()
@@ -307,11 +296,11 @@ class TestSwitchContext:
         assert connector.database_name == "db"
         assert connector.schema_name == "sch"
 
-    def test_switch_context_calls_connect(self):
+    def test_switch_context_does_not_call_connect(self):
         connector = ConcreteConnector()
         with patch.object(connector, "connect") as mock:
             connector.switch_context(database_name="db")
-            mock.assert_called_once()
+            mock.assert_not_called()
 
     def test_switch_context_partial_update(self):
         connector = ConcreteConnector()
@@ -339,24 +328,50 @@ class TestExecuteExplain:
             mock.assert_called_once_with("EXPLAIN SELECT 1", "csv")
 
 
-class TestSafeRollback:
-    def test_rollback_called(self):
-        connector = ConcreteConnector()
-        mock_conn = MagicMock()
-        connector.connection = mock_conn
-        connector._safe_rollback()
-        mock_conn.rollback.assert_called_once()
+class TestThreadLocalContext:
+    def test_thread_local_isolation(self):
+        """Two threads switching context see their own values."""
+        import threading
 
-    def test_rollback_no_connection(self):
         connector = ConcreteConnector()
-        connector._safe_rollback()  # Should not raise
+        results = {}
 
-    def test_rollback_exception_suppressed(self):
+        def worker(thread_id, db_name):
+            connector.switch_context(database_name=db_name)
+            import time
+
+            time.sleep(0.05)
+            results[thread_id] = connector.database_name
+
+        t1 = threading.Thread(target=worker, args=(1, "db1"))
+        t2 = threading.Thread(target=worker, args=(2, "db2"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results[1] == "db1"
+        assert results[2] == "db2"
+
+    def test_default_context_for_new_threads(self):
+        """New threads get the default context, not another thread's context."""
+        import threading
+
         connector = ConcreteConnector()
-        mock_conn = MagicMock()
-        mock_conn.rollback.side_effect = RuntimeError("rollback failed")
-        connector.connection = mock_conn
-        connector._safe_rollback()  # Should not raise
+        connector._default_database = "default_db"
+        connector.switch_context(database_name="main_thread_db")
+
+        results = {}
+
+        def worker():
+            results["db"] = connector.database_name
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert results["db"] == "default_db"
+        assert connector.database_name == "main_thread_db"
 
 
 class TestListToInStr:

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -94,18 +94,31 @@ class ConcreteConnector(BaseSqlConnector):
 
 
 class ContextAwareConnector(ConcreteConnector):
-    """Connector whose execute methods accept context kwargs and record what was passed."""
+    """Connector whose execute methods accept context kwargs and record what was passed.
+
+    last_context/last_context_keys are per-thread so concurrent tests can
+    inspect each thread's result without races.
+    """
 
     _CTX_KEYS = {"catalog_name", "database_name", "schema_name"}
 
     def __init__(self, config=None, dialect="snowflake"):
+        import threading
+
         super().__init__(config, dialect)
-        self.last_context = {}
-        self.last_context_keys: set = set()
+        self._local = threading.local()
+
+    @property
+    def last_context(self):
+        return getattr(self._local, "last_context", {})
+
+    @property
+    def last_context_keys(self):
+        return getattr(self._local, "last_context_keys", set())
 
     def _record(self, **kwargs):
-        self.last_context_keys = set(kwargs.keys()) & self._CTX_KEYS
-        self.last_context = {k: kwargs.get(k, "") for k in self._CTX_KEYS}
+        self._local.last_context_keys = set(kwargs.keys()) & self._CTX_KEYS
+        self._local.last_context = {k: kwargs.get(k, "") for k in self._CTX_KEYS}
 
     def execute_insert(self, sql: str, **kwargs):
         self._record(**kwargs)
@@ -502,14 +515,16 @@ class TestThreadLocalContext:
         assert connector.database_name == "main_thread_db"
 
     def test_concurrent_execute_with_different_contexts(self):
-        """Two threads calling execute() with different context params don't interfere."""
+        """Two threads calling execute() with different contexts don't interfere."""
         import threading
+        import time
 
         connector = ContextAwareConnector()
         results = {}
 
         def worker(thread_id, db_name):
             connector.execute({"sql_query": "SELECT 1"}, database_name=db_name)
+            time.sleep(0.05)
             results[thread_id] = connector.last_context.copy()
 
         t1 = threading.Thread(target=worker, args=(1, "db1"))

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -80,6 +80,41 @@ class ConcreteConnector(BaseSqlConnector):
         )
 
 
+class ContextAwareConnector(ConcreteConnector):
+    """Connector whose execute methods accept context kwargs."""
+
+    def __init__(self, config=None, dialect="snowflake"):
+        super().__init__(config, dialect)
+        self.last_context = {}
+
+    def execute_insert(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+        return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
+
+    def execute_update(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+        return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
+
+    def execute_delete(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+        return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
+
+    def execute_query(
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ):
+        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+        return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format=result_format)
+
+    def execute_ddl(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+        return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format="csv")
+
+
 class TestBaseSqlConnectorInit:
     def test_init_defaults(self):
         connector = ConcreteConnector()
@@ -287,27 +322,97 @@ class TestExecuteErrorHandling:
             mock.assert_called_once_with("SELECT 1", "arrow")
 
 
+class TestExecuteContextPassThrough:
+    """Test that execute() forwards catalog/database/schema to sub-methods via _call_with_ctx."""
+
+    def test_select_receives_context(self):
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "SELECT 1"}, catalog_name="cat", database_name="db", schema_name="sch")
+        assert connector.last_context == {"catalog_name": "cat", "database_name": "db", "schema_name": "sch"}
+
+    def test_insert_receives_context(self):
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "INSERT INTO t VALUES (1)"}, database_name="db")
+        assert connector.last_context["database_name"] == "db"
+
+    def test_update_receives_context(self):
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "UPDATE t SET col=1"}, catalog_name="cat")
+        assert connector.last_context["catalog_name"] == "cat"
+
+    def test_delete_receives_context(self):
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "DELETE FROM t WHERE id=1"}, schema_name="sch")
+        assert connector.last_context["schema_name"] == "sch"
+
+    def test_ddl_receives_context(self):
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "CREATE TABLE t (id INT)"}, database_name="db", schema_name="sch")
+        assert connector.last_context["database_name"] == "db"
+        assert connector.last_context["schema_name"] == "sch"
+
+    def test_empty_context_not_forwarded(self):
+        """When no context is passed, sub-methods get no context kwargs."""
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "SELECT 1"})
+        # _call_with_ctx with empty ctx calls method without context kwargs,
+        # so the method's defaults ("") are used
+        assert connector.last_context == {"catalog_name": "", "database_name": "", "schema_name": ""}
+
+    def test_partial_context_only_forwards_non_empty(self):
+        """Only non-empty context values are forwarded."""
+        connector = ContextAwareConnector()
+        connector.execute({"sql_query": "SELECT 1"}, database_name="db")
+        assert connector.last_context["database_name"] == "db"
+        assert connector.last_context["catalog_name"] == ""
+        assert connector.last_context["schema_name"] == ""
+
+
+class TestCallWithCtx:
+    """Test _call_with_ctx: context forwarding and TypeError fallback."""
+
+    def test_forwards_context_when_method_accepts_it(self):
+        connector = ContextAwareConnector()
+        ctx = {"catalog_name": "cat", "database_name": "db"}
+        result = BaseSqlConnector._call_with_ctx(connector.execute_insert, "INSERT INTO t VALUES (1)", ctx)
+        assert result.success is True
+        assert connector.last_context["catalog_name"] == "cat"
+        assert connector.last_context["database_name"] == "db"
+
+    def test_falls_back_when_method_rejects_context(self):
+        """ConcreteConnector methods don't accept context kwargs — fallback works."""
+        connector = ConcreteConnector()
+        ctx = {"catalog_name": "cat"}
+        result = BaseSqlConnector._call_with_ctx(connector.execute_insert, "INSERT INTO t VALUES (1)", ctx)
+        assert result.success is True
+
+    def test_empty_ctx_skips_forwarding(self):
+        connector = ConcreteConnector()
+        result = BaseSqlConnector._call_with_ctx(connector.execute_insert, "INSERT INTO t VALUES (1)", {})
+        assert result.success is True
+
+    def test_passes_extra_args(self):
+        connector = ContextAwareConnector()
+        ctx = {"database_name": "db"}
+        result = BaseSqlConnector._call_with_ctx(connector.execute_query, "SELECT 1", ctx, "arrow")
+        assert result.success is True
+        assert result.result_format == "arrow"
+        assert connector.last_context["database_name"] == "db"
+
+
 class TestSwitchContext:
     def test_switch_context_updates_names(self):
         connector = ConcreteConnector()
-        with patch.object(connector, "connect"):
-            connector.switch_context(catalog_name="cat", database_name="db", schema_name="sch")
+        connector.switch_context(catalog_name="cat", database_name="db", schema_name="sch")
         assert connector.catalog_name == "cat"
         assert connector.database_name == "db"
         assert connector.schema_name == "sch"
-
-    def test_switch_context_does_not_call_connect(self):
-        connector = ConcreteConnector()
-        with patch.object(connector, "connect") as mock:
-            connector.switch_context(database_name="db")
-            mock.assert_not_called()
 
     def test_switch_context_partial_update(self):
         connector = ConcreteConnector()
         connector.catalog_name = "old_cat"
         connector.database_name = "old_db"
-        with patch.object(connector, "connect"):
-            connector.switch_context(schema_name="new_sch")
+        connector.switch_context(schema_name="new_sch")
         assert connector.catalog_name == "old_cat"
         assert connector.database_name == "old_db"
         assert connector.schema_name == "new_sch"
@@ -372,6 +477,28 @@ class TestThreadLocalContext:
 
         assert results["db"] == "default_db"
         assert connector.database_name == "main_thread_db"
+
+
+    def test_concurrent_execute_with_different_contexts(self):
+        """Two threads calling execute() with different context params don't interfere."""
+        import threading
+
+        connector = ContextAwareConnector()
+        results = {}
+
+        def worker(thread_id, db_name):
+            connector.execute({"sql_query": "SELECT 1"}, database_name=db_name)
+            results[thread_id] = connector.last_context.copy()
+
+        t1 = threading.Thread(target=worker, args=(1, "db1"))
+        t2 = threading.Thread(target=worker, args=(2, "db2"))
+        t1.start()
+        t1.join()
+        t2.start()
+        t2.join()
+
+        assert results[1]["database_name"] == "db1"
+        assert results[2]["database_name"] == "db2"
 
 
 class TestListToInStr:

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -23,17 +23,28 @@ class ConcreteConnector(BaseSqlConnector):
             config = ConnectionConfig()
         super().__init__(config, dialect)
 
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         return ExecuteSQLResult(
             success=True,
@@ -52,7 +63,9 @@ class ConcreteConnector(BaseSqlConnector):
             result_format="pandas",
         )
 
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format="csv")
 
     def execute_csv(self, sql: str) -> ExecuteSQLResult:
@@ -81,37 +94,37 @@ class ConcreteConnector(BaseSqlConnector):
 
 
 class ContextAwareConnector(ConcreteConnector):
-    """Connector whose execute methods accept context kwargs."""
+    """Connector whose execute methods accept context kwargs and record what was passed."""
+
+    _CTX_KEYS = {"catalog_name", "database_name", "schema_name"}
 
     def __init__(self, config=None, dialect="snowflake"):
         super().__init__(config, dialect)
         self.last_context = {}
+        self.last_context_keys: set = set()
 
-    def execute_insert(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+    def _record(self, **kwargs):
+        self.last_context_keys = set(kwargs.keys()) & self._CTX_KEYS
+        self.last_context = {k: kwargs.get(k, "") for k in self._CTX_KEYS}
+
+    def execute_insert(self, sql: str, **kwargs):
+        self._record(**kwargs)
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
-    def execute_update(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+    def execute_update(self, sql: str, **kwargs):
+        self._record(**kwargs)
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
-    def execute_delete(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+    def execute_delete(self, sql: str, **kwargs):
+        self._record(**kwargs)
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=1, sql_return="", result_format="csv")
 
-    def execute_query(
-        self,
-        sql: str,
-        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
-        catalog_name: str = "",
-        database_name: str = "",
-        schema_name: str = "",
-    ):
-        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+    def execute_query(self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv", **kwargs):
+        self._record(**kwargs)
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format=result_format)
 
-    def execute_ddl(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        self.last_context = {"catalog_name": catalog_name, "database_name": database_name, "schema_name": schema_name}
+    def execute_ddl(self, sql: str, **kwargs):
+        self._record(**kwargs)
         return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format="csv")
 
 
@@ -352,20 +365,17 @@ class TestExecuteContextPassThrough:
         assert connector.last_context["schema_name"] == "sch"
 
     def test_empty_context_not_forwarded(self):
-        """When no context is passed, sub-methods get no context kwargs."""
+        """When no context is passed, no context kwargs reach the sub-method."""
         connector = ContextAwareConnector()
         connector.execute({"sql_query": "SELECT 1"})
-        # _call_with_ctx with empty ctx calls method without context kwargs,
-        # so the method's defaults ("") are used
-        assert connector.last_context == {"catalog_name": "", "database_name": "", "schema_name": ""}
+        assert connector.last_context_keys == set()
 
     def test_partial_context_only_forwards_non_empty(self):
-        """Only non-empty context values are forwarded."""
+        """Only non-empty context values are forwarded as kwargs."""
         connector = ContextAwareConnector()
         connector.execute({"sql_query": "SELECT 1"}, database_name="db")
+        assert connector.last_context_keys == {"database_name"}
         assert connector.last_context["database_name"] == "db"
-        assert connector.last_context["catalog_name"] == ""
-        assert connector.last_context["schema_name"] == ""
 
 
 class TestCallWithCtx:
@@ -379,12 +389,15 @@ class TestCallWithCtx:
         assert connector.last_context["catalog_name"] == "cat"
         assert connector.last_context["database_name"] == "db"
 
-    def test_falls_back_when_method_rejects_context(self):
-        """ConcreteConnector methods don't accept context kwargs — fallback works."""
-        connector = ConcreteConnector()
+    def test_raises_when_method_rejects_context(self):
+        """Methods without context kwargs trigger a clear TypeError."""
+
+        def no_ctx_method(sql: str) -> ExecuteSQLResult:
+            return ExecuteSQLResult(success=True, sql_query=sql, row_count=0, sql_return="", result_format="csv")
+
         ctx = {"catalog_name": "cat"}
-        result = BaseSqlConnector._call_with_ctx(connector.execute_insert, "INSERT INTO t VALUES (1)", ctx)
-        assert result.success is True
+        with pytest.raises(TypeError, match="does not accept per-call context overrides"):
+            BaseSqlConnector._call_with_ctx(no_ctx_method, "INSERT INTO t VALUES (1)", ctx)
 
     def test_empty_ctx_skips_forwarding(self):
         connector = ConcreteConnector()

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -399,6 +399,16 @@ class TestCallWithCtx:
         assert result.result_format == "arrow"
         assert connector.last_context["database_name"] == "db"
 
+    def test_internal_type_error_propagates(self):
+        """A TypeError raised inside the method body must not be swallowed."""
+
+        def buggy_insert(sql, catalog_name="", database_name="", schema_name=""):
+            raise TypeError("unsupported operand type(s) for +: 'int' and 'str'")
+
+        ctx = {"catalog_name": "cat"}
+        with pytest.raises(TypeError, match="unsupported operand"):
+            BaseSqlConnector._call_with_ctx(buggy_insert, "INSERT INTO t VALUES (1)", ctx)
+
 
 class TestSwitchContext:
     def test_switch_context_updates_names(self):
@@ -492,8 +502,8 @@ class TestThreadLocalContext:
         t1 = threading.Thread(target=worker, args=(1, "db1"))
         t2 = threading.Thread(target=worker, args=(2, "db2"))
         t1.start()
-        t1.join()
         t2.start()
+        t1.join()
         t2.join()
 
         assert results[1]["database_name"] == "db1"

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -478,7 +478,6 @@ class TestThreadLocalContext:
         assert results["db"] == "default_db"
         assert connector.database_name == "main_thread_db"
 
-
     def test_concurrent_execute_with_different_contexts(self):
         """Two threads calling execute() with different context params don't interfere."""
         import threading

--- a/datus-hive/datus_hive/connector.py
+++ b/datus-hive/datus_hive/connector.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus
 import pandas as pd
 from sqlalchemy import create_engine
 
-from datus_db_core import DatusDbException, ErrorCode, get_logger
+from datus_db_core import ErrorCode, get_logger
 from datus_sqlalchemy import SQLAlchemyConnector
 
 from .config import HiveConfig

--- a/datus-hive/datus_hive/connector.py
+++ b/datus-hive/datus_hive/connector.py
@@ -45,7 +45,7 @@ class HiveConnector(SQLAlchemyConnector):
         super().__init__(connection_string, dialect="hive", timeout_seconds=config.timeout_seconds)
 
         self.config = config
-        self.database_name = database
+        self._default_database = database
         self._connect_args = self._build_connect_args(config)
 
     @staticmethod
@@ -74,38 +74,30 @@ class HiveConnector(SQLAlchemyConnector):
         return normalized
 
     @override
-    def connect(self):
-        """Initialize the SQLAlchemy engine with PyHive connect_args."""
-        if self.engine and self.connection and self._owns_engine:
-            return
-
-        try:
-            self._safe_close()
-
-            connect_args = dict(self._connect_args)
-
-            self.engine = create_engine(
-                self.connection_string,
-                pool_size=10,
-                max_overflow=20,
-                pool_timeout=self.timeout_seconds,
-                pool_recycle=3600,
-                pool_pre_ping=True,
-                connect_args=connect_args,
-            )
-            self.connection = self.engine.connect()
-            self._owns_engine = True
-
-        except Exception as e:
-            self._force_reset()
-            raise self._handle_exception(e, "", "connection") from e
-
-        if not (self.engine and self.connection):
-            self._force_reset()
-            raise DatusDbException(
-                ErrorCode.DB_CONNECTION_FAILED,
-                message_args={"error_message": "Failed to establish connection"},
-            )
+    def _ensure_engine(self):
+        """Create the SQLAlchemy engine with PyHive connect_args. Thread-safe."""
+        if self.engine and self._owns_engine:
+            return self.engine
+        with self._engine_lock:
+            if self.engine and self._owns_engine:
+                return self.engine
+            try:
+                connect_args = dict(self._connect_args)
+                self.engine = create_engine(
+                    self.connection_string,
+                    pool_size=10,
+                    max_overflow=20,
+                    pool_timeout=self.timeout_seconds,
+                    pool_recycle=3600,
+                    pool_pre_ping=True,
+                    connect_args=connect_args,
+                )
+                self._owns_engine = True
+                return self.engine
+            except Exception as e:
+                self.engine = None
+                self._owns_engine = False
+                raise self._handle_exception(e, "", "connection") from e
 
     @override
     def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
@@ -348,11 +340,13 @@ class HiveConnector(SQLAlchemyConnector):
             return f"{self.quote_identifier(db)}.{self.quote_identifier(table_name)}"
         return self.quote_identifier(table_name)
 
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch database context using USE statement."""
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply database context to a connection using USE statement."""
         if database_name:
-            self.execute_ddl(f"USE {self.quote_identifier(database_name)}")
-            self.database_name = database_name
+            from sqlalchemy import text
+
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
+            conn.commit()
 
     @classmethod
     def from_carrier_map(cls, carrier_map: Mapping[str, Any], prefix: str) -> "HiveConnector":

--- a/datus-hive/datus_hive/connector.py
+++ b/datus-hive/datus_hive/connector.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus
 import pandas as pd
 from sqlalchemy import create_engine
 
-from datus_db_core import ErrorCode, get_logger
+from datus_db_core import get_logger
 from datus_sqlalchemy import SQLAlchemyConnector
 
 from .config import HiveConfig

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -75,7 +75,6 @@ class MySQLConnector(SQLAlchemyConnector):
         elif not isinstance(config, MySQLConfig):
             raise TypeError(f"config must be MySQLConfig or dict, got {type(config)}")
 
-        self.config = config
         self.host = config.host
         self.port = config.port
         self.username = config.username
@@ -92,6 +91,9 @@ class MySQLConnector(SQLAlchemyConnector):
         )
 
         super().__init__(connection_string, dialect="mysql")
+        # Set after super().__init__() so BaseSqlConnector doesn't overwrite
+        # with a plain ConnectionConfig (which lacks charset, autocommit, etc.)
+        self.config = config
         self._default_database = database
 
     # ==================== System Resources ====================

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -92,7 +92,7 @@ class MySQLConnector(SQLAlchemyConnector):
         )
 
         super().__init__(connection_string, dialect="mysql")
-        self.database_name = database
+        self._default_database = database
 
     # ==================== System Resources ====================
 
@@ -330,12 +330,11 @@ class MySQLConnector(SQLAlchemyConnector):
         return database_name or self.database_name
 
     @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch database context using USE statement on the persistent connection."""
-
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply database context to a connection using USE statement."""
         if database_name:
-            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
-            self.connection.commit()
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
+            conn.commit()
 
     # ==================== Sample Data ====================
 

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -138,7 +138,8 @@ class MySQLConnector(SQLAlchemyConnector):
 
         # Build WHERE clause
         if database_name:
-            where = f"TABLE_SCHEMA = '{database_name}'"
+            safe_db = database_name.replace("'", "''")
+            where = f"TABLE_SCHEMA = '{safe_db}'"
         else:
             where = f"{list_to_in_str('TABLE_SCHEMA not in', list(self._sys_databases()))}"
 
@@ -289,8 +290,8 @@ class MySQLConnector(SQLAlchemyConnector):
                 COLUMN_DEFAULT as `Default`,
                 COLUMN_COMMENT as Comment
             FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = '{database_name}'
-              AND TABLE_NAME = '{table_name}'
+            WHERE TABLE_SCHEMA = '{database_name.replace("'", "''")}'
+              AND TABLE_NAME = '{table_name.replace("'", "''")}'
             ORDER BY ORDINAL_POSITION
         """
         query_result = self._execute_pandas(sql)

--- a/datus-mysql/tests/unit/test_connector_unit.py
+++ b/datus-mysql/tests/unit/test_connector_unit.py
@@ -358,20 +358,17 @@ def test_connector_database_name_attribute():
 
 
 def test_do_switch_context_uses_persistent_connection():
-    """do_switch_context must execute USE on self.connection, not a temp connection."""
+    """do_switch_context executes USE on the given connection."""
     config = MySQLConfig(username="user", database="db")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = MySQLConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context(database_name="new_db")
+        connector.do_switch_context(mock_conn, database_name="new_db")
 
-        connector.connection.execute.assert_called_once()
-        connector.connection.commit.assert_called_once()
-        # Must NOT create a temp connection via engine.connect()
-        connector.engine.connect.assert_not_called()
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
 
 
 def test_do_switch_context_noop_without_database():
@@ -380,11 +377,11 @@ def test_do_switch_context_noop_without_database():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = MySQLConnector(config)
-        connector.connection = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context()
+        connector.do_switch_context(mock_conn)
 
-        connector.connection.execute.assert_not_called()
+        mock_conn.execute.assert_not_called()
 
 
 def test_connector_database_name_empty_when_none():

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -68,7 +68,6 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         elif not isinstance(config, PostgreSQLConfig):
             raise TypeError(f"config must be PostgreSQLConfig or dict, got {type(config)}")
 
-        self.config = config
         self.host = config.host
         self.port = config.port
         self.username = config.username
@@ -90,6 +89,9 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             dialect="postgresql",
             timeout_seconds=config.timeout_seconds,
         )
+        # Set after super().__init__() so BaseSqlConnector doesn't overwrite
+        # with a plain ConnectionConfig (which lacks sslmode, etc.)
+        self.config = config
         self._default_database = database
         self._default_schema = config.schema_name or "public"
         self._engines: OrderedDict = OrderedDict()  # LRU cache: database_name -> engine

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -155,8 +155,9 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         if table_type == "mv":
             # pg_matviews is scoped to the current database connection.
             # Use a temporary connection if a different database is requested (thread-safe).
+            safe_schema = schema_name.replace("'", "''") if schema_name else ""
             if schema_name:
-                where = f"schemaname = '{schema_name}'"
+                where = f"schemaname = '{safe_schema}'"
             else:
                 where = f"{list_to_in_str('schemaname not in', list(self._sys_schemas()))}"
 
@@ -165,18 +166,13 @@ class PostgreSQLConnector(SQLAlchemyConnector):
                 FROM pg_matviews
                 WHERE {where}
             """
-            # pg_matviews is scoped to the connected database.
-            # Temporarily set thread-local database so _conn() picks the right engine.
-            saved_db = self.database_name
-            try:
-                self.database_name = database_name
-                query_result = self._execute_pandas(query)
-            finally:
-                self.database_name = saved_db
+            query_result = self._execute_pandas(query, database_name=database_name)
         else:
             # Tables and views use information_schema (supports table_catalog filter)
+            safe_schema = schema_name.replace("'", "''") if schema_name else ""
+            safe_db = database_name.replace("'", "''") if database_name else ""
             if schema_name:
-                where = f"table_schema = '{schema_name}'"
+                where = f"table_schema = '{safe_schema}'"
             else:
                 where = f"{list_to_in_str('table_schema not in', list(self._sys_schemas()))}"
 
@@ -188,9 +184,9 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             query = f"""
                 SELECT table_schema, table_name
                 FROM information_schema.{metadata_config.info_table}
-                WHERE table_catalog = '{database_name}' AND {where} {type_filter}
+                WHERE table_catalog = '{safe_db}' AND {where} {type_filter}
             """
-            query_result = self._execute_pandas(query)
+            query_result = self._execute_pandas(query, database_name=database_name)
 
         # Format results
         result = []
@@ -223,10 +219,13 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         """
         full_name = self.full_name(schema_name=schema_name, table_name=table_name)
 
+        safe_schema = schema_name.replace("'", "''") if schema_name else ""
+        safe_table = table_name.replace("'", "''") if table_name else ""
+
         if object_type == "VIEW":
             # Get view definition
             sql = f"""
-                SELECT pg_get_viewdef('{schema_name}.{table_name}'::regclass, true) as definition
+                SELECT pg_get_viewdef('{safe_schema}.{safe_table}'::regclass, true) as definition
             """
             result = self._execute_pandas(sql)
             if not result.empty and result["definition"][0]:
@@ -238,7 +237,7 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             sql = f"""
                 SELECT definition
                 FROM pg_matviews
-                WHERE schemaname = '{schema_name}' AND matviewname = '{table_name}'
+                WHERE schemaname = '{safe_schema}' AND matviewname = '{safe_table}'
             """
             result = self._execute_pandas(sql)
             if not result.empty and result["definition"][0]:
@@ -382,6 +381,10 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         database_name = database_name or self.database_name
         schema_name = schema_name or self.schema_name
 
+        safe_db = database_name.replace("'", "''") if database_name else ""
+        safe_schema = schema_name.replace("'", "''") if schema_name else ""
+        safe_table = table_name.replace("'", "''") if table_name else ""
+
         # Use INFORMATION_SCHEMA to get schema with comments
         sql = f"""
             SELECT
@@ -399,16 +402,16 @@ class PostgreSQLConnector(SQLAlchemyConnector):
                     ON tc.constraint_name = kcu.constraint_name
                     AND tc.table_schema = kcu.table_schema
                 WHERE tc.constraint_type = 'PRIMARY KEY'
-                    AND tc.table_schema = '{schema_name}'
-                    AND tc.table_name = '{table_name}'
+                    AND tc.table_schema = '{safe_schema}'
+                    AND tc.table_name = '{safe_table}'
             ) pk ON c.column_name = pk.column_name
             LEFT JOIN pg_catalog.pg_statio_all_tables st
                 ON st.schemaname = c.table_schema AND st.relname = c.table_name
             LEFT JOIN pg_catalog.pg_description pgd
                 ON pgd.objoid = st.relid AND pgd.objsubid = c.ordinal_position
-            WHERE c.table_catalog = '{database_name}'
-              AND c.table_schema = '{schema_name}'
-              AND c.table_name = '{table_name}'
+            WHERE c.table_catalog = '{safe_db}'
+              AND c.table_schema = '{safe_schema}'
+              AND c.table_name = '{safe_table}'
             ORDER BY c.ordinal_position
         """
         query_result = self._execute_pandas(sql)
@@ -447,7 +450,8 @@ class PostgreSQLConnector(SQLAlchemyConnector):
     def get_schemas(self, catalog_name: str = "", database_name: str = "", include_sys: bool = False) -> List[str]:
         """Get list of schemas in the current database."""
         database_name = database_name or self.database_name
-        sql = f"SELECT schema_name FROM information_schema.schemata WHERE catalog_name = '{database_name}'"
+        safe_db = database_name.replace("'", "''") if database_name else ""
+        sql = f"SELECT schema_name FROM information_schema.schemata WHERE catalog_name = '{safe_db}'"
         result = self._execute_pandas(sql)
         schemas = result["schema_name"].tolist()
 
@@ -517,15 +521,15 @@ class PostgreSQLConnector(SQLAlchemyConnector):
 
     @override
     def close(self):
-        """Dispose all engines."""
+        """Dispose all engines (per-database pool + parent engine)."""
         for engine in self._engines.values():
             try:
                 engine.dispose()
             except Exception as e:
                 logger.warning(f"Error disposing engine: {e}")
         self._engines.clear()
-        self.engine = None
-        self._owns_engine = False
+        # Dispose parent engine that may have been created via connect()/_ensure_engine()
+        super().close()
 
     @override
     def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -5,7 +5,6 @@
 from typing import Any, Dict, List, Optional, Set, Union, override
 from urllib.parse import quote_plus
 
-from pandas import DataFrame
 from pydantic import BaseModel, Field
 from sqlalchemy import create_engine, text
 

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -90,8 +90,9 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             dialect="postgresql",
             timeout_seconds=config.timeout_seconds,
         )
-        self.database_name = database
-        self.schema_name = config.schema_name or "public"
+        self._default_database = database
+        self._default_schema = config.schema_name or "public"
+        self._engines = {}  # database_name -> engine (for cross-database access)
 
     # ==================== System Resources ====================
 
@@ -123,24 +124,6 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             f"postgresql+psycopg2://{encoded_username}:{encoded_password}"
             f"@{self.host}:{self.port}/{database_name}?sslmode={self.config.sslmode}"
         )
-
-    def _execute_on_database(self, sql: str, database_name: str) -> DataFrame:
-        """Execute a query on a specific database using a temporary connection.
-
-        Thread-safe: creates an isolated connection without mutating self.
-        """
-        if database_name == self.database_name:
-            return self._execute_pandas(sql)
-
-        conn_str = self._build_connection_string(database_name)
-        engine = create_engine(conn_str)
-        try:
-            with engine.connect() as conn:
-                result = conn.execute(text(sql))
-                rows = [row._asdict() for row in result.fetchall()]
-                return DataFrame(rows)
-        finally:
-            engine.dispose()
 
     # ==================== Metadata Retrieval ====================
 
@@ -183,7 +166,14 @@ class PostgreSQLConnector(SQLAlchemyConnector):
                 FROM pg_matviews
                 WHERE {where}
             """
-            query_result = self._execute_on_database(query, database_name)
+            # pg_matviews is scoped to the connected database.
+            # Temporarily set thread-local database so _conn() picks the right engine.
+            saved_db = self.database_name
+            try:
+                self.database_name = database_name
+                query_result = self._execute_pandas(query)
+            finally:
+                self.database_name = saved_db
         else:
             # Tables and views use information_schema (supports table_catalog filter)
             if schema_name:
@@ -475,21 +465,79 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         """Get schema name for SQLAlchemy Inspector."""
         return schema_name or self.schema_name
 
-    @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch database/schema context.
+    def _get_engine(self, database_name: str = ""):
+        """Get or create engine for the given database. Thread-safe.
 
-        PostgreSQL requires reconnection to switch databases.
-        Schema switching only updates self.schema_name since all queries
-        use explicit schema qualification via full_name().
+        PostgreSQL requires different connection strings per database,
+        so each database gets its own engine with connection pool.
         """
-        if database_name and database_name != self.database_name:
-            self.connection_string = self._build_connection_string(database_name)
-            self.close()
-            self.connect()
-            self.database_name = database_name
+        db = database_name or self.database_name
+        if db not in self._engines:
+            with self._engine_lock:
+                if db not in self._engines:
+                    conn_str = self._build_connection_string(db)
+                    self._engines[db] = create_engine(
+                        conn_str,
+                        pool_size=5,
+                        max_overflow=10,
+                        pool_timeout=self.timeout_seconds,
+                        pool_recycle=3600,
+                        pool_pre_ping=True,
+                    )
+        return self._engines[db]
+
+    @override
+    def _conn(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Checkout connection from the correct per-database engine. Thread-safe.
+
+        Overrides base _conn() to avoid writing to shared self.engine.
+        Each thread gets a connection from the engine matching its database_name.
+        """
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _pg_conn():
+            effective_database = database_name or self.database_name
+            effective_schema = schema_name or self.schema_name
+            effective_catalog = catalog_name or self.catalog_name
+            engine = self._get_engine(effective_database)
+            conn = engine.connect()
+            try:
+                self.do_switch_context(conn, effective_catalog, effective_database, effective_schema)
+                yield conn
+            except Exception:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+        return _pg_conn()
+
+    @override
+    def close(self):
+        """Dispose all engines."""
+        for engine in self._engines.values():
+            try:
+                engine.dispose()
+            except Exception as e:
+                logger.warning(f"Error disposing engine: {e}")
+        self._engines.clear()
+        self.engine = None
+        self._owns_engine = False
+
+    @override
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply schema context to a connection.
+
+        Database switching is handled by _conn() which picks the right engine
+        based on the effective database_name.
+        """
         if schema_name:
-            self.schema_name = schema_name
+            conn.execute(text(f"SET search_path TO {self._quote_identifier(schema_name)}"))
+            conn.commit()
 
     # ==================== Sample Data ====================
 

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -552,7 +552,7 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         based on the effective database_name.
         """
         if schema_name:
-            conn.execute(text(f"SET search_path TO {self._quote_identifier(schema_name)}"))
+            conn.execute(text(f"SET search_path TO {self.quote_identifier(schema_name)}"))
             conn.commit()
 
     # ==================== Sample Data ====================

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Union, override
 from urllib.parse import quote_plus
 
@@ -91,7 +92,8 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         )
         self._default_database = database
         self._default_schema = config.schema_name or "public"
-        self._engines = {}  # database_name -> engine (for cross-database access)
+        self._engines: OrderedDict = OrderedDict()  # LRU cache: database_name -> engine
+        self._max_engines = 8
 
     # ==================== System Resources ====================
 
@@ -473,21 +475,30 @@ class PostgreSQLConnector(SQLAlchemyConnector):
 
         PostgreSQL requires different connection strings per database,
         so each database gets its own engine with connection pool.
+        Uses LRU eviction (max 8 engines) to avoid holding too many connections.
         """
         db = database_name or self.database_name
-        if db not in self._engines:
-            with self._engine_lock:
-                if db not in self._engines:
-                    conn_str = self._build_connection_string(db)
-                    self._engines[db] = create_engine(
-                        conn_str,
-                        pool_size=5,
-                        max_overflow=10,
-                        pool_timeout=self.timeout_seconds,
-                        pool_recycle=3600,
-                        pool_pre_ping=True,
-                    )
-        return self._engines[db]
+        with self._engine_lock:
+            if db in self._engines:
+                self._engines.move_to_end(db)
+                return self._engines[db]
+            conn_str = self._build_connection_string(db)
+            engine = create_engine(
+                conn_str,
+                pool_size=5,
+                max_overflow=10,
+                pool_timeout=self.timeout_seconds,
+                pool_recycle=3600,
+                pool_pre_ping=True,
+            )
+            self._engines[db] = engine
+            while len(self._engines) > self._max_engines:
+                _, evicted = self._engines.popitem(last=False)
+                try:
+                    evicted.dispose()
+                except Exception as e:
+                    logger.warning(f"Error disposing evicted engine: {e}")
+            return engine
 
     @override
     def _conn(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):

--- a/datus-postgresql/tests/unit/test_connector_unit.py
+++ b/datus-postgresql/tests/unit/test_connector_unit.py
@@ -396,3 +396,117 @@ def test_connector_schema_name_default():
         connector = PostgreSQLConnector(config)
 
         assert connector.schema_name == "public"
+
+
+# ==================== _get_engine LRU Cache Tests ====================
+
+
+def _make_connector():
+    """Helper: create a PostgreSQLConnector with mocked parent __init__."""
+    import threading
+
+    config = PostgreSQLConfig(username="user", password="pass", database="default_db")
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
+        connector = PostgreSQLConnector(config)
+    # Parent __init__ is mocked, so set attributes that _get_engine needs
+    connector._engine_lock = threading.Lock()
+    connector.engine = None
+    connector._owns_engine = False
+    connector.timeout_seconds = 30
+    return connector
+
+
+def test_get_engine_returns_same_engine_for_same_db():
+    """Requesting the same database twice returns the cached engine."""
+    connector = _make_connector()
+    with patch("datus_postgresql.connector.create_engine", return_value=MagicMock()) as mock_ce:
+        e1 = connector._get_engine("db1")
+        e2 = connector._get_engine("db1")
+
+    assert e1 is e2
+    mock_ce.assert_called_once()
+
+
+def test_get_engine_creates_different_engines_per_db():
+    """Different databases get different engines."""
+    connector = _make_connector()
+    engines = [MagicMock(), MagicMock()]
+    with patch("datus_postgresql.connector.create_engine", side_effect=engines):
+        e1 = connector._get_engine("db1")
+        e2 = connector._get_engine("db2")
+
+    assert e1 is not e2
+
+
+def test_get_engine_evicts_lru_when_over_max():
+    """When cache exceeds max_engines, the least-recently-used engine is disposed."""
+    connector = _make_connector()
+    connector._max_engines = 3
+
+    created_engines = []
+
+    def make_engine(*args, **kwargs):
+        e = MagicMock()
+        created_engines.append(e)
+        return e
+
+    with patch("datus_postgresql.connector.create_engine", side_effect=make_engine):
+        connector._get_engine("db1")
+        connector._get_engine("db2")
+        connector._get_engine("db3")
+        # All 3 fit within max_engines=3
+        assert len(connector._engines) == 3
+        created_engines[0].dispose.assert_not_called()
+
+        # Adding a 4th should evict db1 (LRU)
+        connector._get_engine("db4")
+        assert len(connector._engines) == 3
+        assert "db1" not in connector._engines
+        created_engines[0].dispose.assert_called_once()
+
+
+def test_get_engine_lru_access_refreshes_order():
+    """Accessing an existing engine moves it to most-recently-used, protecting it from eviction."""
+    connector = _make_connector()
+    connector._max_engines = 3
+
+    created_engines = {}
+
+    def make_engine(*args, **kwargs):
+        e = MagicMock()
+        created_engines[len(created_engines)] = e
+        return e
+
+    with patch("datus_postgresql.connector.create_engine", side_effect=make_engine):
+        connector._get_engine("db1")  # engines[0]
+        connector._get_engine("db2")  # engines[1]
+        connector._get_engine("db3")  # engines[2]
+
+        # Access db1 again — moves it to MRU
+        connector._get_engine("db1")
+
+        # Add db4 — should evict db2 (now LRU), NOT db1
+        connector._get_engine("db4")
+
+    assert "db1" in connector._engines
+    assert "db2" not in connector._engines
+    assert "db3" in connector._engines
+    assert "db4" in connector._engines
+    created_engines[1].dispose.assert_called_once()  # db2 evicted
+
+
+def test_close_disposes_all_cached_engines():
+    """close() disposes all cached engines and clears the cache."""
+    connector = _make_connector()
+
+    mock_engines = [MagicMock(), MagicMock()]
+    with patch("datus_postgresql.connector.create_engine", side_effect=mock_engines):
+        connector._get_engine("db1")
+        connector._get_engine("db2")
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.close"):
+        connector.close()
+
+    for e in mock_engines:
+        e.dispose.assert_called_once()
+    assert len(connector._engines) == 0

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -153,6 +153,21 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
     - BaseSqlConnector: Base functionality for SQL databases
     - SchemaNamespaceMixin: Support for database.schema.table naming
     - MaterializedViewSupportMixin: Support for materialized views
+
+    Thread safety:
+        This connector is NOT thread-safe when callers pass per-call
+        ``catalog_name`` / ``database_name`` / ``schema_name`` overrides to
+        ``execute_*`` methods. Those methods invoke ``do_switch_context``,
+        which mutates the shared ``self.connection`` (via ``SET search_path``)
+        and the shared ``self.schema_name`` attribute. Concurrent calls with
+        different context overrides can interleave on the same connection and
+        cause queries to run against the wrong schema.
+
+        Recommended workarounds:
+            - Serialize access to a single ``RedshiftConnector`` instance
+              (e.g. with an external lock) when context overrides are used.
+            - Create a separate ``RedshiftConnector`` per thread / request
+              so each owns its own connection and context state.
     """
 
     def __init__(self, config: Union[RedshiftConfig, dict]):

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -444,7 +444,9 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             raise _handle_redshift_exception(e, sql)
 
     @override
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """
         Execute DDL (Data Definition Language) statement.
 
@@ -456,10 +458,14 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with execution status
         """
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
     @override
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """
         Execute INSERT statement.
 
@@ -469,6 +475,8 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with number of rows inserted
         """
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -496,7 +504,9 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             )
 
     @override
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """
         Execute UPDATE statement.
 
@@ -506,10 +516,14 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with number of rows updated
         """
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
     @override
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """
         Execute DELETE statement.
 
@@ -519,9 +533,13 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with number of rows deleted
         """
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
-    def _execute_update_or_delete(self, sql: str) -> ExecuteSQLResult:
+    def _execute_update_or_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """
         Execute UPDATE, DELETE, or DDL statement.
 
@@ -533,6 +551,8 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with execution status
         """
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -596,7 +616,12 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
 
     @override
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         """
         Execute query and return results in specified format.
@@ -608,6 +633,8 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         Returns:
             ExecuteSQLResult with results in requested format
         """
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         # Route to appropriate execution method based on format
         if result_format == "csv":
             return self.execute_csv(sql)

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -220,13 +220,21 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         return result
 
     @override
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute DDL statement."""
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
     @override
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute INSERT statement."""
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -249,17 +257,29 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             )
 
     @override
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute UPDATE statement."""
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
     @override
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute DELETE statement."""
-        return self._execute_update_or_delete(sql)
+        return self._execute_update_or_delete(
+            sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+        )
 
-    def _execute_update_or_delete(self, sql: str) -> ExecuteSQLResult:
+    def _execute_update_or_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute UPDATE or DELETE statement."""
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -306,9 +326,16 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
 
     @override
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         """Execute query and return results in specified format."""
+        if catalog_name or database_name or schema_name:
+            self.do_switch_context(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
         if sql.lower().startswith("show"):
             return self._execute_show(sql, result_format)
 

--- a/datus-spark/datus_spark/connector.py
+++ b/datus-spark/datus_spark/connector.py
@@ -63,7 +63,7 @@ class SparkConnector(SQLAlchemyConnector):
         )
 
         self.dialect = SPARK_DIALECT
-        self.database_name = database
+        self._default_database = database
 
     # ==================== Context Manager Support ====================
 
@@ -186,13 +186,13 @@ class SparkConnector(SQLAlchemyConnector):
         return database_name or self.database_name
 
     @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch database context using USE statement on the persistent connection."""
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply database context to a connection using USE statement."""
         if database_name:
             from sqlalchemy import text
 
-            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
-            self.connection.commit()
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
+            conn.commit()
 
     # ==================== Utility Methods ====================
 

--- a/datus-spark/tests/unit/test_connector_unit.py
+++ b/datus-spark/tests/unit/test_connector_unit.py
@@ -309,20 +309,17 @@ def test_context_manager_support():
 
 
 def test_do_switch_context_uses_persistent_connection():
-    """do_switch_context must execute USE on self.connection, not a temp connection."""
+    """do_switch_context executes USE on the given connection."""
     config = SparkConfig(username="test_user", database="db")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = SparkConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context(database_name="new_db")
+        connector.do_switch_context(mock_conn, database_name="new_db")
 
-        connector.connection.execute.assert_called_once()
-        connector.connection.commit.assert_called_once()
-        # Must NOT create a temp connection via engine.connect()
-        connector.engine.connect.assert_not_called()
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
 
 
 def test_do_switch_context_noop_without_database():
@@ -331,11 +328,11 @@ def test_do_switch_context_noop_without_database():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = SparkConnector(config)
-        connector.connection = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context()
+        connector.do_switch_context(mock_conn)
 
-        connector.connection.execute.assert_not_called()
+        mock_conn.execute.assert_not_called()
 
 
 # ==================== Quote Identifier Tests ====================

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -248,7 +248,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
     ) -> ExecuteSQLResult:
         """Execute SELECT query."""
         try:
-            result = self._execute_query(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
+            result = self._execute_query(
+                sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+            )
             row_count = len(result)
 
             # Format result based on requested format
@@ -271,7 +273,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def _execute_query(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[Dict[str, Any]]:
+    def _execute_query(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[Dict[str, Any]]:
         """Internal query execution returning list of dicts."""
         if parse_sql_type(sql, self.dialect) in (
             SQLType.INSERT,
@@ -297,7 +301,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             raise self._handle_exception(e, sql, "query") from e
 
     @override
-    def execute_insert(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute INSERT statement."""
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
@@ -326,7 +332,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_update(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute UPDATE statement."""
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
@@ -343,7 +351,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_delete(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute DELETE statement."""
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
@@ -360,7 +370,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_ddl(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute DDL statement (CREATE, ALTER, DROP, etc.)."""
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
@@ -376,10 +388,14 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, sql_query=sql, error=str(ex))
 
-    def execute_pandas(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_pandas(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute query and return pandas DataFrame."""
         try:
-            df = self._execute_pandas(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
+            df = self._execute_pandas(
+                sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+            )
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,
@@ -391,14 +407,22 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def _execute_pandas(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> DataFrame:
+    def _execute_pandas(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> DataFrame:
         """Internal pandas execution."""
-        return DataFrame(self._execute_query(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name))
+        return DataFrame(
+            self._execute_query(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
+        )
 
-    def execute_csv(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_csv(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute query and return CSV format."""
         try:
-            df = self._execute_pandas(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
+            df = self._execute_pandas(
+                sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name
+            )
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,
@@ -417,7 +441,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
                 result_format="csv",
             )
 
-    def execute_arrow(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
+    def execute_arrow(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
         """Execute query and return Arrow table."""
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
@@ -474,7 +500,9 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def execute_queries(self, queries: List[str], catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[Any]:
+    def execute_queries(
+        self, queries: List[str], catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[Any]:
         """Execute multiple queries on a single connection (batch atomicity)."""
         results = []
         try:
@@ -672,8 +700,13 @@ class SQLAlchemyConnector(BaseSqlConnector):
     # ==================== Streaming Methods ====================
 
     def execute_csv_iterator(
-        self, sql: str, max_rows: int = 100, with_header: bool = True,
-        catalog_name: str = "", database_name: str = "", schema_name: str = "",
+        self,
+        sql: str,
+        max_rows: int = 100,
+        with_header: bool = True,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> Iterator[Tuple]:
         """Execute query and return CSV rows in batches.
 
@@ -685,9 +718,7 @@ class SQLAlchemyConnector(BaseSqlConnector):
         """
         try:
             with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
-                result = conn.execute(
-                    text(sql).execution_options(stream_results=True, max_row_buffer=max_rows)
-                )
+                result = conn.execute(text(sql).execution_options(stream_results=True, max_row_buffer=max_rows))
                 if result.returns_rows:
                     if with_header:
                         yield result.keys()

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import threading
+from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, override
 
 from pandas import DataFrame
@@ -41,7 +43,10 @@ logger = get_logger(__name__)
 class SQLAlchemyConnector(BaseSqlConnector):
     """
     Base SQLAlchemy connector for database adapters.
-    Provides common SQLAlchemy functionality with Arrow support.
+
+    Thread-safe: each operation checks out a connection from the engine pool,
+    applies the current thread's context via do_switch_context(), executes,
+    and returns the connection to the pool.
     """
 
     def __init__(self, connection_string: str, dialect: str = "", timeout_seconds: int = 30):
@@ -62,11 +67,11 @@ class SQLAlchemyConnector(BaseSqlConnector):
         super().__init__(config, dialect)
         self.connection_string = connection_string
         self.engine = None
-        self.connection = None
         self._owns_engine = False
+        self._engine_lock = threading.Lock()
 
     def __del__(self):
-        """Destructor to ensure connections are properly closed."""
+        """Destructor to ensure engine is properly disposed."""
         try:
             self.close()
         except Exception:
@@ -74,106 +79,88 @@ class SQLAlchemyConnector(BaseSqlConnector):
 
     # ==================== Connection Management ====================
 
-    def _check_connection(self) -> bool:
-        """Check if the persistent connection is still alive."""
-        try:
-            self.connection.execute(text("SELECT 1"))
-            return True
-        except Exception:
-            return False
+    def _ensure_engine(self):
+        """Create the SQLAlchemy engine with connection pool if not exists.
+
+        Returns the engine to use. Callers must use the return value rather
+        than ``self.engine`` to avoid races when subclasses maintain multiple
+        engines (e.g. PostgreSQL engine-per-database).
+        """
+        if self.engine and self._owns_engine:
+            return self.engine
+        with self._engine_lock:
+            # Double-check after acquiring lock
+            if self.engine and self._owns_engine:
+                return self.engine
+            try:
+                if self.dialect not in ("duckdb", "sqlite"):
+                    self.engine = create_engine(
+                        self.connection_string,
+                        pool_size=10,
+                        max_overflow=20,
+                        pool_timeout=self.timeout_seconds,
+                        pool_recycle=3600,
+                        pool_pre_ping=True,
+                    )
+                else:
+                    self.engine = create_engine(self.connection_string)
+                self._owns_engine = True
+                return self.engine
+            except Exception as e:
+                self.engine = None
+                self._owns_engine = False
+                raise self._handle_exception(e, "", "connection") from e
 
     @override
     def connect(self):
-        """Establish connection to the database, reconnecting if stale."""
-        if self.engine and self.connection and self._owns_engine:
-            if self._check_connection():
-                return
-            # Connection is stale, rebuild it
-            logger.warning("Stale connection detected, reconnecting...")
-            needs_context_replay = True
-            self._force_reset()
-        else:
-            needs_context_replay = False
+        """Backward-compatible alias for _ensure_engine()."""
+        self._ensure_engine()
 
+    @contextmanager
+    def _conn(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Checkout a connection from pool with context applied.
+
+        Args:
+            catalog_name: Override thread-local catalog (empty = use thread-local)
+            database_name: Override thread-local database (empty = use thread-local)
+            schema_name: Override thread-local schema (empty = use thread-local)
+
+        Usage:
+            with self._conn(database_name="db1") as conn:
+                result = conn.execute(text(sql))
+        """
+        effective_catalog = catalog_name or self.catalog_name
+        effective_database = database_name or self.database_name
+        effective_schema = schema_name or self.schema_name
+        engine = self._ensure_engine()
+        conn = engine.connect()
         try:
-            self._safe_close()
-
-            # Create engine with connection pool
-            if self.dialect not in ("duckdb", "sqlite"):
-                self.engine = create_engine(
-                    self.connection_string,
-                    pool_size=10,  # Increased for parallel execution
-                    max_overflow=20,  # Allow more overflow connections
-                    pool_timeout=self.timeout_seconds,
-                    pool_recycle=3600,
-                    pool_pre_ping=True,  # Verify connections before use
-                )
-            else:
-                self.engine = create_engine(self.connection_string)
-
-            self.connection = self.engine.connect()
-            self._owns_engine = True
-
-        except Exception as e:
-            self._force_reset()
-            raise self._handle_exception(e, "", "connection") from e
-
-        # Replay switched context after stale reconnect
-        if needs_context_replay:
             self.do_switch_context(
-                catalog_name=self.catalog_name,
-                database_name=self.database_name,
-                schema_name=self.schema_name,
+                conn,
+                catalog_name=effective_catalog,
+                database_name=effective_database,
+                schema_name=effective_schema,
             )
-
-        if not (self.engine and self.connection):
-            self._force_reset()
-            raise DatusDbException(
-                ErrorCode.DB_CONNECTION_FAILED,
-                message_args={"error_message": "Failed to establish connection"},
-            )
+            yield conn
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
 
     @override
     def close(self):
-        """Close the database connection."""
+        """Dispose the engine and its connection pool."""
         try:
-            if self.connection:
-                self.connection.close()
-                self.connection = None
             if self.engine:
                 self.engine.dispose()
                 self.engine = None
             self._owns_engine = False
         except Exception as e:
             logger.warning(f"Error disposing engine: {str(e)}")
-
-    def _safe_close(self):
-        """Safely close connection, ignoring errors."""
-        try:
-            self.close()
-        except Exception:
-            pass
-
-    def _force_reset(self):
-        """Force reset engine on error."""
-        try:
-            self._safe_rollback()
-            if self.connection:
-                try:
-                    self.connection.close()
-                except Exception:
-                    pass
-                self.connection = None
-            if self.engine:
-                try:
-                    self.engine.dispose()
-                except Exception:
-                    pass
-                self.engine = None
-            self._owns_engine = False
-        except Exception:
-            self.engine = None
-            self._owns_engine = False
 
     # ==================== Error Handling ====================
 
@@ -205,8 +192,7 @@ class SQLAlchemyConnector(BaseSqlConnector):
         if isinstance(e, (OperationalError, InterfaceError)):
             # Transaction rollback errors
             if any(kw in error_msg_lower for kw in ["invalid transaction", "can't reconnect"]):
-                logger.warning("Invalid transaction state detected, resetting connection")
-                self._force_reset()
+                logger.warning("Invalid transaction state detected")
                 return DatusDbException(ErrorCode.DB_TRANSACTION_FAILED, message_args=message_args)
 
             # Timeout errors
@@ -253,12 +239,16 @@ class SQLAlchemyConnector(BaseSqlConnector):
 
     @override
     def execute_query(
-        self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
     ) -> ExecuteSQLResult:
         """Execute SELECT query."""
         try:
-            self.connect()
-            result = self._execute_query(sql)
+            result = self._execute_query(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
             row_count = len(result)
 
             # Format result based on requested format
@@ -281,7 +271,7 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def _execute_query(self, sql: str) -> List[Dict[str, Any]]:
+    def _execute_query(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[Dict[str, Any]]:
         """Internal query execution returning list of dicts."""
         if parse_sql_type(sql, self.dialect) in (
             SQLType.INSERT,
@@ -296,106 +286,100 @@ class SQLAlchemyConnector(BaseSqlConnector):
                 message="Only SELECT and metadata queries are supported",
             )
 
-        self.connect()
         try:
-            result = self.connection.execute(text(sql))
-            rows = result.fetchall()
-            return [row._asdict() for row in rows]
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                result = conn.execute(text(sql))
+                rows = result.fetchall()
+                return [row._asdict() for row in rows]
         except DatusDbException:
-            self._safe_rollback()
             raise
         except Exception as e:
-            self._safe_rollback()
             raise self._handle_exception(e, sql, "query") from e
 
     @override
-    def execute_insert(self, sql: str) -> ExecuteSQLResult:
+    def execute_insert(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute INSERT statement."""
         try:
-            self.connect()
-            res = self.connection.execute(text(sql))
-            self.connection.commit()
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                res = conn.execute(text(sql))
+                conn.commit()
 
-            # Get inserted primary key or row count
-            inserted_pk = None
-            try:
-                if hasattr(res, "inserted_primary_key") and res.inserted_primary_key:
-                    inserted_pk = res.inserted_primary_key
-            except Exception:
-                pass
+                # Get inserted primary key or row count
+                inserted_pk = None
+                try:
+                    if hasattr(res, "inserted_primary_key") and res.inserted_primary_key:
+                        inserted_pk = res.inserted_primary_key
+                except Exception:
+                    pass
 
-            lastrowid = getattr(res, "lastrowid", None)
-            return_value = inserted_pk if inserted_pk else (lastrowid if lastrowid else res.rowcount)
+                lastrowid = getattr(res, "lastrowid", None)
+                return_value = inserted_pk if inserted_pk else (lastrowid if lastrowid else res.rowcount)
 
-            return ExecuteSQLResult(
-                success=True,
-                sql_query=sql,
-                sql_return=str(return_value),
-                row_count=res.rowcount,
-            )
+                return ExecuteSQLResult(
+                    success=True,
+                    sql_query=sql,
+                    sql_return=str(return_value),
+                    row_count=res.rowcount,
+                )
         except Exception as e:
-            self._safe_rollback()
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_update(self, sql: str) -> ExecuteSQLResult:
+    def execute_update(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute UPDATE statement."""
         try:
-            self.connect()
-            res = self.connection.execute(text(sql))
-            self.connection.commit()
-            return ExecuteSQLResult(
-                success=True,
-                sql_query=sql,
-                sql_return=str(res.rowcount),
-                row_count=res.rowcount,
-            )
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                res = conn.execute(text(sql))
+                conn.commit()
+                return ExecuteSQLResult(
+                    success=True,
+                    sql_query=sql,
+                    sql_return=str(res.rowcount),
+                    row_count=res.rowcount,
+                )
         except Exception as e:
-            self._safe_rollback()
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_delete(self, sql: str) -> ExecuteSQLResult:
+    def execute_delete(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute DELETE statement."""
         try:
-            self.connect()
-            res = self.connection.execute(text(sql))
-            self.connection.commit()
-            return ExecuteSQLResult(
-                success=True,
-                sql_query=sql,
-                sql_return=str(res.rowcount),
-                row_count=res.rowcount,
-            )
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                res = conn.execute(text(sql))
+                conn.commit()
+                return ExecuteSQLResult(
+                    success=True,
+                    sql_query=sql,
+                    sql_return=str(res.rowcount),
+                    row_count=res.rowcount,
+                )
         except Exception as e:
-            self._safe_rollback()
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql, sql_return="", row_count=0)
 
     @override
-    def execute_ddl(self, sql: str) -> ExecuteSQLResult:
+    def execute_ddl(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute DDL statement (CREATE, ALTER, DROP, etc.)."""
         try:
-            self.connect()
-            res = self.connection.execute(text(sql))
-            self.connection.commit()
-            return ExecuteSQLResult(
-                success=True,
-                sql_query=sql,
-                sql_return=str(res.rowcount),
-                row_count=res.rowcount,
-            )
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                res = conn.execute(text(sql))
+                conn.commit()
+                return ExecuteSQLResult(
+                    success=True,
+                    sql_query=sql,
+                    sql_return=str(res.rowcount),
+                    row_count=res.rowcount,
+                )
         except Exception as e:
-            self._safe_rollback()
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, sql_query=sql, error=str(ex))
 
-    def execute_pandas(self, sql: str) -> ExecuteSQLResult:
+    def execute_pandas(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute query and return pandas DataFrame."""
         try:
-            df = self._execute_pandas(sql)
+            df = self._execute_pandas(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,
@@ -407,15 +391,14 @@ class SQLAlchemyConnector(BaseSqlConnector):
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def _execute_pandas(self, sql: str) -> DataFrame:
+    def _execute_pandas(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> DataFrame:
         """Internal pandas execution."""
-        return DataFrame(self._execute_query(sql))
+        return DataFrame(self._execute_query(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name))
 
-    def execute_csv(self, sql: str) -> ExecuteSQLResult:
+    def execute_csv(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute query and return CSV format."""
         try:
-            self.connect()
-            df = self._execute_pandas(sql)
+            df = self._execute_pandas(sql, catalog_name=catalog_name, database_name=database_name, schema_name=schema_name)
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,
@@ -434,28 +417,28 @@ class SQLAlchemyConnector(BaseSqlConnector):
                 result_format="csv",
             )
 
-    def execute_arrow(self, sql: str) -> ExecuteSQLResult:
+    def execute_arrow(self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> ExecuteSQLResult:
         """Execute query and return Arrow table."""
         try:
-            self.connect()
-            result = self.connection.execute(text(sql))
-            if result.returns_rows:
-                df = DataFrame(result.fetchall(), columns=result.keys())
-                table = Table.from_pandas(df)
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                result = conn.execute(text(sql))
+                if result.returns_rows:
+                    df = DataFrame(result.fetchall(), columns=result.keys())
+                    table = Table.from_pandas(df)
+                    return ExecuteSQLResult(
+                        success=True,
+                        sql_query=sql,
+                        sql_return=table,
+                        row_count=len(df),
+                        result_format="arrow",
+                    )
                 return ExecuteSQLResult(
                     success=True,
                     sql_query=sql,
-                    sql_return=table,
-                    row_count=len(df),
+                    sql_return=result.rowcount,
+                    row_count=0,
                     result_format="arrow",
                 )
-            return ExecuteSQLResult(
-                success=True,
-                sql_query=sql,
-                sql_return=result.rowcount,
-                row_count=0,
-                result_format="arrow",
-            )
         except Exception as e:
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(
@@ -470,12 +453,12 @@ class SQLAlchemyConnector(BaseSqlConnector):
     @override
     def execute_content_set(self, sql: str) -> ExecuteSQLResult:
         """Execute USE/SET commands."""
-        self.connect()
         try:
-            self.connection.execute(text(sql))
-            self.connection.commit()
+            with self._conn() as conn:
+                conn.execute(text(sql))
+                conn.commit()
 
-            # Update context if applicable
+            # Update thread-local context if applicable
             if self.dialect != "sqlite":
                 context = parse_context_switch(sql=sql, dialect=self.dialect)
                 if context:
@@ -488,46 +471,46 @@ class SQLAlchemyConnector(BaseSqlConnector):
 
             return ExecuteSQLResult(success=True, sql_query=sql, sql_return="Successful", row_count=0)
         except Exception as e:
-            self._safe_rollback()
             ex = e if isinstance(e, DatusDbException) else self._handle_exception(e, sql)
             return ExecuteSQLResult(success=False, error=str(ex), sql_query=sql)
 
-    def execute_queries(self, queries: List[str]) -> List[Any]:
-        """Execute multiple queries."""
+    def execute_queries(self, queries: List[str], catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[Any]:
+        """Execute multiple queries on a single connection (batch atomicity)."""
         results = []
-        self.connect()
         try:
-            for query in queries:
-                result = self.connection.execute(text(query))
-                if result.returns_rows:
-                    df = DataFrame(result.fetchall(), columns=list(result.keys()))
-                    results.append(df.to_dict(orient="records"))
-                else:
-                    query_lower = query.strip().lower()
-                    if query_lower.startswith("insert"):
-                        inserted_pk = None
-                        try:
-                            if hasattr(result, "inserted_primary_key") and result.inserted_primary_key:
-                                inserted_pk = result.inserted_primary_key
-                        except Exception:
-                            pass
-                        lastrowid = getattr(result, "lastrowid", None)
-                        results.append(inserted_pk if inserted_pk else (lastrowid if lastrowid else result.rowcount))
-                    elif query_lower.startswith(("update", "delete")):
-                        results.append(result.rowcount)
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                for query in queries:
+                    result = conn.execute(text(query))
+                    if result.returns_rows:
+                        df = DataFrame(result.fetchall(), columns=list(result.keys()))
+                        results.append(df.to_dict(orient="records"))
                     else:
-                        results.append(None)
-            self.connection.commit()
+                        query_lower = query.strip().lower()
+                        if query_lower.startswith("insert"):
+                            inserted_pk = None
+                            try:
+                                if hasattr(result, "inserted_primary_key") and result.inserted_primary_key:
+                                    inserted_pk = result.inserted_primary_key
+                            except Exception:
+                                pass
+                            lastrowid = getattr(result, "lastrowid", None)
+                            results.append(
+                                inserted_pk if inserted_pk else (lastrowid if lastrowid else result.rowcount)
+                            )
+                        elif query_lower.startswith(("update", "delete")):
+                            results.append(result.rowcount)
+                        else:
+                            results.append(None)
+                conn.commit()
         except SQLAlchemyError as e:
-            self._safe_rollback()
             raise self._handle_exception(e, "\n".join(queries), "batch query") from e
         return results
 
     def test_connection(self) -> bool:
         """Test database connection."""
-        self.connect()
         try:
-            self._execute_query("SELECT 1")
+            with self._conn() as conn:
+                conn.execute(text("SELECT 1"))
             return True
         except Exception as e:
             if isinstance(e, DatusDbException):
@@ -541,22 +524,20 @@ class SQLAlchemyConnector(BaseSqlConnector):
 
     def _inspector(self) -> Inspector:
         """Get SQLAlchemy inspector."""
-        self.connect()
+        engine = self._ensure_engine()
         try:
-            return inspect(self.engine)
+            return inspect(engine)
         except Exception as e:
             raise self._handle_exception(e, operation="inspector creation") from e
 
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of tables."""
-        self.connect()
         sqlalchemy_schema = self._sqlalchemy_schema(catalog_name, database_name, schema_name)
         inspector = self._inspector()
         return inspector.get_table_names(schema=sqlalchemy_schema)
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of views."""
-        self.connect()
         sqlalchemy_schema = self._sqlalchemy_schema(catalog_name, database_name, schema_name)
         inspector = self._inspector()
         try:
@@ -690,23 +671,35 @@ class SQLAlchemyConnector(BaseSqlConnector):
 
     # ==================== Streaming Methods ====================
 
-    def execute_csv_iterator(self, sql: str, max_rows: int = 100, with_header: bool = True) -> Iterator[Tuple]:
-        """Execute query and return CSV rows in batches."""
-        self.connect()
+    def execute_csv_iterator(
+        self, sql: str, max_rows: int = 100, with_header: bool = True,
+        catalog_name: str = "", database_name: str = "", schema_name: str = "",
+    ) -> Iterator[Tuple]:
+        """Execute query and return CSV rows in batches.
+
+        Warning: The underlying pool connection stays checked out for the
+        lifetime of this generator.  Callers must fully consume the iterator
+        or explicitly call ``.close()`` on it to return the connection to
+        the pool.  Abandoning an unconsumed iterator may starve the pool
+        until the generator is garbage-collected.
+        """
         try:
-            result = self.connection.execute(text(sql).execution_options(stream_results=True, max_row_buffer=max_rows))
-            if result.returns_rows:
-                if with_header:
-                    yield result.keys()
-                while True:
-                    batch_rows = result.fetchmany(max_rows)
-                    if not batch_rows:
-                        break
-                    for row in batch_rows:
-                        yield row
-            else:
-                if with_header:
-                    yield ()
-                yield from []
+            with self._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                result = conn.execute(
+                    text(sql).execution_options(stream_results=True, max_row_buffer=max_rows)
+                )
+                if result.returns_rows:
+                    if with_header:
+                        yield result.keys()
+                    while True:
+                        batch_rows = result.fetchmany(max_rows)
+                        if not batch_rows:
+                            break
+                        for row in batch_rows:
+                            yield row
+                else:
+                    if with_header:
+                        yield ()
+                    yield from []
         except Exception as e:
             raise self._handle_exception(e) from e

--- a/datus-sqlalchemy/tests/unit/test_connector_unit.py
+++ b/datus-sqlalchemy/tests/unit/test_connector_unit.py
@@ -48,8 +48,10 @@ def test_conn_applies_context_per_checkout():
         with connector._conn():
             pass
 
-    # Verify USE was executed on the checked-out connection
+    # Verify USE analytics was executed on the checked-out connection
     mock_conn.execute.assert_called()
+    sql_arg = str(mock_conn.execute.call_args_list[0][0][0].text)
+    assert "analytics" in sql_arg
     mock_conn.commit.assert_called()
 
 
@@ -108,3 +110,167 @@ def test_thread_local_context_isolation_with_conn():
 
     assert results[1] == "db1"
     assert results[2] == "db2"
+
+
+# ==================== _conn() Context Override Tests ====================
+
+
+def test_conn_explicit_params_override_thread_local():
+    """Explicit _conn(database_name=...) overrides thread-local default."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    connector.switch_context(database_name="thread_default")
+
+    mock_conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        connector._ensure_engine()
+        with connector._conn(database_name="override_db"):
+            pass
+
+    sql_arg = str(mock_conn.execute.call_args_list[0][0][0].text)
+    assert "override_db" in sql_arg
+    assert "thread_default" not in sql_arg
+
+
+def test_conn_falls_back_to_thread_local_when_no_override():
+    """_conn() without explicit params uses thread-local context."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    connector.switch_context(database_name="my_default")
+
+    mock_conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        connector._ensure_engine()
+        with connector._conn():
+            pass
+
+    sql_arg = str(mock_conn.execute.call_args_list[0][0][0].text)
+    assert "my_default" in sql_arg
+
+
+# ==================== Execute Methods with Context Params ====================
+
+
+def test_execute_query_with_context_params():
+    """execute_query passes context to _conn()."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+
+    mock_conn = MagicMock()
+    query_result = MagicMock()
+    query_result.fetchall.return_value = [MagicMock(_asdict=lambda: {"id": 1})]
+    mock_conn.execute.return_value = query_result
+
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        result = connector.execute_query("SELECT 1", database_name="target_db")
+
+    assert result.success is True
+    # do_switch_context should have been called with target_db
+    sql_arg = str(mock_conn.execute.call_args_list[0][0][0].text)
+    assert "target_db" in sql_arg
+
+
+def test_execute_insert_with_context_params():
+    """execute_insert passes context to _conn()."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_result.rowcount = 1
+    mock_result.inserted_primary_key = None
+    mock_conn.execute.return_value = mock_result
+
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        result = connector.execute_insert("INSERT INTO t VALUES (1)", database_name="target_db")
+
+    assert result.success is True
+    sql_arg = str(mock_conn.execute.call_args_list[0][0][0].text)
+    assert "target_db" in sql_arg
+
+
+def test_execute_ddl_with_context_params():
+    """execute_ddl passes context to _conn()."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_result.rowcount = 0
+    mock_conn.execute.return_value = mock_result
+
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        result = connector.execute_ddl("CREATE TABLE t (id INT)", catalog_name="cat", database_name="db")
+
+    assert result.success is True
+
+
+# ==================== _conn() Rollback on Exception ====================
+
+
+def test_conn_rollback_on_exception():
+    """_conn() calls conn.rollback() when an exception occurs."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+
+    mock_conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    # Make do_switch_context raise to trigger the exception path
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        connector._ensure_engine()
+        with patch.object(connector, "do_switch_context", side_effect=RuntimeError("boom")):
+            try:
+                with connector._conn():
+                    pass
+            except RuntimeError:
+                pass
+
+    mock_conn.rollback.assert_called_once()
+    mock_conn.close.assert_called_once()
+
+
+# ==================== _ensure_engine Thread Safety ====================
+
+
+def test_ensure_engine_concurrent_access():
+    """Multiple threads calling _ensure_engine create only one engine."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    call_count = 0
+
+    def counting_create_engine(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        import time
+
+        time.sleep(0.02)  # Simulate slow engine creation
+        return MagicMock()
+
+    results = {}
+
+    def worker(thread_id):
+        engine = connector._ensure_engine()
+        results[thread_id] = engine
+
+    with patch("datus_sqlalchemy.connector.create_engine", side_effect=counting_create_engine):
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    # Double-check locking should ensure create_engine is called exactly once
+    assert call_count == 1
+    # All threads should get the same engine instance
+    engines = list(results.values())
+    assert all(e is engines[0] for e in engines)

--- a/datus-sqlalchemy/tests/unit/test_connector_unit.py
+++ b/datus-sqlalchemy/tests/unit/test_connector_unit.py
@@ -3,7 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import threading
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from datus_sqlalchemy import SQLAlchemyConnector
 

--- a/datus-sqlalchemy/tests/unit/test_connector_unit.py
+++ b/datus-sqlalchemy/tests/unit/test_connector_unit.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import MagicMock, patch
+import threading
+from unittest.mock import MagicMock, call, patch
 
 from datus_sqlalchemy import SQLAlchemyConnector
 
@@ -11,25 +12,99 @@ class DummySQLAlchemyConnector(SQLAlchemyConnector):
     def get_databases(self, catalog_name: str = "", include_sys: bool = False):
         return []
 
+    def do_switch_context(self, conn, catalog_name="", database_name="", schema_name=""):
+        if database_name:
+            from sqlalchemy import text
 
-def test_execute_content_set_and_query_share_persistent_connection():
-    """USE/SET statements must affect later queries executed by the connector."""
-    connector = DummySQLAlchemyConnector("sqlite://", dialect="mysql")
-    persistent_conn = MagicMock()
-    query_result = MagicMock()
-    query_result.fetchall.return_value = [MagicMock(_asdict=lambda: {"id": 1})]
+            conn.execute(text(f"USE {database_name}"))
+            conn.commit()
 
+
+def test_conn_checks_out_and_returns_connection():
+    """Each _conn() call checks out a connection from pool and returns it."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    mock_conn = MagicMock()
     engine = MagicMock()
-    engine.connect.return_value = persistent_conn
-    # 1st connect: fresh, no health check → execute_content_set: USE + commit
-    # 2nd connect: _check_connection (SELECT 1) → _execute_query: SELECT
-    persistent_conn.execute.side_effect = [MagicMock(), MagicMock(), query_result]
+    engine.connect.return_value = mock_conn
 
     with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
-        set_result = connector.execute_content_set("USE analytics")
-        query_rows = connector._execute_query("SELECT id FROM users")
+        connector._ensure_engine()
+        with connector._conn() as conn:
+            assert conn is mock_conn
+        mock_conn.close.assert_called_once()
 
-    assert set_result.success is True
-    assert query_rows == [{"id": 1}]
-    assert engine.connect.call_count == 1
-    assert persistent_conn.execute.call_count == 3
+
+def test_conn_applies_context_per_checkout():
+    """Each _conn() checkout calls do_switch_context with current thread's context."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    connector.switch_context(database_name="analytics")
+
+    mock_conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        connector._ensure_engine()
+        with connector._conn():
+            pass
+
+    # Verify USE was executed on the checked-out connection
+    mock_conn.execute.assert_called()
+    mock_conn.commit.assert_called()
+
+
+def test_execute_content_set_updates_thread_local_context():
+    """USE db via execute_content_set updates the calling thread's context."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="mysql")
+    mock_conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = mock_conn
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        result = connector.execute_content_set("USE analytics")
+
+    assert result.success is True
+    assert connector.database_name == "analytics"
+
+
+def test_per_operation_connections_are_independent():
+    """Two operations get independent connections from the pool."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    conn1, conn2 = MagicMock(), MagicMock()
+    engine = MagicMock()
+    engine.connect.side_effect = [conn1, conn2]
+
+    query_result = MagicMock()
+    query_result.fetchall.return_value = [MagicMock(_asdict=lambda: {"id": 1})]
+    conn1.execute.return_value = MagicMock()  # for do_switch_context
+    conn2.execute.return_value = query_result  # for the actual query
+
+    with patch("datus_sqlalchemy.connector.create_engine", return_value=engine):
+        connector.execute_content_set("USE analytics")
+        rows = connector._execute_query("SELECT id FROM users")
+
+    assert engine.connect.call_count == 2
+    assert rows == [{"id": 1}]
+
+
+def test_thread_local_context_isolation_with_conn():
+    """Two threads using the same connector get isolated contexts."""
+    connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
+    results = {}
+
+    def worker(thread_id, db_name):
+        connector.switch_context(database_name=db_name)
+        import time
+
+        time.sleep(0.05)
+        results[thread_id] = connector.database_name
+
+    t1 = threading.Thread(target=worker, args=(1, "db1"))
+    t2 = threading.Thread(target=worker, args=(2, "db2"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert results[1] == "db1"
+    assert results[2] == "db2"

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -2,15 +2,18 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+from contextlib import contextmanager
 from typing import Any, Dict, List, Set, Union, override
 
 from sqlalchemy import text
 
 from datus_db_core import (
     CatalogSupportMixin,
+    ExecuteSQLResult,
     MaterializedViewSupportMixin,
     get_logger,
     list_to_in_str,
+    parse_context_switch,
 )
 from datus_mysql import MySQLConnector
 
@@ -129,6 +132,59 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
             conn.commit()
             logger.debug(f"Switched database to: {database_name}")
+
+    @contextmanager
+    @override
+    def _conn(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Checkout a connection with catalog-aware context.
+
+        When a per-call ``catalog_name`` override targets a catalog different
+        from the stored thread-local catalog and no ``database_name`` is
+        passed explicitly, the stored ``self.database_name`` is NOT carried
+        over: it belongs to the old catalog and may not exist in the new
+        one, which would fail ``USE <db>`` after ``SET CATALOG <new>``.
+        """
+        if catalog_name and not database_name and catalog_name != self.catalog_name:
+            effective_catalog = catalog_name
+            effective_database = ""
+            effective_schema = schema_name or self.schema_name
+            engine = self._ensure_engine()
+            conn = engine.connect()
+            try:
+                self.do_switch_context(
+                    conn,
+                    catalog_name=effective_catalog,
+                    database_name=effective_database,
+                    schema_name=effective_schema,
+                )
+                yield conn
+            except Exception:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+        else:
+            with super()._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+                yield conn
+
+    @override
+    def execute_content_set(self, sql: str) -> ExecuteSQLResult:
+        """Execute USE/SET, clearing stored database on SET CATALOG.
+
+        Mirrors ``switch_catalog()``: when the catalog changes, the stored
+        ``database_name`` no longer refers to a valid database under the
+        new catalog, so it is cleared to avoid a stale ``USE`` on the next
+        checkout.
+        """
+        result = super().execute_content_set(sql)
+        if result.success:
+            context = parse_context_switch(sql=sql, dialect=self.dialect)
+            if context and context.get("target") == "catalog" and context.get("catalog_name"):
+                self.database_name = ""
+        return result
 
     # ==================== Metadata Retrieval (Stateless, Catalog-Qualified) ====================
 

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -143,9 +143,14 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         passed explicitly, the stored ``self.database_name`` is NOT carried
         over: it belongs to the old catalog and may not exist in the new
         one, which would fail ``USE <db>`` after ``SET CATALOG <new>``.
+
+        The per-call ``catalog_name`` is normalized via ``_resolve_catalog``
+        (e.g. the ``"def"`` alias → ``default_catalog``) before both the
+        divergence check and the downstream ``SET CATALOG``, so aliases are
+        compared and applied consistently.
         """
-        if catalog_name and not database_name and catalog_name != self.catalog_name:
-            effective_catalog = catalog_name
+        resolved_catalog = self._resolve_catalog(catalog_name) if catalog_name else ""
+        if resolved_catalog and not database_name and resolved_catalog != self.catalog_name:
             effective_database = ""
             effective_schema = schema_name or self.schema_name
             engine = self._ensure_engine()
@@ -153,7 +158,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             try:
                 self.do_switch_context(
                     conn,
-                    catalog_name=effective_catalog,
+                    catalog_name=resolved_catalog,
                     database_name=effective_database,
                     schema_name=effective_schema,
                 )
@@ -167,7 +172,11 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             finally:
                 conn.close()
         else:
-            with super()._conn(catalog_name=catalog_name, database_name=database_name, schema_name=schema_name) as conn:
+            with super()._conn(
+                catalog_name=resolved_catalog or catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+            ) as conn:
                 yield conn
 
     @override

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -65,7 +65,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         )
         super().__init__(mysql_config)
         self._deferred_database = config.database if needs_catalog_switch else ""
-        self._default_catalog = config.catalog
+        self._default_catalog = (self.default_catalog() if config.catalog in ("", None, "def") else config.catalog)
         self._default_database = config.database or ""
 
         # Override dialect to StarRocks

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -64,34 +64,12 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             timeout_seconds=config.timeout_seconds,
         )
         super().__init__(mysql_config)
-
-        self.catalog_name = config.catalog
         self._deferred_database = config.database if needs_catalog_switch else ""
-        self.database_name = config.database or ""
+        self._default_catalog = config.catalog
+        self._default_database = config.database or ""
+
         # Override dialect to StarRocks
         self.dialect = "starrocks"
-
-    # ==================== Connection Management ====================
-
-    @override
-    def connect(self):
-        """Establish connection and switch to configured catalog on first connect.
-
-        Reconnect context replay is handled by the base class via do_switch_context().
-        """
-        already_connected = self.engine and self.connection and self._owns_engine
-        super().connect()
-        if not already_connected and self.catalog_name and self.catalog_name != self.default_catalog():
-            self.connection.execute(text(f"SET CATALOG {self.quote_identifier(self.catalog_name)}"))
-            self.connection.commit()
-            logger.debug(f"Switched to catalog on first connect: {self.catalog_name}")
-
-            # Now that the catalog is set, switch to the deferred database
-            if self._deferred_database:
-                self.connection.execute(text(f"USE {self.quote_identifier(self._deferred_database)}"))
-                self.connection.commit()
-                self.database_name = self._deferred_database
-                logger.debug(f"Switched to deferred database: {self._deferred_database}")
 
     # ==================== Context Manager Support ====================
 
@@ -128,7 +106,6 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             catalog_name: Name of the catalog to switch to
         """
         self.switch_context(catalog_name=catalog_name)
-        self.catalog_name = catalog_name
 
     def _resolve_catalog(self, catalog_name: str = "") -> str:
         """Resolve the effective catalog name, falling back to configured or default."""
@@ -138,15 +115,16 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         return catalog
 
     @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch catalog and/or database context on the persistent connection."""
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply catalog and/or database context to a connection."""
         if catalog_name:
-            self.connection.execute(text(f"SET CATALOG {self.quote_identifier(catalog_name)}"))
-            self.connection.commit()
+            conn.execute(text(f"SET CATALOG {self.quote_identifier(catalog_name)}"))
+            conn.commit()
             logger.debug(f"Switched catalog to: {catalog_name}")
         if database_name:
-            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
-            self.connection.commit()
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
+            conn.commit()
+            logger.debug(f"Switched database to: {database_name}")
 
     # ==================== Metadata Retrieval (Stateless, Catalog-Qualified) ====================
 
@@ -342,7 +320,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
     @override
     def close(self):
         """
-        Close connection with special handling for PyMySQL cleanup errors.
+        Close engine with special handling for PyMySQL cleanup errors.
 
         StarRocks may trigger PyMySQL struct.pack errors during cleanup,
         which we safely ignore.
@@ -362,10 +340,6 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
 
             if any(err in error_str for err in pymysql_errors):
                 logger.debug(f"Ignoring PyMySQL cleanup error: {e}")
-
-                # Force cleanup of connection variables
-                if hasattr(self, "connection"):
-                    self.connection = None
                 if hasattr(self, "engine"):
                     try:
                         if self.engine:
@@ -374,8 +348,8 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
                         pass
                     finally:
                         self.engine = None
+                self._owns_engine = False
             else:
-                # Re-raise unexpected errors
                 logger.error(f"Unexpected close error: {e}")
                 raise
 

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -65,7 +65,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         )
         super().__init__(mysql_config)
         self._deferred_database = config.database if needs_catalog_switch else ""
-        self._default_catalog = (self.default_catalog() if config.catalog in ("", None, "def") else config.catalog)
+        self._default_catalog = self.default_catalog() if config.catalog in ("", None, "def") else config.catalog
         self._default_database = config.database or ""
 
         # Override dialect to StarRocks

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -102,10 +102,14 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
     def switch_catalog(self, catalog_name: str) -> None:
         """Switch to a different catalog.
 
+        Clears database_name because the old database may not exist
+        in the new catalog.
+
         Args:
             catalog_name: Name of the catalog to switch to
         """
         self.switch_context(catalog_name=catalog_name)
+        self.database_name = ""
 
     def _resolve_catalog(self, catalog_name: str = "") -> str:
         """Resolve the effective catalog name, falling back to configured or default."""
@@ -150,7 +154,8 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
 
         # Build WHERE clause
         if database_name:
-            where = f"TABLE_SCHEMA = '{database_name}'"
+            safe_db = database_name.replace("'", "''")
+            where = f"TABLE_SCHEMA = '{safe_db}'"
         else:
             where = list_to_in_str("TABLE_SCHEMA NOT IN", list(self._sys_databases()))
 
@@ -229,7 +234,8 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         )
 
         if database_name:
-            query_sql = f"{query_sql} WHERE TABLE_SCHEMA = '{database_name}'"
+            safe_db = database_name.replace("'", "''")
+            query_sql = f"{query_sql} WHERE TABLE_SCHEMA = '{safe_db}'"
         else:
             ignore_dbs = list(self._sys_databases())
             query_sql = f"{query_sql} {list_to_in_str('WHERE TABLE_SCHEMA NOT IN', ignore_dbs)}"

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -346,72 +346,67 @@ def test_sqlalchemy_schema_uses_default_catalog():
 
 
 @pytest.mark.acceptance
-def test_do_switch_context_catalog_uses_persistent_connection():
-    """do_switch_context must execute SET CATALOG on self.connection."""
+def test_do_switch_context_catalog():
+    """do_switch_context executes SET CATALOG on the given connection."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context(catalog_name="new_catalog")
+        connector.do_switch_context(mock_conn, catalog_name="new_catalog")
 
-        connector.connection.execute.assert_called_once()
-        connector.connection.commit.assert_called_once()
-        connector.engine.connect.assert_not_called()
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
 
-        # Verify SET CATALOG was issued
-        sql_arg = str(connector.connection.execute.call_args[0][0].text)
+        sql_arg = str(mock_conn.execute.call_args[0][0].text)
         assert "SET CATALOG" in sql_arg
         assert "new_catalog" in sql_arg
 
 
-def test_do_switch_context_database_uses_persistent_connection():
-    """do_switch_context must execute USE on self.connection."""
+def test_do_switch_context_database():
+    """do_switch_context executes USE on the given connection."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context(database_name="new_db")
+        connector.do_switch_context(mock_conn, database_name="new_db")
 
-        connector.connection.execute.assert_called_once()
-        connector.connection.commit.assert_called_once()
-        connector.engine.connect.assert_not_called()
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
 
-        sql_arg = str(connector.connection.execute.call_args[0][0].text)
+        sql_arg = str(mock_conn.execute.call_args[0][0].text)
         assert "USE" in sql_arg
         assert "new_db" in sql_arg
 
 
 def test_do_switch_context_catalog_and_database():
-    """do_switch_context handles both catalog and database."""
+    """do_switch_context handles both catalog and database on the given connection."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
 
-        connector.do_switch_context(catalog_name="cat", database_name="db")
+        connector.do_switch_context(mock_conn, catalog_name="cat", database_name="db")
 
         # Two execute calls: SET CATALOG + USE
-        assert connector.connection.execute.call_count == 2
-        assert connector.connection.commit.call_count == 2
-        connector.engine.connect.assert_not_called()
+        assert mock_conn.execute.call_count == 2
+        assert mock_conn.commit.call_count == 2
 
 
 def test_set_catalog():
-    """connector.execute('set catalog ...') updates StarRocksConnector.catalog_name without calling engine.connect."""
+    """connector.execute('set catalog ...') updates catalog_name via execute_content_set."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
-        connector.engine = MagicMock()
+        mock_conn = MagicMock()
+        engine = MagicMock()
+        engine.connect.return_value = mock_conn
+        connector.engine = engine
         connector._owns_engine = True
         assert connector.catalog_name == "default_catalog"
 
@@ -420,7 +415,6 @@ def test_set_catalog():
 
         connector.execute(input_params={"sql_query": "set catalog default_catalog"})
         assert connector.catalog_name == "default_catalog"
-        connector.engine.connect.assert_not_called()
 
 
 def test_init_normalizes_def_catalog():

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -139,12 +139,11 @@ def test_resolve_catalog_preserves_custom():
 
 @pytest.mark.acceptance
 def test_switch_catalog_updates_catalog_name():
-    """Test that switch_catalog updates catalog_name attribute."""
+    """Test that switch_catalog updates catalog_name via switch_context."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.switch_context = MagicMock()
 
         connector.switch_catalog("new_catalog")
 
@@ -443,7 +442,6 @@ def test_close_ignores_struct_pack_error():
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
         connector.engine = None
 
         with patch(
@@ -452,8 +450,7 @@ def test_close_ignores_struct_pack_error():
         ):
             # Should not raise exception
             connector.close()
-
-            assert connector.connection is None
+            assert connector.engine is None
 
 
 def test_close_ignores_com_quit_error():
@@ -462,7 +459,6 @@ def test_close_ignores_com_quit_error():
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
         connector.engine = None
 
         with patch(
@@ -471,8 +467,7 @@ def test_close_ignores_com_quit_error():
         ):
             # Should not raise exception
             connector.close()
-
-            assert connector.connection is None
+            assert connector.engine is None
 
 
 def test_close_ignores_required_argument_error():
@@ -481,7 +476,6 @@ def test_close_ignores_required_argument_error():
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
         connector.engine = None
 
         with patch(
@@ -490,23 +484,20 @@ def test_close_ignores_required_argument_error():
         ):
             # Should not raise exception
             connector.close()
+            assert connector.engine is None
 
-            assert connector.connection is None
 
-
-def test_close_clears_connection_on_pymysql_error():
-    """Test close clears connection variables on PyMySQL error."""
+def test_close_clears_engine_on_pymysql_error():
+    """Test close clears engine on PyMySQL error."""
     config = StarRocksConfig(username="test_user")
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = MagicMock()
         connector.engine = None
 
         with patch("datus_mysql.MySQLConnector.close", side_effect=Exception("struct.error")):
             connector.close()
-
-            assert connector.connection is None
+            assert connector.engine is None
 
 
 def test_close_disposes_engine_on_error():
@@ -515,7 +506,6 @@ def test_close_disposes_engine_on_error():
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = None
         mock_engine = MagicMock()
         connector.engine = mock_engine
 
@@ -533,7 +523,6 @@ def test_close_reraises_unexpected_errors():
 
     with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
         connector = StarRocksConnector(config)
-        connector.connection = None
         connector.engine = None
 
         with patch(

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -62,21 +62,20 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
         self._verify_ssl = config.verify
 
         self.dialect = TRINO_DIALECT
-        self.catalog_name = config.catalog
-        self.schema_name = config.schema_name
-        self.database_name = config.schema_name  # In Trino, schemas map to databases
+        self._default_catalog = config.catalog
+        self._default_schema = config.schema_name
+        self._default_database = config.schema_name  # In Trino, schemas map to databases
 
     # ==================== Connection Management ====================
 
     @override
-    def connect(self):
-        """Initialize connection pool with SSL verification setting."""
-        if self.engine and self.connection and self._owns_engine:
-            return
-
-        try:
-            self._safe_close()
-
+    def _ensure_engine(self):
+        """Create engine with SSL verification setting. Thread-safe."""
+        if self.engine and self._owns_engine:
+            return self.engine
+        with self._engine_lock:
+            if self.engine and self._owns_engine:
+                return self.engine
             self.engine = create_engine(
                 self.connection_string,
                 pool_size=10,
@@ -86,11 +85,8 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
                 pool_pre_ping=True,
                 connect_args={"verify": self._verify_ssl},
             )
-            self.connection = self.engine.connect()
             self._owns_engine = True
-        except Exception as e:
-            self._force_reset()
-            raise self._handle_exception(e, "", "connection") from e
+            return self.engine
 
     # ==================== Context Manager Support ====================
 
@@ -261,14 +257,9 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
         return schema if schema else None
 
     @override
-    def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
-        """Switch catalog/schema context."""
-        if catalog_name:
-            self.catalog_name = catalog_name
-        if database_name or schema_name:
-            schema = schema_name or database_name
-            self.schema_name = schema
-            self.database_name = schema
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """No-op: Trino uses fully-qualified names. Context is tracked in thread-local state."""
+        pass
 
     # ==================== Utility Methods ====================
 

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -170,8 +170,9 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
         catalog = catalog_name or self.catalog_name
         schema = schema_name or database_name or self.schema_name
         try:
+            safe_schema = schema.replace("'", "''")
             result = self._execute_pandas(
-                f"SELECT table_name FROM \"{catalog}\".information_schema.views WHERE table_schema = '{schema}'"
+                f"SELECT table_name FROM \"{catalog}\".information_schema.views WHERE table_schema = '{safe_schema}'"
             )
             if result.empty:
                 return []
@@ -195,12 +196,15 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
         catalog = catalog_name or self.catalog_name
         schema = schema_name or database_name or self.schema_name
 
+        safe_catalog = catalog.replace("'", "''")
+        safe_schema = schema.replace("'", "''")
+        safe_table = table_name.replace("'", "''")
         sql = (
             f"SELECT column_name, data_type, is_nullable, column_default, comment "
             f'FROM "{catalog}".information_schema.columns '
-            f"WHERE table_catalog = '{catalog}' "
-            f"AND table_schema = '{schema}' "
-            f"AND table_name = '{table_name}' "
+            f"WHERE table_catalog = '{safe_catalog}' "
+            f"AND table_schema = '{safe_schema}' "
+            f"AND table_name = '{safe_table}' "
             f"ORDER BY ordinal_position"
         )
         query_result = self._execute_pandas(sql)

--- a/datus-trino/tests/unit/test_connector_unit.py
+++ b/datus-trino/tests/unit/test_connector_unit.py
@@ -387,41 +387,39 @@ def test_sys_schemas():
 # ==================== do_switch_context Tests ====================
 
 
-def test_do_switch_context_catalog():
-    """Test do_switch_context updates catalog."""
+def test_switch_context_catalog():
+    """Test switch_context updates catalog."""
     config = TrinoConfig(username="test_user")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = TrinoConnector(config)
 
-        connector.do_switch_context(catalog_name="new_catalog")
+        connector.switch_context(catalog_name="new_catalog")
 
         assert connector.catalog_name == "new_catalog"
 
 
-def test_do_switch_context_schema():
-    """Test do_switch_context updates schema."""
+def test_switch_context_schema():
+    """Test switch_context updates schema."""
     config = TrinoConfig(username="test_user")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = TrinoConnector(config)
 
-        connector.do_switch_context(schema_name="new_schema")
+        connector.switch_context(schema_name="new_schema")
 
         assert connector.schema_name == "new_schema"
-        assert connector.database_name == "new_schema"
 
 
-def test_do_switch_context_database():
-    """Test do_switch_context with database_name updates schema."""
+def test_switch_context_database():
+    """Test switch_context with database_name updates database."""
     config = TrinoConfig(username="test_user")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = TrinoConnector(config)
 
-        connector.do_switch_context(database_name="new_db")
+        connector.switch_context(database_name="new_db")
 
-        assert connector.schema_name == "new_db"
         assert connector.database_name == "new_db"
 
 

--- a/datus-trino/tests/unit/test_connector_unit.py
+++ b/datus-trino/tests/unit/test_connector_unit.py
@@ -423,6 +423,36 @@ def test_switch_context_database():
         assert connector.database_name == "new_db"
 
 
+def test_thread_local_context_isolation():
+    """Two threads switching context see their own catalog/schema values."""
+    import threading
+    import time
+
+    config = TrinoConfig(username="test_user")
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
+        connector = TrinoConnector(config)
+        results = {}
+
+        def worker(thread_id, catalog, schema):
+            connector.switch_context(catalog_name=catalog, schema_name=schema)
+            time.sleep(0.05)
+            results[thread_id] = {
+                "catalog": connector.catalog_name,
+                "schema": connector.schema_name,
+            }
+
+        t1 = threading.Thread(target=worker, args=(1, "hive", "analytics"))
+        t2 = threading.Thread(target=worker, args=(2, "iceberg", "raw"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results[1] == {"catalog": "hive", "schema": "analytics"}
+        assert results[2] == {"catalog": "iceberg", "schema": "raw"}
+
+
 # ==================== Quote Identifier Tests ====================
 
 


### PR DESCRIPTION
 Replace persistent self.connection with per-operation pool checkout via _conn()
    context manager. Each execute method now: checkout connection from pool →
    do_switch_context(conn) → execute → return to pool.
    
    Context state (catalog_name, database_name, schema_name) uses ContextVar for
    thread + asyncio coroutine isolation. All execute methods accept optional
    catalog_name/database_name/schema_name params for per-call context override.
    
    Key changes:
    - BaseSqlConnector: ContextVar properties, _call_with_ctx for backward compat
    - SQLAlchemyConnector: _conn() with context, _ensure_engine() with lock
    - PostgreSQL: engine-per-database with overridden _conn() (no shared self.engine)
    - StarRocks: always SET CATALOG on checkout (pool sessions retain state)
    - MySQL/Spark/Hive: USE {db} on checkout via do_switch_context(conn)
    - ClickHouse: USE {db} on checkout (was no-op before)
    - Trino: no-op do_switch_context (fully-qualified names)
    - Native connectors: _apply_live_context() backward compat hook
    
    Scope: SQLAlchemy-based adapters. Redshift/Snowflake/ClickZetta in follow-up.
    
    Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call overrides for catalog/database/schema on queries, DDL and DML
  * Per-operation pooled connections that apply context per checkout

* **Improvements**
  * Stronger thread/task-local context isolation to prevent cross-operation leakage
  * More consistent engine/connection lifecycle and safer connection-scoped context switching
  * Hardened metadata queries by escaping embedded identifiers

* **Tests**
  * Expanded concurrency, context-isolation, connection-pool and context-forwarding coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->