### PR TITLE
[Refactor] Move dialect-specific identifier quoting to adapter layer

### DIFF
--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -103,10 +103,10 @@ class ClickHouseConnector(SQLAlchemyConnector):
 
     # ==================== Utility Methods ====================
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with backticks for ClickHouse-compatible dialects."""
-        escaped = identifier.replace("`", "``")
+    @override
+    def quote_identifier(self, name: str) -> str:
+        """Quote identifiers with backticks for ClickHouse."""
+        escaped = name.replace("`", "``")
         return f"`{escaped}`"
 
     # ==================== Metadata Retrieval ====================
@@ -415,8 +415,8 @@ class ClickHouseConnector(SQLAlchemyConnector):
     ) -> str:
         """Build fully-qualified table name."""
         if database_name:
-            return f"{self._quote_identifier(database_name)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(database_name)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     @override
     def _reset_filter_tables(

--- a/datus-clickhouse/tests/unit/test_connector_unit.py
+++ b/datus-clickhouse/tests/unit/test_connector_unit.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pandas import DataFrame
@@ -167,28 +167,28 @@ def test_sys_schemas():
 @pytest.mark.acceptance
 def test_quote_identifier_basic():
     """Test _quote_identifier with basic identifier."""
-    assert ClickHouseConnector._quote_identifier("table_name") == "`table_name`"
+    assert ClickHouseConnector.quote_identifier(MagicMock(), "table_name") == "`table_name`"
 
 
 @pytest.mark.acceptance
 def test_quote_identifier_with_backticks():
     """Test _quote_identifier escapes backticks."""
-    assert ClickHouseConnector._quote_identifier("table`name") == "`table``name`"
+    assert ClickHouseConnector.quote_identifier(MagicMock(), "table`name") == "`table``name`"
 
 
 def test_quote_identifier_with_multiple_backticks():
     """Test _quote_identifier escapes multiple backticks."""
-    assert ClickHouseConnector._quote_identifier("ta`ble`name") == "`ta``ble``name`"
+    assert ClickHouseConnector.quote_identifier(MagicMock(), "ta`ble`name") == "`ta``ble``name`"
 
 
 def test_quote_identifier_empty_string():
     """Test _quote_identifier with empty string."""
-    assert ClickHouseConnector._quote_identifier("") == "``"
+    assert ClickHouseConnector.quote_identifier(MagicMock(), "") == "``"
 
 
 def test_quote_identifier_special_characters():
     """Test _quote_identifier with special characters."""
-    assert ClickHouseConnector._quote_identifier("table-name_123") == "`table-name_123`"
+    assert ClickHouseConnector.quote_identifier(MagicMock(), "table-name_123") == "`table-name_123`"
 
 
 @pytest.mark.acceptance

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -56,6 +56,15 @@ class BaseSqlConnector(ABC):
             except Exception:
                 pass
 
+    def quote_identifier(self, name: str) -> str:
+        """Quote an identifier using the dialect-appropriate quoting character.
+
+        Default uses ANSI SQL double quotes. Subclasses should override
+        for dialects that use a different quoting style (e.g. backticks).
+        """
+        escaped = name.replace('"', '""')
+        return f'"{escaped}"'
+
     def execute(
         self,
         input_params: Any,

--- a/datus-greenplum/datus_greenplum/connector.py
+++ b/datus-greenplum/datus_greenplum/connector.py
@@ -93,7 +93,7 @@ class GreenplumConnector(PostgreSQLConnector):
             if result.empty or (len(result) == 1 and result["attname"][0] is None):
                 return "DISTRIBUTED RANDOMLY"
 
-            dist_cols = [self._quote_identifier(row) for row in result["attname"].tolist() if row is not None]
+            dist_cols = [self.quote_identifier(row) for row in result["attname"].tolist() if row is not None]
             if dist_cols:
                 return f"DISTRIBUTED BY ({', '.join(dist_cols)})"
             return "DISTRIBUTED RANDOMLY"

--- a/datus-greenplum/tests/unit/test_connector_unit.py
+++ b/datus-greenplum/tests/unit/test_connector_unit.py
@@ -161,13 +161,13 @@ def test_sys_schemas():
 @pytest.mark.acceptance
 def test_quote_identifier_basic():
     """Test _quote_identifier with basic identifier."""
-    assert GreenplumConnector._quote_identifier("table_name") == '"table_name"'
+    assert GreenplumConnector.quote_identifier(MagicMock(), "table_name") == '"table_name"'
 
 
 @pytest.mark.acceptance
 def test_quote_identifier_with_double_quotes():
     """Test _quote_identifier escapes double quotes."""
-    assert GreenplumConnector._quote_identifier('table"name') == '"table""name"'
+    assert GreenplumConnector.quote_identifier(MagicMock(), 'table"name') == '"table""name"'
 
 
 @pytest.mark.acceptance

--- a/datus-hive/datus_hive/connector.py
+++ b/datus-hive/datus_hive/connector.py
@@ -136,7 +136,7 @@ class HiveConnector(SQLAlchemyConnector):
         self.connect()
         database_name = database_name or self.database_name
         if database_name:
-            sql = f"SHOW TABLES IN {self._quote_identifier(database_name)}"
+            sql = f"SHOW TABLES IN {self.quote_identifier(database_name)}"
         else:
             sql = "SHOW TABLES"
         result = self._execute_pandas(sql)
@@ -148,7 +148,7 @@ class HiveConnector(SQLAlchemyConnector):
         self.connect()
         database_name = database_name or self.database_name
         if database_name:
-            sql = f"SHOW VIEWS IN {self._quote_identifier(database_name)}"
+            sql = f"SHOW VIEWS IN {self.quote_identifier(database_name)}"
         else:
             sql = "SHOW VIEWS"
         try:
@@ -328,10 +328,10 @@ class HiveConnector(SQLAlchemyConnector):
 
         return []
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with backticks for Hive."""
-        escaped = identifier.replace("`", "``")
+    @override
+    def quote_identifier(self, name: str) -> str:
+        """Quote identifiers with backticks for Hive."""
+        escaped = name.replace("`", "``")
         return f"`{escaped}`"
 
     @override
