### PR TITLE
[BugFix] Adapter metadata method robustness (trino/spark/greenplum)

### DIFF
--- a/datus-greenplum/datus_greenplum/connector.py
+++ b/datus-greenplum/datus_greenplum/connector.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from typing import Any, Dict, Optional, Set, Union, override
+from typing import Any, Dict, List, Optional, Set, Union, override
 
 from datus_db_core import get_logger
 from datus_postgresql import PostgreSQLConnector
@@ -59,6 +59,15 @@ class GreenplumConnector(PostgreSQLConnector):
             "pg_aoseg",
             "pg_bitmapindex",
         }
+
+    @override
+    def get_materialized_views(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[str]:
+        """Greenplum 6.x does not expose a `pg_matviews` system view, and materialized
+        views themselves are not part of the GP 6 core. Returning an empty list keeps
+        callers (e.g. `DBFuncTool.list_tables`) from raising when probing for MVs."""
+        return []
 
     # ==================== DDL Generation ====================
 

--- a/datus-spark/datus_spark/connector.py
+++ b/datus-spark/datus_spark/connector.py
@@ -140,6 +140,71 @@ class SparkConnector(SQLAlchemyConnector):
             logger.warning(f"Failed to get views: {e}")
             return []
 
+    def _show_create_definition(self, db: str, table: str) -> str:
+        """Run `SHOW CREATE TABLE` and return the first cell (the DDL text)."""
+        sql = f"SHOW CREATE TABLE {self.full_name(database_name=db, table_name=table)}"
+        result = self._execute_pandas(sql)
+        if result.empty:
+            return ""
+        return str(result.iloc[0, 0])
+
+    def _objects_with_ddl(
+        self,
+        object_type: str,
+        names: List[str],
+        db: str,
+        tables_filter: Optional[List[str]],
+    ) -> List[Dict[str, str]]:
+        """Assemble DDL payloads matching the shape other adapters return."""
+        result: List[Dict[str, str]] = []
+        for name in names:
+            full = self.full_name(database_name=db, table_name=name)
+            if tables_filter and full not in tables_filter:
+                continue
+            try:
+                ddl = self._show_create_definition(db, name)
+            except Exception as e:
+                logger.warning(f"Could not get DDL for {full}: {e}")
+                ddl = f"-- DDL not available for {name}"
+            result.append(
+                {
+                    "identifier": full,
+                    "catalog_name": "",
+                    "database_name": db,
+                    "schema_name": db,
+                    "table_name": name,
+                    "table_type": object_type,
+                    "definition": ddl,
+                }
+            )
+        return result
+
+    @override
+    def get_tables_with_ddl(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        tables: Optional[List[str]] = None,
+    ) -> List[Dict[str, str]]:
+        """Get tables with DDL statements (via `SHOW CREATE TABLE`)."""
+        db = database_name or self.database_name
+        filter_tables = self._reset_filter_tables(tables, catalog_name, database_name, schema_name)
+        names = self.get_tables(catalog_name=catalog_name, database_name=db, schema_name=schema_name)
+        return self._objects_with_ddl("table", names, db, filter_tables)
+
+    @override
+    def get_views_with_ddl(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> List[Dict[str, str]]:
+        """Get views with DDL statements (via `SHOW CREATE TABLE`; Spark treats views the same way)."""
+        db = database_name or self.database_name
+        names = self.get_views(catalog_name=catalog_name, database_name=db, schema_name=schema_name)
+        return self._objects_with_ddl("view", names, db, None)
+
     @override
     def get_schema(
         self,

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -184,6 +184,75 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
             logger.warning(f"Failed to get views: {e}")
             return []
 
+    def _show_create_definition(self, object_kind: str, catalog: str, schema: str, table: str) -> str:
+        """Run `SHOW CREATE TABLE/VIEW` and return the first cell (the DDL text)."""
+        sql = f'SHOW CREATE {object_kind} "{catalog}"."{schema}"."{table}"'
+        result = self._execute_pandas(sql)
+        if result.empty:
+            return ""
+        return str(result.iloc[0, 0])
+
+    def _objects_with_ddl(
+        self,
+        object_kind: str,
+        names: List[str],
+        catalog: str,
+        schema: str,
+        tables_filter: Optional[List[str]],
+    ) -> List[Dict[str, str]]:
+        """Assemble `[{identifier, catalog_name, database_name, schema_name, table_name,
+        table_type, definition}, ...]` for the requested object kind."""
+        result: List[Dict[str, str]] = []
+        for name in names:
+            full = self.full_name(catalog_name=catalog, schema_name=schema, table_name=name)
+            if tables_filter and full not in tables_filter:
+                continue
+            try:
+                ddl = self._show_create_definition(object_kind, catalog, schema, name)
+            except Exception as e:
+                logger.warning(f"Could not get DDL for {full}: {e}")
+                ddl = f"-- DDL not available for {name}"
+            result.append(
+                {
+                    "identifier": full,
+                    "catalog_name": catalog,
+                    "database_name": schema,
+                    "schema_name": schema,
+                    "table_name": name,
+                    "table_type": object_kind.lower(),
+                    "definition": ddl,
+                }
+            )
+        return result
+
+    @override
+    def get_tables_with_ddl(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        tables: Optional[List[str]] = None,
+    ) -> List[Dict[str, str]]:
+        """Get tables with DDL statements (via `SHOW CREATE TABLE`)."""
+        catalog = catalog_name or self.catalog_name
+        schema = schema_name or database_name or self.schema_name
+        filter_tables = self._reset_filter_tables(tables, catalog_name, database_name, schema_name)
+        names = self.get_tables(catalog_name=catalog, schema_name=schema)
+        return self._objects_with_ddl("TABLE", names, catalog, schema, filter_tables)
+
+    @override
+    def get_views_with_ddl(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> List[Dict[str, str]]:
+        """Get views with DDL statements (via `SHOW CREATE VIEW`)."""
+        catalog = catalog_name or self.catalog_name
+        schema = schema_name or database_name or self.schema_name
+        names = self.get_views(catalog_name=catalog, schema_name=schema)
+        return self._objects_with_ddl("VIEW", names, catalog, schema, None)
+
     @override
     def get_schema(
         self,


### PR DESCRIPTION
## Summary

Three adapters were violating the metadata-method contract that downstream agents (e.g. Datus-agent's \`DBFuncTool.get_table_ddl\` / \`list_tables\`) rely on:

- **datus-trino**: \`get_tables_with_ddl\` / \`get_views_with_ddl\` inherited \`NotImplementedError\` from \`BaseSqlConnector\`, surfacing as \`success=0, error=''\` to callers.
- **datus-spark**: same gap.
- **datus-greenplum**: \`PostgreSQLConnector.get_materialized_views\` queries \`pg_matviews\`, which does not exist in Greenplum 6.x. The inherited SQL error propagates up and breaks \`DBFuncTool.list_tables\` entirely (that method only catches \`NotImplementedError\` / \`AttributeError\`).

## Changes

- \`datus-trino/datus_trino/connector.py\` — implement \`get_tables_with_ddl\` and \`get_views_with_ddl\` via \`SHOW CREATE TABLE/VIEW \"catalog\".\"schema\".\"table\"\`.
- \`datus-spark/datus_spark/connector.py\` — same, via \`SHOW CREATE TABLE\` (Spark uses the same statement for views).
- \`datus-greenplum/datus_greenplum/connector.py\` — \`@override get_materialized_views\` to return \`[]\`.

## Test Plan

- [x] datus-trino: \`uv run --package datus-trino pytest tests/\` — 55 unit + 26 integration pass locally against \`apache/hive:4.0.1\`-style docker.
- [x] Main-repo adapter contract tests (tests/integration/adapters/test_trino.py / test_spark.py / test_greenplum.py) — 6/6 each, verified against docker containers.
- [x] \`ruff format\` / \`ruff check --fix\` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Data Definition Language (DDL) retrieval for tables and views in Spark and Trino connectors, enabling access to complete schema definitions
  * Introduced materialized view query support for Greenplum connector, expanding database object discovery capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->