@@ -345,13 +345,13 @@ class HiveConnector(SQLAlchemyConnector):
         """Build fully-qualified table name."""
         db = database_name or self.database_name
         if db:
-            return f"{self._quote_identifier(db)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(db)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         """Switch database context using USE statement."""
         if database_name:
-            self.execute_ddl(f"USE {self._quote_identifier(database_name)}")
+            self.execute_ddl(f"USE {self.quote_identifier(database_name)}")
             self.database_name = database_name
 
     @classmethod

--- a/datus-hive/tests/unit/test_connector_unit.py
+++ b/datus-hive/tests/unit/test_connector_unit.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -209,22 +209,22 @@ def test_normalize_configuration_string_values():
 
 def test_quote_identifier_basic():
     """Test _quote_identifier with basic identifier."""
-    assert HiveConnector._quote_identifier("table_name") == "`table_name`"
+    assert HiveConnector.quote_identifier(MagicMock(), "table_name") == "`table_name`"
 
 
 def test_quote_identifier_with_backticks():
     """Test _quote_identifier escapes backticks."""
-    assert HiveConnector._quote_identifier("table`name") == "`table``name`"
+    assert HiveConnector.quote_identifier(MagicMock(), "table`name") == "`table``name`"
 
 
 def test_quote_identifier_empty_string():
     """Test _quote_identifier with empty string."""
-    assert HiveConnector._quote_identifier("") == "``"
+    assert HiveConnector.quote_identifier(MagicMock(), "") == "``"
 
 
 def test_quote_identifier_special_characters():
     """Test _quote_identifier with special characters."""
-    assert HiveConnector._quote_identifier("table-name_123") == "`table-name_123`"
+    assert HiveConnector.quote_identifier(MagicMock(), "table-name_123") == "`table-name_123`"
 
 
 # ==================== full_name Tests ====================

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -108,10 +108,10 @@ class MySQLConnector(SQLAlchemyConnector):
 
     # ==================== Utility Methods ====================
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with backticks for MySQL-compatible dialects."""
-        escaped = identifier.replace("`", "``")
+    @override
+    def quote_identifier(self, name: str) -> str:
+        """Quote identifiers with backticks for MySQL-compatible dialects."""
+        escaped = name.replace("`", "``")
         return f"`{escaped}`"
 
     # ==================== Metadata Retrieval ====================
@@ -334,7 +334,7 @@ class MySQLConnector(SQLAlchemyConnector):
         """Switch database context using USE statement on the persistent connection."""
 
         if database_name:
-            self.connection.execute(text(f"USE {self._quote_identifier(database_name)}"))
+            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
             self.connection.commit()
 
     # ==================== Sample Data ====================
@@ -422,8 +422,8 @@ class MySQLConnector(SQLAlchemyConnector):
     ) -> str:
         """Build fully-qualified table name."""
         if database_name:
-            return f"{self._quote_identifier(database_name)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(database_name)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     @override
     def _reset_filter_tables(

--- a/datus-mysql/tests/unit/test_connector_unit.py
+++ b/datus-mysql/tests/unit/test_connector_unit.py
@@ -208,28 +208,28 @@ def test_sys_schemas():
 @pytest.mark.acceptance
 def test_quote_identifier_basic():
     """Test _quote_identifier with basic identifier."""
-    assert MySQLConnector._quote_identifier("table_name") == "`table_name`"
+    assert MySQLConnector.quote_identifier(MagicMock(), "table_name") == "`table_name`"
 
 
 @pytest.mark.acceptance
 def test_quote_identifier_with_backticks():
     """Test _quote_identifier escapes backticks."""
-    assert MySQLConnector._quote_identifier("table`name") == "`table``name`"
+    assert MySQLConnector.quote_identifier(MagicMock(), "table`name") == "`table``name`"
 
 
 def test_quote_identifier_with_multiple_backticks():
     """Test _quote_identifier escapes multiple backticks."""
-    assert MySQLConnector._quote_identifier("ta`ble`name") == "`ta``ble``name`"
+    assert MySQLConnector.quote_identifier(MagicMock(), "ta`ble`name") == "`ta``ble``name`"
 
 
 def test_quote_identifier_empty_string():
     """Test _quote_identifier with empty string."""
-    assert MySQLConnector._quote_identifier("") == "``"
+    assert MySQLConnector.quote_identifier(MagicMock(), "") == "``"
 
 
 def test_quote_identifier_special_characters():
     """Test _quote_identifier with special characters."""
-    assert MySQLConnector._quote_identifier("table-name_123") == "`table-name_123`"
+    assert MySQLConnector.quote_identifier(MagicMock(), "table-name_123") == "`table-name_123`"
 
 
 @pytest.mark.acceptance

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -113,11 +113,7 @@ class PostgreSQLConnector(SQLAlchemyConnector):
 
     # ==================== Utility Methods ====================
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with double quotes for PostgreSQL."""
-        escaped = identifier.replace('"', '""')
-        return f'"{escaped}"'
+    # quote_identifier: uses BaseSqlConnector default (ANSI double quotes)
 
     def _build_connection_string(self, database_name: str) -> str:
         """Build a PostgreSQL connection string for a given database."""
@@ -269,7 +265,7 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             col_defs = []
             pk_cols = []
             for col in columns:
-                col_def = f"    {self._quote_identifier(col['name'])} {col['type']}"
+                col_def = f"    {self.quote_identifier(col['name'])} {col['type']}"
                 if not col.get("nullable", True):
                     col_def += " NOT NULL"
                 if col.get("default_value"):
@@ -281,7 +277,7 @@ class PostgreSQLConnector(SQLAlchemyConnector):
             ddl = f"CREATE TABLE {full_name} (\n"
             ddl += ",\n".join(col_defs)
             if pk_cols:
-                pk_names = ", ".join(self._quote_identifier(c) for c in pk_cols)
+                pk_names = ", ".join(self.quote_identifier(c) for c in pk_cols)
                 ddl += f",\n    PRIMARY KEY ({pk_names})"
             ddl += "\n);"
             return ddl
@@ -591,10 +587,10 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         database_name = database_name or self.database_name
         schema_name = schema_name or self.schema_name
         if database_name and schema_name:
-            return f"{self._quote_identifier(database_name)}.{self._quote_identifier(schema_name)}.{self._quote_identifier(table_name)}"
+            return f"{self.quote_identifier(database_name)}.{self.quote_identifier(schema_name)}.{self.quote_identifier(table_name)}"
         if schema_name:
-            return f"{self._quote_identifier(schema_name)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(schema_name)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     @override
     def _reset_filter_tables(

--- a/datus-postgresql/tests/unit/test_connector_unit.py
+++ b/datus-postgresql/tests/unit/test_connector_unit.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -193,28 +193,28 @@ def test_sys_schemas():
 @pytest.mark.acceptance
 def test_quote_identifier_basic():
     """Test _quote_identifier with basic identifier."""
-    assert PostgreSQLConnector._quote_identifier("table_name") == '"table_name"'
+    assert PostgreSQLConnector.quote_identifier(MagicMock(), "table_name") == '"table_name"'
 
 
 @pytest.mark.acceptance
 def test_quote_identifier_with_double_quotes():
     """Test _quote_identifier escapes double quotes."""
-    assert PostgreSQLConnector._quote_identifier('table"name') == '"table""name"'
+    assert PostgreSQLConnector.quote_identifier(MagicMock(), 'table"name') == '"table""name"'
 
 
 def test_quote_identifier_with_multiple_double_quotes():
     """Test _quote_identifier escapes multiple double quotes."""
-    assert PostgreSQLConnector._quote_identifier('ta"ble"name') == '"ta""ble""name"'
+    assert PostgreSQLConnector.quote_identifier(MagicMock(), 'ta"ble"name') == '"ta""ble""name"'
 
 
 def test_quote_identifier_empty_string():
     """Test _quote_identifier with empty string."""
-    assert PostgreSQLConnector._quote_identifier("") == '""'
+    assert PostgreSQLConnector.quote_identifier(MagicMock(), "") == '""'
 
 
 def test_quote_identifier_special_characters():
     """Test _quote_identifier with special characters."""
-    assert PostgreSQLConnector._quote_identifier("table-name_123") == '"table-name_123"'
+    assert PostgreSQLConnector.quote_identifier(MagicMock(), "table-name_123") == '"table-name_123"'
 
 
 @pytest.mark.acceptance

--- a/datus-spark/datus_spark/connector.py
+++ b/datus-spark/datus_spark/connector.py
@@ -112,7 +112,7 @@ class SparkConnector(SQLAlchemyConnector):
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
         db = database_name or self.database_name
-        result = self._execute_pandas(f"SHOW TABLES IN {self._quote_identifier(db)}")
+        result = self._execute_pandas(f"SHOW TABLES IN {self.quote_identifier(db)}")
         if result.empty:
             return []
         # SHOW TABLES returns (namespace, tableName, isTemporary) in Spark 3.x
@@ -128,7 +128,7 @@ class SparkConnector(SQLAlchemyConnector):
         """Get list of view names."""
         db = database_name or self.database_name
         try:
-            result = self._execute_pandas(f"SHOW VIEWS IN {self._quote_identifier(db)}")
+            result = self._execute_pandas(f"SHOW VIEWS IN {self.quote_identifier(db)}")
             if result.empty:
                 return []
             if len(result.columns) >= 2:
@@ -191,15 +191,15 @@ class SparkConnector(SQLAlchemyConnector):
         if database_name:
             from sqlalchemy import text
 
-            self.connection.execute(text(f"USE {self._quote_identifier(database_name)}"))
+            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
             self.connection.commit()
 
     # ==================== Utility Methods ====================
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with backticks for Spark."""
-        escaped = identifier.replace("`", "``")
+    @override
+    def quote_identifier(self, name: str) -> str:
+        """Quote identifiers with backticks for Spark."""
+        escaped = name.replace("`", "``")
         return f"`{escaped}`"
 
     @override
@@ -217,8 +217,8 @@ class SparkConnector(SQLAlchemyConnector):
         """
         db = database_name or self.database_name
         if db:
-            return f"{self._quote_identifier(db)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(db)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert connector to serializable dictionary."""

--- a/datus-spark/tests/unit/test_connector_unit.py
+++ b/datus-spark/tests/unit/test_connector_unit.py
@@ -343,9 +343,9 @@ def test_do_switch_context_noop_without_database():
 
 def test_quote_identifier():
     """Test _quote_identifier uses backticks."""
-    assert SparkConnector._quote_identifier("table") == "`table`"
+    assert SparkConnector.quote_identifier(MagicMock(), "table") == "`table`"
 
 
 def test_quote_identifier_with_special_chars():
     """Test _quote_identifier escapes backticks."""
-    assert SparkConnector._quote_identifier("my`table") == "`my``table`"
+    assert SparkConnector.quote_identifier(MagicMock(), "my`table") == "`my``table`"

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -82,13 +82,13 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         already_connected = self.engine and self.connection and self._owns_engine
         super().connect()
         if not already_connected and self.catalog_name and self.catalog_name != self.default_catalog():
-            self.connection.execute(text(f"SET CATALOG {self._quote_identifier(self.catalog_name)}"))
+            self.connection.execute(text(f"SET CATALOG {self.quote_identifier(self.catalog_name)}"))
             self.connection.commit()
             logger.debug(f"Switched to catalog on first connect: {self.catalog_name}")
 
             # Now that the catalog is set, switch to the deferred database
             if self._deferred_database:
-                self.connection.execute(text(f"USE {self._quote_identifier(self._deferred_database)}"))
+                self.connection.execute(text(f"USE {self.quote_identifier(self._deferred_database)}"))
                 self.connection.commit()
                 self.database_name = self._deferred_database
                 logger.debug(f"Switched to deferred database: {self._deferred_database}")
@@ -141,11 +141,11 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
     def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         """Switch catalog and/or database context on the persistent connection."""
         if catalog_name:
-            self.connection.execute(text(f"SET CATALOG {self._quote_identifier(catalog_name)}"))
+            self.connection.execute(text(f"SET CATALOG {self.quote_identifier(catalog_name)}"))
             self.connection.commit()
             logger.debug(f"Switched catalog to: {catalog_name}")
         if database_name:
-            self.connection.execute(text(f"USE {self._quote_identifier(database_name)}"))
+            self.connection.execute(text(f"USE {self.quote_identifier(database_name)}"))
             self.connection.commit()
 
     # ==================== Metadata Retrieval (Stateless, Catalog-Qualified) ====================
@@ -181,7 +181,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         # Use catalog-qualified information_schema — no SET CATALOG needed
         query = (
             f"SELECT TABLE_SCHEMA, TABLE_NAME "
-            f"FROM {self._quote_identifier(current_catalog)}.information_schema.{metadata_config.info_table} "
+            f"FROM {self.quote_identifier(current_catalog)}.information_schema.{metadata_config.info_table} "
             f"WHERE {where} {type_filter}"
         )
 
@@ -247,7 +247,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         # Use catalog-qualified information_schema
         query_sql = (
             f"SELECT TABLE_SCHEMA, TABLE_NAME, MATERIALIZED_VIEW_DEFINITION "
-            f"FROM {self._quote_identifier(current_catalog)}.information_schema.materialized_views"
+            f"FROM {self.quote_identifier(current_catalog)}.information_schema.materialized_views"
         )
 
         if database_name:
@@ -291,7 +291,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
     def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
         """Get list of databases using catalog-qualified SHOW DATABASES."""
         current_catalog = self._resolve_catalog(catalog_name)
-        result = self._execute_pandas(f"SHOW DATABASES FROM {self._quote_identifier(current_catalog)}")
+        result = self._execute_pandas(f"SHOW DATABASES FROM {self.quote_identifier(current_catalog)}")
         if result.empty:
             return []
         databases = result.iloc[:, 0].tolist()

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -226,11 +226,7 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
 
     # ==================== Full Name Construction ====================
 
-    @staticmethod
-    def _quote_identifier(identifier: str) -> str:
-        """Safely wrap identifiers with double quotes for Trino."""
-        escaped = identifier.replace('"', '""')
-        return f'"{escaped}"'
+    # quote_identifier: uses BaseSqlConnector default (ANSI double quotes)
 
     @override
     def full_name(
@@ -250,12 +246,11 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
 
         if catalog and schema:
             return (
-                f"{self._quote_identifier(catalog)}.{self._quote_identifier(schema)}"
-                f".{self._quote_identifier(table_name)}"
+                f"{self.quote_identifier(catalog)}.{self.quote_identifier(schema)}.{self.quote_identifier(table_name)}"
             )
         elif schema:
-            return f"{self._quote_identifier(schema)}.{self._quote_identifier(table_name)}"
-        return self._quote_identifier(table_name)
+            return f"{self.quote_identifier(schema)}.{self.quote_identifier(table_name)}"
+        return self.quote_identifier(table_name)
 
     @override
     def _sqlalchemy_schema(

--- a/datus-trino/tests/unit/test_connector_unit.py
+++ b/datus-trino/tests/unit/test_connector_unit.py
@@ -430,9 +430,9 @@ def test_do_switch_context_database():
 
 def test_quote_identifier():
     """Test _quote_identifier uses double quotes."""
-    assert TrinoConnector._quote_identifier("table") == '"table"'
+    assert TrinoConnector.quote_identifier(MagicMock(), "table") == '"table"'
 
 
 def test_quote_identifier_with_special_chars():
     """Test _quote_identifier escapes double quotes."""
-    assert TrinoConnector._quote_identifier('my"table') == '"my""table"'
+    assert TrinoConnector.quote_identifier(MagicMock(), 'my"table') == '"my""table"'


### PR DESCRIPTION
## Summary

- Add `quote_identifier(name)` instance method to `BaseSqlConnector` with ANSI SQL double-quote default
- Override in backtick-using adapters: MySQL, ClickHouse, Spark, Hive
- Remove redundant `_quote_identifier` from PostgreSQL and Trino (base class default is identical)
- Update all internal callers and tests across 9 adapters

This enables `datus-agent` to call `connector.quote_identifier(name)` polymorphically instead of hardcoding dialect-specific quoting logic like:
```python
backtick_dialects = ("mysql", "starrocks", "hive", "spark", "bigquery", "clickhouse")
quote_char = "`" if dialect in backtick_dialects else '"'
```

Resolves Datus-ai/Datus-agent#563

## Adapter Quoting Summary

| Adapter | Quoting | Source |
|---------|---------|--------|
| MySQL | `` ` `` | Override |
| StarRocks | `` ` `` | Inherited from MySQL |
| ClickHouse | `` ` `` | Override |
| Spark | `` ` `` | Override |
| Hive | `` ` `` | Override |
| PostgreSQL | `"` | Base class default |
| Greenplum | `"` | Inherited from PostgreSQL |
| Redshift | `"` | Base class default |
| Snowflake | `"` | Base class default |
| Trino | `"` | Base class default |
| ClickZetta | N/A | Independent adapter, not inheriting BaseSqlConnector |

## Test plan

- [x] All 638 unit tests pass across 9 adapters + datus-db-core
- [x] No remaining references to `_quote_identifier` in source code
- [x] Pre-commit hooks (black, isort, ruff) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized identifier quoting mechanism across all supported database connectors (ClickHouse, Greenplum, Hive, MySQL, PostgreSQL, Spark, StarRocks, Trino) for improved consistency and maintainability. Identifier quoting behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->