### PR TITLE
[Feature] Add MigrationTargetMixin and dialect implementations for 6 adapters

### DIFF
--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -475,7 +475,7 @@ class ClickHouseConnector(SQLAlchemyConnector, MigrationTargetMixin):
             "type_hints": {
                 "VARCHAR": "String",
                 "TEXT": "String",
-                "CHAR": "FixedString(n)",
+                "CHAR": "String (use FixedString(n) for fixed-length semantics)",
                 "BOOLEAN": "UInt8",
                 "TIMESTAMP": "DateTime64(3)",
                 "DECIMAL(p,s)": "Decimal(p,s)",

--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -11,6 +11,7 @@ from datus_db_core import (
     TABLE_TYPE,
     DatusDbException,
     ErrorCode,
+    MigrationTargetMixin,
     get_logger,
     list_to_in_str,
 )
@@ -54,7 +55,12 @@ def _get_metadata_config(table_type: TABLE_TYPE) -> TableMetadataNames:
     return METADATA_DICT[table_type]
 
 
-class ClickHouseConnector(SQLAlchemyConnector):
+_CLICKHOUSE_INTEGER_TYPES = frozenset(
+    {"INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "INT2", "INT4", "INT8", "INT16", "INT32", "INT64", "UINT64"}
+)
+
+
+class ClickHouseConnector(SQLAlchemyConnector, MigrationTargetMixin):
     """ClickHouse database connector."""
 
     def __init__(self, config: Union[ClickHouseConfig, dict]):
@@ -448,3 +454,143 @@ class ClickHouseConnector(SQLAlchemyConnector):
             return table_name
         else:
             return f"{catalog_name}.{database_name}.{table_name}" if catalog_name else f"{database_name}.{table_name}"
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "clickhouse",
+            "requires": [
+                "ENGINE clause (e.g., ENGINE = MergeTree())",
+                "ORDER BY clause (tuple of sort keys, may be empty tuple ())",
+            ],
+            "forbids": [
+                "VARCHAR (use String)",
+                "BOOLEAN / BOOL (use UInt8)",
+                "DECIMAL without precision",
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY (StarRocks-only)",
+            ],
+            "type_hints": {
+                "VARCHAR": "String",
+                "TEXT": "String",
+                "CHAR": "FixedString(n)",
+                "BOOLEAN": "UInt8",
+                "TIMESTAMP": "DateTime64(3)",
+                "DECIMAL(p,s)": "Decimal(p,s)",
+                "INTEGER": "Int32",
+                "BIGINT": "Int64",
+                "SMALLINT": "Int16",
+                "TINYINT": "Int8",
+                "DOUBLE": "Float64",
+                "FLOAT": "Float32",
+                "UUID": "UUID",
+                "HUGEINT": "Int128",
+                "LARGEINT": "Int128",
+            },
+            "example_ddl": (
+                "CREATE TABLE db.t (\n"
+                "  id Int64,\n"
+                "  name String,\n"
+                "  created_at DateTime64(3)\n"
+                ") ENGINE = MergeTree() ORDER BY id"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not columns:
+            return {"engine": "MergeTree()", "order_by": []}
+
+        keys = self._ch_score_keys(columns, max_keys=1)
+        return {"engine": "MergeTree()", "order_by": keys}
+
+    @staticmethod
+    def _ch_score_keys(columns: List[Dict[str, Any]], max_keys: int = 1) -> List[str]:
+        import re as _re
+
+        scored = []
+        for col in columns:
+            name = col["name"]
+            col_type = str(col.get("type", "")).upper()
+            base_type = _re.sub(r"\(.*\)", "", col_type).strip()
+            nullable = col.get("nullable", True)
+
+            score = 0
+            if name.lower() == "id" or name.lower().endswith("_id"):
+                score += 100
+            if base_type in _CLICKHOUSE_INTEGER_TYPES:
+                score += 50
+            # ClickHouse ORDER BY columns should ideally be non-nullable
+            if not nullable:
+                score += 20
+            # DateTime columns also make excellent ORDER BY keys
+            if "DATE" in base_type or "TIME" in base_type:
+                score += 30
+
+            scored.append((score, name))
+
+        scored.sort(key=lambda x: (-x[0], x[1]))
+
+        if scored[0][0] == 0:
+            return [columns[0]["name"]]
+
+        return [name for score, name in scored[:max_keys]]
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if "ENGINE" not in upper:
+            errors.append("ClickHouse CREATE TABLE requires an ENGINE clause (e.g., ENGINE = MergeTree())")
+        if "ORDER BY" not in upper:
+            errors.append("ClickHouse CREATE TABLE requires an ORDER BY clause (may be empty tuple ())")
+
+        # Re-check VARCHAR only as a column type, not as e.g. 'FixedString' -> both contain 'STRING'
+        # Split into column definitions to check the types.
+        import re as _re
+
+        # Matches 'VARCHAR' as a standalone token, followed by optional (n)
+        if _re.search(r"\bVARCHAR\s*(\([^)]*\))?", upper):
+            errors.append("ClickHouse does not support VARCHAR; use String instead")
+        if _re.search(r"\bBOOLEAN\b", upper) or _re.search(r"\bBOOL\b", upper):
+            errors.append("ClickHouse does not support BOOLEAN/BOOL; use UInt8 instead")
+
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; ClickHouse uses ORDER BY tuple")
+        if "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY is StarRocks syntax; ClickHouse uses Distributed engine with separate DDL")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "VARCHAR": "String",
+            "TEXT": "String",
+            "STRING": "String",
+            "CHAR": "String",
+            "BOOLEAN": "UInt8",
+            "BOOL": "UInt8",
+            "TIMESTAMP": "DateTime64(3)",
+            "TIMESTAMPTZ": "DateTime64(3, 'UTC')",
+            "DATETIME": "DateTime64(3)",
+            "INTEGER": "Int32",
+            "INT": "Int32",
+            "INT4": "Int32",
+            "BIGINT": "Int64",
+            "INT8": "Int64",
+            "SMALLINT": "Int16",
+            "INT2": "Int16",
+            "TINYINT": "Int8",
+            "DOUBLE": "Float64",
+            "FLOAT8": "Float64",
+            "FLOAT": "Float32",
+            "FLOAT4": "Float32",
+            "REAL": "Float32",
+            "HUGEINT": "Int128",
+            "LARGEINT": "Int128",
+        }
+        return overrides.get(base)

--- a/datus-clickhouse/tests/unit/test_migration_mixin.py
+++ b/datus-clickhouse/tests/unit/test_migration_mixin.py
@@ -1,0 +1,147 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for ClickHouse MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_clickhouse import ClickHouseConnector
+from datus_db_core import MigrationTargetMixin
+
+
+@pytest.fixture
+def connector():
+    return ClickHouseConnector.__new__(ClickHouseConnector)
+
+
+class TestMixinInheritance:
+    def test_clickhouse_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        assert connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_clickhouse(self, connector):
+        assert connector.describe_migration_capabilities()["dialect_family"] == "clickhouse"
+
+    def test_requires_engine_and_order_by(self, connector):
+        result = connector.describe_migration_capabilities()
+        requires_str = " ".join(result["requires"]).upper()
+        assert "ENGINE" in requires_str
+        assert "ORDER BY" in requires_str
+
+    def test_forbids_varchar_and_boolean(self, connector):
+        """ClickHouse has String/UInt8 instead of VARCHAR/BOOLEAN."""
+        result = connector.describe_migration_capabilities()
+        forbids_str = " ".join(result["forbids"]).upper()
+        assert "VARCHAR" in forbids_str
+        assert "BOOLEAN" in forbids_str or "BOOL" in forbids_str
+
+    def test_type_hints_reference_string_uint8(self, connector):
+        hints = connector.describe_migration_capabilities()["type_hints"]
+        hints_str = " ".join(hints.values())
+        assert "String" in hints_str
+        assert "UInt8" in hints_str
+
+    def test_example_ddl_has_engine_merge_tree_and_order_by(self, connector):
+        ddl = connector.describe_migration_capabilities()["example_ddl"]
+        assert "MergeTree" in ddl
+        upper = ddl.upper()
+        assert "ORDER BY" in upper
+
+
+class TestValidateDdl:
+    def test_accepts_valid_merge_tree_ddl(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id Int64,
+          name String
+        ) ENGINE = MergeTree() ORDER BY id"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_missing_engine(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id Int64,
+          name String
+        ) ORDER BY id"""
+        errors = connector.validate_ddl(ddl)
+        assert any("ENGINE" in e.upper() for e in errors)
+
+    def test_rejects_missing_order_by(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id Int64,
+          name String
+        ) ENGINE = MergeTree()"""
+        errors = connector.validate_ddl(ddl)
+        assert any("ORDER BY" in e.upper() for e in errors)
+
+    def test_rejects_varchar(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id Int64,
+          name VARCHAR(255)
+        ) ENGINE = MergeTree() ORDER BY id"""
+        errors = connector.validate_ddl(ddl)
+        assert any("VARCHAR" in e.upper() or "STRING" in e.upper() for e in errors)
+
+    def test_rejects_boolean_type(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id Int64,
+          active BOOLEAN
+        ) ENGINE = MergeTree() ORDER BY id"""
+        errors = connector.validate_ddl(ddl)
+        assert any("BOOLEAN" in e.upper() or "UINT8" in e.upper() for e in errors)
+
+    def test_rejects_starrocks_distributed_by(self, connector):
+        ddl = """CREATE TABLE db.t (id Int64)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "DISTRIBUTED BY" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_returns_engine_and_order_by(self, connector):
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout.get("engine") == "MergeTree()"
+        assert "order_by" in layout
+        assert layout["order_by"] == ["id"]
+
+    def test_fallback_first_column_when_no_integer(self, connector):
+        columns = [
+            {"name": "code", "type": "VARCHAR", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["order_by"] == ["code"]
+
+
+class TestMapSourceType:
+    def test_varchar_to_string(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") == "String"
+
+    def test_varchar_with_length_to_string(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR(255)") == "String"
+
+    def test_text_to_string(self, connector):
+        assert connector.map_source_type("duckdb", "TEXT") == "String"
+
+    def test_boolean_to_uint8(self, connector):
+        assert connector.map_source_type("duckdb", "BOOLEAN") == "UInt8"
+
+    def test_timestamp_to_datetime64(self, connector):
+        assert connector.map_source_type("duckdb", "TIMESTAMP") == "DateTime64(3)"
+
+    def test_integer_to_int32(self, connector):
+        assert connector.map_source_type("duckdb", "INTEGER") == "Int32"
+
+    def test_bigint_to_int64(self, connector):
+        assert connector.map_source_type("duckdb", "BIGINT") == "Int64"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "GEOMETRY") is None

--- a/datus-db-core/datus_db_core/__init__.py
+++ b/datus-db-core/datus_db_core/__init__.py
@@ -7,12 +7,14 @@ from datus_db_core.config import ConnectionConfig
 from datus_db_core.constants import SQLType
 from datus_db_core.exceptions import DatusDbException, ErrorCode
 from datus_db_core.logging import get_logger
+from datus_db_core.migration import MigrationTargetMixin
 from datus_db_core.mixins import (
     CatalogSupportMixin,
     MaterializedViewSupportMixin,
     SchemaNamespaceMixin,
 )
 from datus_db_core.models import TABLE_TYPE, ExecuteSQLInput, ExecuteSQLResult
+from datus_db_core.reconciliation import build_reconciliation_checks
 from datus_db_core.registry import (
     AdapterMetadata,
     ConnectorRegistry,
@@ -35,6 +37,7 @@ __all__ = [
     "get_logger",
     "CatalogSupportMixin",
     "MaterializedViewSupportMixin",
+    "MigrationTargetMixin",
     "SchemaNamespaceMixin",
     "TABLE_TYPE",
     "ExecuteSQLInput",
@@ -42,6 +45,7 @@ __all__ = [
     "AdapterMetadata",
     "ConnectorRegistry",
     "connector_registry",
+    "build_reconciliation_checks",
     "metadata_identifier",
     "parse_context_switch",
     "parse_sql_type",

--- a/datus-db-core/datus_db_core/migration.py
+++ b/datus-db-core/datus_db_core/migration.py
@@ -1,0 +1,72 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Mixin interface for connectors that can serve as a cross-database migration target.
+
+Adapters implement this Mixin to declare their dialect-specific constraints, type
+hints, and optional DDL validation. The migration agent reads these through a set
+of thin wrapper tools, keeping dialect knowledge out of the agent layer.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+
+class MigrationTargetMixin(ABC):
+    """Capabilities exposed when this connector is used as a migration target.
+
+    Only ``describe_migration_capabilities`` is mandatory. All other methods have
+    sensible defaults so an adapter can declare partial support.
+    """
+
+    @abstractmethod
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        """Return dialect hints and constraints for migration DDL generation.
+
+        Recommended keys:
+          * ``supported`` (bool) — whether this adapter is a usable migration target.
+          * ``dialect_family`` (str) — e.g. ``"mysql-like"``, ``"postgres-like"``,
+            ``"clickhouse"``, ``"trino-hive"``.
+          * ``requires`` (list[str]) — clauses the DDL MUST include.
+          * ``forbids`` (list[str]) — patterns the DDL MUST NOT include.
+          * ``type_hints`` (dict[str, str]) — preferred type mappings (human-readable).
+          * ``example_ddl`` (str) — a minimal CREATE TABLE example for the dialect.
+        """
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        """Deterministic type mapping.
+
+        Default returns ``None`` — the LLM will decide. Adapters may override to
+        enforce precision on well-known pairings (e.g. ``HUGEINT`` → ``NUMERIC(38,0)``).
+        """
+        return None
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Suggest dialect-specific table layout (keys, distribution, partitioning).
+
+        OLAP targets may return e.g.::
+
+            {"duplicate_key": ["id"], "distributed_by": ["id"], "buckets": 10}
+            {"order_by": ["id"], "engine": "MergeTree()"}
+            {"partitioned_by": ["ds"]}
+
+        Default returns an empty dict (OLTP / unspecified).
+        """
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        """Static structural check of a target-dialect CREATE TABLE DDL.
+
+        Returns a list of error strings (empty == ok). Does not execute anything.
+        """
+        return []
+
+    def dry_run_ddl(self, ddl: str, target_table: str) -> List[str]:
+        """Actually CREATE the target table to a temp name and DROP it.
+
+        Returns a list of error strings (empty == ok). This is the strongest form
+        of validation. Default raises ``NotImplementedError`` — agents must catch
+        and fall back to static ``validate_ddl`` only.
+        """
+        raise NotImplementedError("dry_run_ddl is not supported by this adapter")

--- a/datus-db-core/datus_db_core/reconciliation.py
+++ b/datus-db-core/datus_db_core/reconciliation.py
@@ -157,11 +157,11 @@ def build_reconciliation_checks(
                     "name": "duplicate_key",
                     "source_query": (
                         f"SELECT {all_keys}, COUNT(*) AS cnt FROM {source_table} "
-                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 ORDER BY {key_str} LIMIT 5"
                     ),
                     "target_query": (
                         f"SELECT {all_keys}, COUNT(*) AS cnt FROM {target_table} "
-                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 ORDER BY {key_str} LIMIT 5"
                     ),
                 }
             )
@@ -171,11 +171,11 @@ def build_reconciliation_checks(
                     "name": "duplicate_key",
                     "source_query": (
                         f"SELECT {key_str}, COUNT(*) AS cnt FROM {source_table} "
-                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 ORDER BY {key_str} LIMIT 5"
                     ),
                     "target_query": (
                         f"SELECT {key_str}, COUNT(*) AS cnt FROM {target_table} "
-                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 ORDER BY {key_str} LIMIT 5"
                     ),
                 }
             )

--- a/datus-db-core/datus_db_core/reconciliation.py
+++ b/datus-db-core/datus_db_core/reconciliation.py
@@ -9,7 +9,7 @@ after a migration transfer. Dialect-agnostic: uses standard SQL only.
 """
 
 import re
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from datus_db_core.logging import get_logger
 
@@ -49,6 +49,7 @@ def build_reconciliation_checks(
     target_table: str,
     columns: List[dict],
     key_columns: Optional[List[str]] = None,
+    quote_identifier: Optional[Callable[[str], str]] = None,
 ) -> List[dict]:
     """Build reconciliation check SQL pairs for source vs target comparison.
 
@@ -58,10 +59,15 @@ def build_reconciliation_checks(
         columns: List of column defs with name, type, nullable.
         key_columns: Optional list of key/PK column names. If None or empty,
                      key-dependent checks (duplicate_key, sample_diff) are skipped.
+        quote_identifier: Optional callable to quote identifiers per dialect.
+                          Defaults to double-quote quoting (ANSI SQL). Pass a
+                          backtick-quoting callable for MySQL/StarRocks/ClickHouse,
+                          or the connector's own quote_identifier when available.
 
     Returns:
         List of check dicts, each with: name, source_query, target_query.
     """
+    quote = quote_identifier or _quote_identifier
     checks = []
     has_keys = bool(key_columns)
 
@@ -80,10 +86,10 @@ def build_reconciliation_checks(
         src_parts = []
         tgt_parts = []
         for col in nullable_cols:
-            qname = _quote_identifier(col["name"])
+            qname = quote(col["name"])
             alias = col["name"].replace('"', "")
-            src_parts.append(f"COUNT(*) - COUNT({qname}) AS {_quote_identifier(alias + '_null_count')}")
-            tgt_parts.append(f"COUNT(*) - COUNT({qname}) AS {_quote_identifier(alias + '_null_count')}")
+            src_parts.append(f"COUNT(*) - COUNT({qname}) AS {quote(alias + '_null_count')}")
+            tgt_parts.append(f"COUNT(*) - COUNT({qname}) AS {quote(alias + '_null_count')}")
 
         src_parts.append("COUNT(*) AS total")
         tgt_parts.append("COUNT(*) AS total")
@@ -102,10 +108,10 @@ def build_reconciliation_checks(
         src_parts = []
         tgt_parts = []
         for col in minmax_cols:
-            qname = _quote_identifier(col["name"])
+            qname = quote(col["name"])
             alias = col["name"].replace('"', "")
-            min_alias = _quote_identifier(alias + "_min")
-            max_alias = _quote_identifier(alias + "_max")
+            min_alias = quote(alias + "_min")
+            max_alias = quote(alias + "_max")
             src_parts.append(f"MIN({qname}) AS {min_alias}, MAX({qname}) AS {max_alias}")
             tgt_parts.append(f"MIN({qname}) AS {min_alias}, MAX({qname}) AS {max_alias}")
 
@@ -121,7 +127,7 @@ def build_reconciliation_checks(
     distinct_cols = key_columns if has_keys else [c["name"] for c in columns]
     if distinct_cols:
         if has_keys and len(distinct_cols) > 1:
-            key_expr = ", ".join(_quote_identifier(c) for c in distinct_cols)
+            key_expr = ", ".join(quote(c) for c in distinct_cols)
             checks.append(
                 {
                     "name": "distinct_count",
@@ -130,12 +136,8 @@ def build_reconciliation_checks(
                 }
             )
         else:
-            src_parts = [
-                f"COUNT(DISTINCT {_quote_identifier(c)}) AS {_quote_identifier(c + '_distinct')}" for c in distinct_cols
-            ]
-            tgt_parts = [
-                f"COUNT(DISTINCT {_quote_identifier(c)}) AS {_quote_identifier(c + '_distinct')}" for c in distinct_cols
-            ]
+            src_parts = [f"COUNT(DISTINCT {quote(c)}) AS {quote(c + '_distinct')}" for c in distinct_cols]
+            tgt_parts = [f"COUNT(DISTINCT {quote(c)}) AS {quote(c + '_distinct')}" for c in distinct_cols]
             checks.append(
                 {
                     "name": "distinct_count",
@@ -146,7 +148,7 @@ def build_reconciliation_checks(
 
     # 5. Duplicate key — only if key columns provided
     if has_keys:
-        quoted_keys = [_quote_identifier(k) for k in key_columns]
+        quoted_keys = [quote(k) for k in key_columns]
         key_str = ", ".join(quoted_keys)
         if len(key_columns) > 1:
             all_keys = ", ".join(quoted_keys)
@@ -180,9 +182,9 @@ def build_reconciliation_checks(
 
     # 6. Sample diff — key-based sample, only if key columns provided
     if has_keys:
-        quoted_keys = [_quote_identifier(k) for k in key_columns]
+        quoted_keys = [quote(k) for k in key_columns]
         key_order = ", ".join(quoted_keys)
-        all_cols = ", ".join(_quote_identifier(c["name"]) for c in columns)
+        all_cols = ", ".join(quote(c["name"]) for c in columns)
         checks.append(
             {
                 "name": "sample_diff",
@@ -197,10 +199,10 @@ def build_reconciliation_checks(
         src_parts = []
         tgt_parts = []
         for col in numeric_cols:
-            qname = _quote_identifier(col["name"])
+            qname = quote(col["name"])
             alias = col["name"].replace('"', "")
-            sum_alias = _quote_identifier(alias + "_sum")
-            avg_alias = _quote_identifier(alias + "_avg")
+            sum_alias = quote(alias + "_sum")
+            avg_alias = quote(alias + "_avg")
             src_parts.append(f"SUM({qname}) AS {sum_alias}, AVG({qname}) AS {avg_alias}")
             tgt_parts.append(f"SUM({qname}) AS {sum_alias}, AVG({qname}) AS {avg_alias}")
 

--- a/datus-db-core/datus_db_core/reconciliation.py
+++ b/datus-db-core/datus_db_core/reconciliation.py
@@ -1,0 +1,215 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Reconciliation check generation for cross-database migration.
+
+Generates pairs of SQL queries (source vs target) for data reconciliation
+after a migration transfer. Dialect-agnostic: uses standard SQL only.
+"""
+
+import re
+from typing import List, Optional
+
+from datus_db_core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_NUMERIC_TYPE_PATTERN = re.compile(
+    r"^(INTEGER|INT[248]?|BIGINT|SMALLINT|TINYINT|FLOAT[48]?|DOUBLE|REAL|DECIMAL|NUMERIC|HUGEINT|LARGEINT)\b",
+    re.IGNORECASE,
+)
+
+_DATE_TYPE_PATTERN = re.compile(
+    r"^(DATE|TIMESTAMP|DATETIME|TIME)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_numeric_type(col_type: str) -> bool:
+    return bool(_NUMERIC_TYPE_PATTERN.match(col_type.strip()))
+
+
+def _is_date_type(col_type: str) -> bool:
+    return bool(_DATE_TYPE_PATTERN.match(col_type.strip()))
+
+
+def _is_minmax_type(col_type: str) -> bool:
+    return _is_numeric_type(col_type) or _is_date_type(col_type)
+
+
+def _quote_identifier(name: str) -> str:
+    """Quote a SQL identifier with double quotes to handle reserved words and special characters."""
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def build_reconciliation_checks(
+    source_table: str,
+    target_table: str,
+    columns: List[dict],
+    key_columns: Optional[List[str]] = None,
+) -> List[dict]:
+    """Build reconciliation check SQL pairs for source vs target comparison.
+
+    Args:
+        source_table: Fully qualified source table name.
+        target_table: Fully qualified target table name.
+        columns: List of column defs with name, type, nullable.
+        key_columns: Optional list of key/PK column names. If None or empty,
+                     key-dependent checks (duplicate_key, sample_diff) are skipped.
+
+    Returns:
+        List of check dicts, each with: name, source_query, target_query.
+    """
+    checks = []
+    has_keys = bool(key_columns)
+
+    # 1. Row count
+    checks.append(
+        {
+            "name": "row_count",
+            "source_query": f"SELECT COUNT(*) AS row_count FROM {source_table}",
+            "target_query": f"SELECT COUNT(*) AS row_count FROM {target_table}",
+        }
+    )
+
+    # 2. Null ratio — for all nullable columns
+    nullable_cols = [c for c in columns if c.get("nullable", True)]
+    if nullable_cols:
+        src_parts = []
+        tgt_parts = []
+        for col in nullable_cols:
+            qname = _quote_identifier(col["name"])
+            alias = col["name"].replace('"', "")
+            src_parts.append(f"COUNT(*) - COUNT({qname}) AS {_quote_identifier(alias + '_null_count')}")
+            tgt_parts.append(f"COUNT(*) - COUNT({qname}) AS {_quote_identifier(alias + '_null_count')}")
+
+        src_parts.append("COUNT(*) AS total")
+        tgt_parts.append("COUNT(*) AS total")
+
+        checks.append(
+            {
+                "name": "null_ratio",
+                "source_query": f"SELECT {', '.join(src_parts)} FROM {source_table}",
+                "target_query": f"SELECT {', '.join(tgt_parts)} FROM {target_table}",
+            }
+        )
+
+    # 3. Min/max — for numeric and date columns
+    minmax_cols = [c for c in columns if _is_minmax_type(c["type"])]
+    if minmax_cols:
+        src_parts = []
+        tgt_parts = []
+        for col in minmax_cols:
+            qname = _quote_identifier(col["name"])
+            alias = col["name"].replace('"', "")
+            min_alias = _quote_identifier(alias + "_min")
+            max_alias = _quote_identifier(alias + "_max")
+            src_parts.append(f"MIN({qname}) AS {min_alias}, MAX({qname}) AS {max_alias}")
+            tgt_parts.append(f"MIN({qname}) AS {min_alias}, MAX({qname}) AS {max_alias}")
+
+        checks.append(
+            {
+                "name": "min_max",
+                "source_query": f"SELECT {', '.join(src_parts)} FROM {source_table}",
+                "target_query": f"SELECT {', '.join(tgt_parts)} FROM {target_table}",
+            }
+        )
+
+    # 4. Distinct count — for key columns or all columns
+    distinct_cols = key_columns if has_keys else [c["name"] for c in columns]
+    if distinct_cols:
+        if has_keys and len(distinct_cols) > 1:
+            key_expr = ", ".join(_quote_identifier(c) for c in distinct_cols)
+            checks.append(
+                {
+                    "name": "distinct_count",
+                    "source_query": f"SELECT COUNT(*) AS distinct_key_count FROM (SELECT DISTINCT {key_expr} FROM {source_table}) t",
+                    "target_query": f"SELECT COUNT(*) AS distinct_key_count FROM (SELECT DISTINCT {key_expr} FROM {target_table}) t",
+                }
+            )
+        else:
+            src_parts = [
+                f"COUNT(DISTINCT {_quote_identifier(c)}) AS {_quote_identifier(c + '_distinct')}" for c in distinct_cols
+            ]
+            tgt_parts = [
+                f"COUNT(DISTINCT {_quote_identifier(c)}) AS {_quote_identifier(c + '_distinct')}" for c in distinct_cols
+            ]
+            checks.append(
+                {
+                    "name": "distinct_count",
+                    "source_query": f"SELECT {', '.join(src_parts)} FROM {source_table}",
+                    "target_query": f"SELECT {', '.join(tgt_parts)} FROM {target_table}",
+                }
+            )
+
+    # 5. Duplicate key — only if key columns provided
+    if has_keys:
+        quoted_keys = [_quote_identifier(k) for k in key_columns]
+        key_str = ", ".join(quoted_keys)
+        if len(key_columns) > 1:
+            all_keys = ", ".join(quoted_keys)
+            checks.append(
+                {
+                    "name": "duplicate_key",
+                    "source_query": (
+                        f"SELECT {all_keys}, COUNT(*) AS cnt FROM {source_table} "
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                    ),
+                    "target_query": (
+                        f"SELECT {all_keys}, COUNT(*) AS cnt FROM {target_table} "
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                    ),
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "duplicate_key",
+                    "source_query": (
+                        f"SELECT {key_str}, COUNT(*) AS cnt FROM {source_table} "
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                    ),
+                    "target_query": (
+                        f"SELECT {key_str}, COUNT(*) AS cnt FROM {target_table} "
+                        f"GROUP BY {key_str} HAVING COUNT(*) > 1 LIMIT 5"
+                    ),
+                }
+            )
+
+    # 6. Sample diff — key-based sample, only if key columns provided
+    if has_keys:
+        quoted_keys = [_quote_identifier(k) for k in key_columns]
+        key_order = ", ".join(quoted_keys)
+        all_cols = ", ".join(_quote_identifier(c["name"]) for c in columns)
+        checks.append(
+            {
+                "name": "sample_diff",
+                "source_query": (f"SELECT {all_cols} FROM {source_table} ORDER BY {key_order} LIMIT 10"),
+                "target_query": (f"SELECT {all_cols} FROM {target_table} ORDER BY {key_order} LIMIT 10"),
+            }
+        )
+
+    # 7. Numeric aggregate — SUM/AVG for numeric columns
+    numeric_cols = [c for c in columns if _is_numeric_type(c["type"])]
+    if numeric_cols:
+        src_parts = []
+        tgt_parts = []
+        for col in numeric_cols:
+            qname = _quote_identifier(col["name"])
+            alias = col["name"].replace('"', "")
+            sum_alias = _quote_identifier(alias + "_sum")
+            avg_alias = _quote_identifier(alias + "_avg")
+            src_parts.append(f"SUM({qname}) AS {sum_alias}, AVG({qname}) AS {avg_alias}")
+            tgt_parts.append(f"SUM({qname}) AS {sum_alias}, AVG({qname}) AS {avg_alias}")
+
+        checks.append(
+            {
+                "name": "numeric_aggregate",
+                "source_query": f"SELECT {', '.join(src_parts)} FROM {source_table}",
+                "target_query": f"SELECT {', '.join(tgt_parts)} FROM {target_table}",
+            }
+        )
+
+    return checks

--- a/datus-db-core/tests/unit/test_migration_mixin.py
+++ b/datus-db-core/tests/unit/test_migration_mixin.py
@@ -1,0 +1,100 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for MigrationTargetMixin interface contract."""
+
+import pytest
+
+from datus_db_core.migration import MigrationTargetMixin
+
+
+class _MinimalImpl(MigrationTargetMixin):
+    """Minimal concrete implementation for testing default method behavior."""
+
+    def describe_migration_capabilities(self) -> dict:
+        return {"supported": True, "dialect_family": "test"}
+
+
+class _FullImpl(MigrationTargetMixin):
+    """Concrete impl that overrides every optional method."""
+
+    def describe_migration_capabilities(self) -> dict:
+        return {"supported": True, "dialect_family": "custom"}
+
+    def map_source_type(self, source_dialect: str, source_type: str):
+        return f"{source_dialect}->{source_type}"
+
+    def suggest_table_layout(self, columns):
+        return {"primary_key": [columns[0]["name"]]} if columns else {}
+
+    def validate_ddl(self, ddl: str):
+        return ["has DROP TABLE"] if "DROP TABLE" in ddl else []
+
+    def dry_run_ddl(self, ddl: str, target_table: str):
+        return []
+
+
+class TestAbstractContract:
+    def test_cannot_instantiate_without_describe(self):
+        """MigrationTargetMixin requires describe_migration_capabilities."""
+        with pytest.raises(TypeError):
+            MigrationTargetMixin()  # abstract
+
+    def test_concrete_impl_can_be_instantiated(self):
+        impl = _MinimalImpl()
+        assert isinstance(impl, MigrationTargetMixin)
+
+
+class TestDefaultMethodBehavior:
+    """Optional methods must have sensible defaults so adapters can skip them."""
+
+    def test_map_source_type_returns_none_by_default(self):
+        impl = _MinimalImpl()
+        assert impl.map_source_type("duckdb", "VARCHAR") is None
+
+    def test_suggest_table_layout_returns_empty_dict(self):
+        impl = _MinimalImpl()
+        assert impl.suggest_table_layout([{"name": "id", "type": "INT"}]) == {}
+
+    def test_validate_ddl_returns_empty_list(self):
+        impl = _MinimalImpl()
+        assert impl.validate_ddl("CREATE TABLE t (id INT)") == []
+
+    def test_dry_run_ddl_raises_not_implemented(self):
+        impl = _MinimalImpl()
+        with pytest.raises(NotImplementedError):
+            impl.dry_run_ddl("CREATE TABLE t (id INT)", "t")
+
+
+class TestDescribeContract:
+    def test_describe_returns_dict(self):
+        impl = _MinimalImpl()
+        result = impl.describe_migration_capabilities()
+        assert isinstance(result, dict)
+
+    def test_describe_should_have_supported_key(self):
+        impl = _MinimalImpl()
+        result = impl.describe_migration_capabilities()
+        assert "supported" in result
+
+
+class TestFullOverride:
+    """If an adapter overrides everything, its overrides win."""
+
+    def test_map_source_type_override(self):
+        impl = _FullImpl()
+        assert impl.map_source_type("mysql", "BIGINT") == "mysql->BIGINT"
+
+    def test_suggest_table_layout_override(self):
+        impl = _FullImpl()
+        assert impl.suggest_table_layout([{"name": "pk", "type": "BIGINT"}]) == {"primary_key": ["pk"]}
+
+    def test_validate_ddl_override(self):
+        impl = _FullImpl()
+        assert impl.validate_ddl("DROP TABLE t") == ["has DROP TABLE"]
+        assert impl.validate_ddl("CREATE TABLE t (id INT)") == []
+
+    def test_dry_run_ddl_override_does_not_raise(self):
+        impl = _FullImpl()
+        assert impl.dry_run_ddl("CREATE TABLE t (id INT)", "t") == []

--- a/datus-db-core/tests/unit/test_reconciliation.py
+++ b/datus-db-core/tests/unit/test_reconciliation.py
@@ -1,0 +1,306 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for reconciliation check generation."""
+
+import pytest
+
+from datus_db_core.reconciliation import build_reconciliation_checks
+
+
+class TestBuildReconciliationChecks:
+    """Test that all 7 check types are generated correctly."""
+
+    @pytest.fixture
+    def sample_columns(self):
+        return [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "amount", "type": "DECIMAL(10,2)", "nullable": True},
+            {"name": "created_at", "type": "DATE", "nullable": True},
+            {"name": "is_active", "type": "BOOLEAN", "nullable": True},
+        ]
+
+    def test_returns_list_of_checks(self, sample_columns):
+        checks = build_reconciliation_checks(
+            source_table="src.users",
+            target_table="tgt.users",
+            columns=sample_columns,
+            key_columns=["id"],
+        )
+        assert isinstance(checks, list)
+        assert len(checks) == 7
+
+    def test_all_checks_have_required_fields(self, sample_columns):
+        checks = build_reconciliation_checks(
+            source_table="src.users",
+            target_table="tgt.users",
+            columns=sample_columns,
+            key_columns=["id"],
+        )
+        assert len(checks) > 0
+        for check in checks:
+            assert "name" in check
+            assert "source_query" in check
+            assert "target_query" in check
+            assert isinstance(check["source_query"], str)
+            assert len(check["source_query"]) > 0
+            assert isinstance(check["target_query"], str)
+            assert len(check["target_query"]) > 0
+
+    def test_check_names_present(self, sample_columns):
+        checks = build_reconciliation_checks(
+            source_table="src.users",
+            target_table="tgt.users",
+            columns=sample_columns,
+            key_columns=["id"],
+        )
+        check_names = [c["name"] for c in checks]
+        assert "row_count" in check_names
+        assert "null_ratio" in check_names
+        assert "min_max" in check_names
+        assert "distinct_count" in check_names
+        assert "duplicate_key" in check_names
+        assert "sample_diff" in check_names
+        assert "numeric_aggregate" in check_names
+
+
+class TestIndividualCheckSQL:
+    """Test SQL correctness for each individual check type."""
+
+    def test_row_count_sql(self):
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=[{"name": "id", "type": "INTEGER", "nullable": False}],
+            key_columns=["id"],
+        )
+        row_count = next(c for c in checks if c["name"] == "row_count")
+        assert "COUNT(*)" in row_count["source_query"].upper()
+        assert "src.t" in row_count["source_query"]
+        assert "COUNT(*)" in row_count["target_query"].upper()
+        assert "tgt.t" in row_count["target_query"]
+        assert "SELECT" in row_count["source_query"].upper()
+        assert "FROM" in row_count["source_query"].upper()
+
+    def test_null_ratio_for_nullable_columns(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        null_checks = [c for c in checks if c["name"] == "null_ratio"]
+        assert len(null_checks) > 0
+        sql = null_checks[0]["source_query"].upper()
+        assert "COUNT" in sql
+        assert "NULL" in sql
+        assert "name" in null_checks[0]["source_query"]
+        assert '"id"' not in null_checks[0]["source_query"]
+
+    def test_min_max_for_numeric_columns(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "amount", "type": "DECIMAL(10,2)", "nullable": True},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        min_max_checks = [c for c in checks if c["name"] == "min_max"]
+        assert len(min_max_checks) > 0
+        sql = min_max_checks[0]["source_query"].upper()
+        assert "MIN" in sql
+        assert "MAX" in sql
+
+    def test_min_max_includes_date_columns(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "created_at", "type": "DATE", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        min_max_checks = [c for c in checks if c["name"] == "min_max"]
+        assert len(min_max_checks) > 0
+        sql = min_max_checks[0]["source_query"].upper()
+        assert "MIN" in sql
+        assert "MAX" in sql
+        assert "created_at" in min_max_checks[0]["source_query"]
+
+    def test_aggregate_for_numeric_columns(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "amount", "type": "DECIMAL(10,2)", "nullable": True},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        agg_checks = [c for c in checks if c["name"] == "numeric_aggregate"]
+        assert len(agg_checks) > 0
+        sql = agg_checks[0]["source_query"].upper()
+        assert "SUM" in sql
+        assert "AVG" in sql
+
+    def test_duplicate_key_sql(self):
+        columns = [{"name": "id", "type": "INTEGER", "nullable": False}]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        dup_check = next(c for c in checks if c["name"] == "duplicate_key")
+        sql = dup_check["target_query"].upper()
+        assert "GROUP BY" in sql
+        assert "HAVING" in sql
+        assert "COUNT" in sql
+
+    def test_sample_diff_sql(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        sample_check = next(c for c in checks if c["name"] == "sample_diff")
+        assert "ORDER BY" in sample_check["source_query"].upper()
+        assert "LIMIT" in sample_check["source_query"].upper()
+
+
+class TestCheckSkipping:
+    """Test that checks are skipped when required columns are absent."""
+
+    def test_skips_key_dependent_checks(self):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "amount", "type": "DECIMAL", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=None,
+        )
+        check_names = [c["name"] for c in checks]
+        assert "row_count" in check_names
+        assert "numeric_aggregate" in check_names
+        assert "duplicate_key" not in check_names
+        assert "sample_diff" not in check_names
+
+    def test_empty_key_columns_same_as_none(self):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "amount", "type": "DECIMAL", "nullable": True},
+        ]
+        checks_none = build_reconciliation_checks("s", "t", columns, key_columns=None)
+        checks_empty = build_reconciliation_checks("s", "t", columns, key_columns=[])
+        assert [c["name"] for c in checks_none] == [c["name"] for c in checks_empty]
+
+    def test_all_non_nullable_skips_null_ratio(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "code", "type": "VARCHAR", "nullable": False},
+            {"name": "amount", "type": "DECIMAL(10,2)", "nullable": False},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        check_names = [c["name"] for c in checks]
+        assert "null_ratio" not in check_names
+
+    def test_no_numeric_columns_skips_aggregates(self):
+        columns = [
+            {"name": "id", "type": "VARCHAR", "nullable": False},
+            {"name": "label", "type": "VARCHAR", "nullable": True},
+            {"name": "active", "type": "BOOLEAN", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id"],
+        )
+        check_names = [c["name"] for c in checks]
+        assert "numeric_aggregate" not in check_names
+        assert "min_max" not in check_names
+
+
+class TestIdentifierQuoting:
+    """Test that column identifiers are quoted in generated SQL."""
+
+    def test_column_names_are_quoted(self):
+        columns = [
+            {"name": "order", "type": "INTEGER", "nullable": False},
+            {"name": "group", "type": "VARCHAR", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["order"],
+        )
+        null_check = next(c for c in checks if c["name"] == "null_ratio")
+        assert '"group"' in null_check["source_query"]
+
+        distinct_check = next(c for c in checks if c["name"] == "distinct_count")
+        assert '"order"' in distinct_check["source_query"]
+
+    def test_composite_key_distinct_count_uses_subquery(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "region", "type": "VARCHAR", "nullable": False},
+            {"name": "amount", "type": "DECIMAL", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id", "region"],
+        )
+        distinct_check = next(c for c in checks if c["name"] == "distinct_count")
+        sql = distinct_check["source_query"].upper()
+        assert "SELECT DISTINCT" in sql
+        assert "COUNT(*)" in sql
+        assert '"id"' in distinct_check["source_query"]
+        assert '"region"' in distinct_check["source_query"]
+
+    def test_composite_key_duplicate_check(self):
+        columns = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "region", "type": "VARCHAR", "nullable": False},
+            {"name": "amount", "type": "DECIMAL", "nullable": True},
+        ]
+        checks = build_reconciliation_checks(
+            source_table="src.t",
+            target_table="tgt.t",
+            columns=columns,
+            key_columns=["id", "region"],
+        )
+        dup_check = next(c for c in checks if c["name"] == "duplicate_key")
+        sql = dup_check["target_query"]
+        assert '"id"' in sql
+        assert '"region"' in sql
+        assert "GROUP BY" in sql.upper()

--- a/datus-greenplum/datus_greenplum/connector.py
+++ b/datus-greenplum/datus_greenplum/connector.py
@@ -4,12 +4,14 @@
 
 from typing import Any, Dict, List, Optional, Set, Union, override
 
-from datus_db_core import get_logger
+from datus_db_core import MigrationTargetMixin, get_logger
 from datus_postgresql import PostgreSQLConnector
 
 from .config import GreenplumConfig
 
 logger = get_logger(__name__)
+
+_GREENPLUM_INTEGER_TYPES = frozenset({"INT", "INTEGER", "BIGINT", "SMALLINT", "INT2", "INT4", "INT8"})
 
 
 def _escape_literal(value: str) -> str:
@@ -17,7 +19,7 @@ def _escape_literal(value: str) -> str:
     return value.replace("'", "''")
 
 
-class GreenplumConnector(PostgreSQLConnector):
+class GreenplumConnector(PostgreSQLConnector, MigrationTargetMixin):
     """Greenplum database connector.
 
     Greenplum is based on PostgreSQL and uses the same wire protocol.
@@ -181,3 +183,93 @@ class GreenplumConnector(PostgreSQLConnector):
             logger.warning(f"Could not get storage info for {schema_name}.{table_name}: {e}")
 
         return None
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "postgres-like",
+            "requires": [],  # DISTRIBUTED BY is recommended, not strictly required
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH with BUCKETS (StarRocks-only; use DISTRIBUTED BY without BUCKETS)",
+            ],
+            "type_hints": {
+                "HUGEINT": "NUMERIC(38,0) (Greenplum has no HUGEINT)",
+                "unbounded VARCHAR": "TEXT (prefer over unbounded VARCHAR)",
+                "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
+                "distribution": "Add DISTRIBUTED BY (<col>) or DISTRIBUTED RANDOMLY for even data layout",
+            },
+            "example_ddl": (
+                "CREATE TABLE public.t (\n  id BIGINT NOT NULL,\n  name VARCHAR(255)\n)\nDISTRIBUTED BY (id)"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not columns:
+            return {"distributed_by": []}
+
+        keys = self._gp_score_keys(columns, max_keys=1)
+        return {"distributed_by": keys}
+
+    @staticmethod
+    def _gp_score_keys(columns: List[Dict[str, Any]], max_keys: int = 1) -> List[str]:
+        """Select distribution columns for Greenplum.
+
+        Priority:
+          1. Columns with 'id' or '_id' suffix (+100)
+          2. INT/BIGINT type columns (+50)
+          3. Non-nullable columns (+10)
+        """
+        import re as _re
+
+        scored = []
+        for col in columns:
+            name = col["name"]
+            col_type = str(col.get("type", "")).upper()
+            base_type = _re.sub(r"\(.*\)", "", col_type).strip()
+            nullable = col.get("nullable", True)
+
+            score = 0
+            if name.lower() == "id" or name.lower().endswith("_id"):
+                score += 100
+            if base_type in _GREENPLUM_INTEGER_TYPES:
+                score += 50
+            if not nullable:
+                score += 10
+
+            scored.append((score, name))
+
+        scored.sort(key=lambda x: (-x[0], x[1]))
+
+        if scored[0][0] == 0:
+            return [columns[0]["name"]]
+
+        return [name for score, name in scored[:max_keys]]
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; Greenplum uses DISTRIBUTED BY or PRIMARY KEY")
+        if "BUCKETS" in upper and "DISTRIBUTED BY HASH" in upper:
+            errors.append(
+                "DISTRIBUTED BY HASH(...) BUCKETS N is StarRocks syntax; Greenplum uses DISTRIBUTED BY (<cols>)"
+            )
+        if "ENGINE =" in upper or "ENGINE=" in upper:
+            errors.append("ENGINE clause is MySQL/ClickHouse syntax; not supported in Greenplum")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "NUMERIC(38,0)",
+            "DATETIME": "TIMESTAMP",
+            "LARGEINT": "NUMERIC(38,0)",
+        }
+        return overrides.get(base)

--- a/datus-greenplum/tests/unit/test_migration_mixin.py
+++ b/datus-greenplum/tests/unit/test_migration_mixin.py
@@ -1,0 +1,102 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for Greenplum MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_greenplum import GreenplumConnector
+
+
+@pytest.fixture
+def connector():
+    return GreenplumConnector.__new__(GreenplumConnector)
+
+
+class TestMixinInheritance:
+    def test_greenplum_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["supported"] is True
+
+    def test_dialect_family_postgres_like(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["dialect_family"] == "postgres-like"
+
+    def test_mentions_distributed_by_as_recommended(self, connector):
+        """DISTRIBUTED BY should be recommended in type_hints or example, but NOT required."""
+        result = connector.describe_migration_capabilities()
+        haystack = " ".join(
+            [
+                " ".join(result.get("requires", [])),
+                " ".join(result.get("forbids", [])),
+                " ".join(result.get("type_hints", {}).values()),
+                result.get("example_ddl", ""),
+            ]
+        ).upper()
+        assert "DISTRIBUTED BY" in haystack
+
+    def test_distributed_by_not_hard_required(self, connector):
+        result = connector.describe_migration_capabilities()
+        requires_str = " ".join(result.get("requires", [])).upper()
+        assert "DISTRIBUTED BY" not in requires_str
+
+    def test_example_ddl_has_create_table(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert "CREATE TABLE" in result["example_ddl"].upper()
+
+
+class TestValidateDdl:
+    def test_accepts_ddl_without_distributed_by(self, connector):
+        """DISTRIBUTED BY is recommended, not required; should accept without it."""
+        ddl = "CREATE TABLE public.t (id BIGINT NOT NULL, name VARCHAR(255))"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_ddl_with_distributed_by(self, connector):
+        ddl = "CREATE TABLE public.t (id BIGINT NOT NULL) DISTRIBUTED BY (id)"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_starrocks_specific_syntax(self, connector):
+        """Guard against cross-dialect mistakes."""
+        ddl = """CREATE TABLE public.t (id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_suggests_distributed_by_id_column(self, connector):
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert "distributed_by" in layout
+        assert layout["distributed_by"] == ["id"]
+
+    def test_fallback_first_column_when_no_integer_key(self, connector):
+        columns = [
+            {"name": "code", "type": "VARCHAR", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["distributed_by"] == ["code"]
+
+    def test_empty_columns(self, connector):
+        layout = connector.suggest_table_layout([])
+        assert isinstance(layout, dict)
+
+
+class TestMapSourceType:
+    def test_hugeint_to_numeric(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "NUMERIC(38,0)"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -12,6 +12,7 @@ from datus_db_core import (
     TABLE_TYPE,
     DatusDbException,
     ErrorCode,
+    MigrationTargetMixin,
     get_logger,
     list_to_in_str,
 )
@@ -59,7 +60,7 @@ def _get_metadata_config(table_type: TABLE_TYPE) -> TableMetadataNames:
     return METADATA_DICT[table_type]
 
 
-class MySQLConnector(SQLAlchemyConnector):
+class MySQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
     """MySQL database connector."""
 
     def __init__(self, config: Union[MySQLConfig, dict]):
@@ -438,3 +439,57 @@ class MySQLConnector(SQLAlchemyConnector):
         """Reset filter tables with full names."""
         database_name = database_name or self.database_name
         return super()._reset_filter_tables(tables, "", database_name, "")
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "mysql-like",
+            "requires": [],  # OLTP — no distribution/partition required
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH ... BUCKETS (StarRocks-only)",
+            ],
+            "type_hints": {
+                "HUGEINT": "DECIMAL(38,0) (MySQL has no HUGEINT)",
+                "LARGEINT": "DECIMAL(38,0)",
+                "unbounded VARCHAR": "VARCHAR(255) for indexed columns, TEXT otherwise",
+                "BOOLEAN": "TINYINT(1)",
+                "TIMESTAMP": "DATETIME (MySQL TIMESTAMP has 2038 limit)",
+            },
+            "example_ddl": (
+                "CREATE TABLE db.t (\n"
+                "  id BIGINT AUTO_INCREMENT PRIMARY KEY,\n"
+                "  name VARCHAR(255),\n"
+                "  created_at DATETIME DEFAULT CURRENT_TIMESTAMP\n"
+                ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # MySQL is OLTP — no distribution keys required
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if "DUPLICATE KEY" in upper and "ON DUPLICATE KEY" not in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; MySQL uses PRIMARY KEY / UNIQUE KEY")
+        if "BUCKETS" in upper and "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY ... BUCKETS is StarRocks syntax; MySQL does not support it")
+        if "ORDER BY" in upper and "CREATE TABLE" in upper and ("ENGINE = MERGETREE" in upper or "MERGETREE" in upper):
+            errors.append("ENGINE = MergeTree is ClickHouse-only; MySQL supports InnoDB/MyISAM/Memory/etc.")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "DECIMAL(38,0)",
+            "LARGEINT": "DECIMAL(38,0)",
+        }
+        return overrides.get(base)

--- a/datus-mysql/tests/unit/test_migration_mixin.py
+++ b/datus-mysql/tests/unit/test_migration_mixin.py
@@ -1,0 +1,75 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for MySQL MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_mysql import MySQLConnector
+
+
+@pytest.fixture
+def connector():
+    return MySQLConnector.__new__(MySQLConnector)
+
+
+class TestMixinInheritance:
+    def test_mysql_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        assert connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_mysql_like(self, connector):
+        assert connector.describe_migration_capabilities()["dialect_family"] == "mysql-like"
+
+    def test_no_hard_requirements(self, connector):
+        assert connector.describe_migration_capabilities()["requires"] == []
+
+    def test_type_hints_boolean_to_tinyint(self, connector):
+        hints = connector.describe_migration_capabilities()["type_hints"]
+        hints_str = " ".join(hints.values()).upper()
+        assert "TINYINT" in hints_str
+
+    def test_example_ddl_has_engine_innodb(self, connector):
+        ddl = connector.describe_migration_capabilities()["example_ddl"].upper()
+        assert "ENGINE=INNODB" in ddl.replace(" ", "") or "ENGINE = INNODB" in ddl
+
+
+class TestValidateDdl:
+    def test_accepts_standard_mysql_ddl(self, connector):
+        ddl = "CREATE TABLE db.t (id BIGINT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255)) ENGINE=InnoDB"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_duplicate_key_starrocks(self, connector):
+        ddl = """CREATE TABLE db.t (id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+    def test_rejects_distributed_by_buckets(self, connector):
+        ddl = "CREATE TABLE db.t (id BIGINT) DISTRIBUTED BY HASH(id) BUCKETS 10"
+        errors = connector.validate_ddl(ddl)
+        assert any("BUCKETS" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_returns_empty_dict(self, connector):
+        columns = [{"name": "id", "type": "BIGINT", "nullable": False}]
+        assert connector.suggest_table_layout(columns) == {}
+
+
+class TestMapSourceType:
+    def test_hugeint_to_decimal(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "DECIMAL(38,0)"
+
+    def test_largeint_to_decimal(self, connector):
+        assert connector.map_source_type("starrocks", "LARGEINT") == "DECIMAL(38,0)"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -13,6 +13,7 @@ from datus_db_core import (
     TABLE_TYPE,
     DatusDbException,
     ErrorCode,
+    MigrationTargetMixin,
     get_logger,
     list_to_in_str,
 )
@@ -52,7 +53,7 @@ def _get_metadata_config(table_type: TABLE_TYPE) -> TableMetadataNames:
     return METADATA_DICT[table_type]
 
 
-class PostgreSQLConnector(SQLAlchemyConnector):
+class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
     """PostgreSQL database connector."""
 
     def __init__(self, config: Union[PostgreSQLConfig, dict]):
@@ -667,3 +668,66 @@ class PostgreSQLConnector(SQLAlchemyConnector):
         """Reset filter tables with full names."""
         schema_name = schema_name or self.schema_name
         return super()._reset_filter_tables(tables, "", database_name, schema_name)
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "postgres-like",
+            "requires": [],  # OLTP — no distribution/partition required
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH ... BUCKETS (StarRocks-only)",
+                "ENGINE = (MySQL/ClickHouse syntax)",
+            ],
+            "type_hints": {
+                "HUGEINT": "NUMERIC(38,0) (Postgres has no HUGEINT/LARGEINT)",
+                "LARGEINT": "NUMERIC(38,0)",
+                "unbounded VARCHAR": "TEXT (prefer TEXT over unbounded VARCHAR)",
+                "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
+                "JSON": "JSONB (prefer for indexing)",
+                "BOOLEAN": "BOOLEAN (no TINYINT cast needed)",
+            },
+            "example_ddl": (
+                "CREATE TABLE public.t (\n"
+                "  id BIGSERIAL PRIMARY KEY,\n"
+                "  name VARCHAR(255),\n"
+                "  created_at TIMESTAMPTZ DEFAULT now()\n"
+                ")"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # Postgres is OLTP — no distribution keys or bucketing required
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; Postgres does not support it")
+        if "BUCKETS" in upper and "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY ... BUCKETS is StarRocks syntax; Postgres does not support it")
+        if "ENGINE =" in upper or "ENGINE=" in upper:
+            errors.append("ENGINE clause is MySQL/ClickHouse syntax; not supported in Postgres")
+        if "ORDER BY" in upper and "CREATE TABLE" in upper:
+            # Rough heuristic: top-level ORDER BY inside CREATE TABLE is ClickHouse's
+            # MergeTree syntax. Postgres allows ORDER BY inside CTAS SELECT, so this
+            # check is intentionally loose (only flags when accompanied by ENGINE).
+            if "ENGINE" in upper:
+                errors.append("ORDER BY inside CREATE TABLE is ClickHouse syntax; use CREATE INDEX in Postgres")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "NUMERIC(38,0)",
+            "LARGEINT": "NUMERIC(38,0)",
+            "DATETIME": "TIMESTAMP",
+        }
+        return overrides.get(base)

--- a/datus-postgresql/tests/unit/test_migration_mixin.py
+++ b/datus-postgresql/tests/unit/test_migration_mixin.py
@@ -1,0 +1,89 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for PostgreSQL MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_postgresql import PostgreSQLConnector
+
+
+@pytest.fixture
+def connector():
+    return PostgreSQLConnector.__new__(PostgreSQLConnector)
+
+
+class TestMixinInheritance:
+    def test_postgresql_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["supported"] is True
+
+    def test_dialect_family_postgres_like(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["dialect_family"] == "postgres-like"
+
+    def test_no_hard_requirements(self, connector):
+        """Postgres is OLTP — no distribution/partition required."""
+        result = connector.describe_migration_capabilities()
+        assert result["requires"] == []
+
+    def test_type_hints_mention_text_over_varchar(self, connector):
+        result = connector.describe_migration_capabilities()
+        hints_str = " ".join(result["type_hints"].values()).upper()
+        assert "TEXT" in hints_str
+
+    def test_example_ddl_is_simple(self, connector):
+        result = connector.describe_migration_capabilities()
+        ddl = result["example_ddl"].upper()
+        assert "CREATE TABLE" in ddl
+        # Should NOT contain DUPLICATE KEY or BUCKETS
+        assert "DUPLICATE KEY" not in ddl
+        assert "BUCKETS" not in ddl
+
+
+class TestValidateDdl:
+    def test_accepts_standard_postgres_ddl(self, connector):
+        ddl = "CREATE TABLE public.t (id BIGSERIAL PRIMARY KEY, name VARCHAR(255))"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_duplicate_key_starrocks_syntax(self, connector):
+        ddl = """CREATE TABLE public.t (id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+    def test_rejects_distributed_by_hash_buckets(self, connector):
+        ddl = "CREATE TABLE public.t (id BIGINT) DISTRIBUTED BY HASH(id) BUCKETS 10"
+        errors = connector.validate_ddl(ddl)
+        assert any("BUCKETS" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_returns_empty_dict(self, connector):
+        """Postgres doesn't need distribution keys — OLTP."""
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout == {}
+
+
+class TestMapSourceType:
+    def test_hugeint_to_numeric(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "NUMERIC(38,0)"
+
+    def test_largeint_to_numeric(self, connector):
+        """StarRocks LARGEINT has no direct Postgres equivalent."""
+        assert connector.map_source_type("starrocks", "LARGEINT") == "NUMERIC(38,0)"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -35,6 +35,7 @@ from datus_db_core import (
     ErrorCode,
     ExecuteSQLResult,
     MaterializedViewSupportMixin,
+    MigrationTargetMixin,
     SchemaNamespaceMixin,
     get_logger,
     parse_context_switch,
@@ -139,7 +140,7 @@ def _validate_sql_identifier(identifier: str, identifier_type: str = "identifier
         )
 
 
-class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedViewSupportMixin):
+class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedViewSupportMixin, MigrationTargetMixin):
     """
     Connector for Amazon Redshift databases using native Redshift SDK.
 
@@ -1409,3 +1410,110 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
         else:
             # Just table name (will use current schema from search_path)
             return f'"{table_name}"'
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "redshift",
+            "requires": [],  # DISTKEY/SORTKEY are strongly recommended but not required
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH ... BUCKETS (StarRocks-only)",
+                "ENGINE = ... (MySQL/ClickHouse syntax)",
+                "SERIAL (use IDENTITY(1,1) in Redshift)",
+                "VARCHAR(MAX) (Redshift max is 65535; length must be explicit)",
+            ],
+            "type_hints": {
+                "DISTKEY": "Add DISTKEY(<col>) for even data distribution; prefer a high-cardinality join key",
+                "SORTKEY": "Add SORTKEY(<col>) for date/timestamp columns used in filters",
+                "ENCODE": "Add ENCODE <scheme> per column for compression; AZ64 is a good default",
+                "unbounded VARCHAR": "VARCHAR with explicit length (max 65535)",
+                "JSON": "SUPER (preferred for semi-structured data)",
+                "JSONB": "SUPER",
+                "HUGEINT": "NUMERIC(38,0)",
+                "LARGEINT": "NUMERIC(38,0)",
+                "BOOLEAN": "BOOLEAN",
+                "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
+            },
+            "example_ddl": (
+                "CREATE TABLE public.t (\n"
+                "  id BIGINT IDENTITY(1,1),\n"
+                "  event_date DATE,\n"
+                "  amount NUMERIC(18,2)\n"
+                ")\n"
+                "DISTKEY(id)\n"
+                "SORTKEY(event_date)"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Suggest DISTKEY (high-cardinality key) + SORTKEY (date/time columns)."""
+        if not columns:
+            return {}
+        import re as _re
+
+        _INT_TYPES = {"INT", "INTEGER", "BIGINT", "SMALLINT", "INT2", "INT4", "INT8"}
+
+        # DISTKEY preference: *_id integer columns → any INT column → first column (preserve input order)
+        distkey = None
+        scored = []
+        for idx, col in enumerate(columns):
+            name = col["name"]
+            col_type = str(col.get("type", "")).upper()
+            base_type = _re.sub(r"\(.*\)", "", col_type).strip()
+            score = 0
+            if name.lower() == "id" or name.lower().endswith("_id"):
+                score += 100
+            if base_type in _INT_TYPES:
+                score += 50
+            scored.append((score, idx, name))
+        # Sort by score desc, then by input order (stable fallback to first column when all scored 0)
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        distkey = scored[0][2] if scored else columns[0]["name"]
+
+        # SORTKEY preference: date/time columns
+        sortkey: List[str] = []
+        for col in columns:
+            base_type = _re.sub(r"\(.*\)", "", str(col.get("type", "")).upper()).strip()
+            if base_type in ("DATE", "DATETIME", "TIMESTAMP", "TIMESTAMPTZ", "TIME"):
+                sortkey.append(col["name"])
+
+        layout: Dict[str, Any] = {"distkey": distkey}
+        if sortkey:
+            layout["sortkey"] = sortkey[:2]  # Redshift compound sortkey max is reasonable to keep small
+        return layout
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; Redshift uses DISTKEY/SORTKEY")
+        if "BUCKETS" in upper and "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY ... BUCKETS is StarRocks syntax; Redshift uses DISTKEY")
+        if "ENGINE =" in upper or "ENGINE=" in upper:
+            errors.append("ENGINE clause is MySQL/ClickHouse syntax; not supported by Redshift")
+        if "SERIAL" in upper:
+            # Check as a word-boundary match to avoid false positives on column names
+            import re as _re
+
+            if _re.search(r"\bSERIAL\b", upper):
+                errors.append("Redshift does not support SERIAL; use IDENTITY(1,1) instead")
+        if "VARCHAR(MAX)" in upper.replace(" ", ""):
+            errors.append("Redshift does not support VARCHAR(MAX); use VARCHAR(<explicit length up to 65535>)")
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "NUMERIC(38,0)",
+            "LARGEINT": "NUMERIC(38,0)",
+            "JSON": "SUPER",
+            "JSONB": "SUPER",
+            "VARIANT": "SUPER",
+            "DATETIME": "TIMESTAMP",
+        }
+        return overrides.get(base)

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -1494,12 +1494,12 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             errors.append("DISTRIBUTED BY ... BUCKETS is StarRocks syntax; Redshift uses DISTKEY")
         if "ENGINE =" in upper or "ENGINE=" in upper:
             errors.append("ENGINE clause is MySQL/ClickHouse syntax; not supported by Redshift")
-        if "SERIAL" in upper:
-            # Check as a word-boundary match to avoid false positives on column names
-            import re as _re
+        import re as _re
 
-            if _re.search(r"\bSERIAL\b", upper):
-                errors.append("Redshift does not support SERIAL; use IDENTITY(1,1) instead")
+        # Word-boundary match covers SERIAL, BIGSERIAL, SMALLSERIAL while avoiding
+        # false positives on column names like SERIAL_NUMBER.
+        if _re.search(r"\b(?:BIG|SMALL)?SERIAL\b", upper):
+            errors.append("Redshift does not support SERIAL/BIGSERIAL/SMALLSERIAL; use IDENTITY(1,1) instead")
         if "VARCHAR(MAX)" in upper.replace(" ", ""):
             errors.append("Redshift does not support VARCHAR(MAX); use VARCHAR(<explicit length up to 65535>)")
         return errors

--- a/datus-redshift/tests/unit/test_migration_mixin.py
+++ b/datus-redshift/tests/unit/test_migration_mixin.py
@@ -24,7 +24,7 @@ class TestDescribeMigrationCapabilities:
     def test_supported_true(self, connector):
         assert connector.describe_migration_capabilities()["supported"] is True
 
-    def test_dialect_family_postgres_like(self, connector):
+    def test_dialect_family_redshift(self, connector):
         assert connector.describe_migration_capabilities()["dialect_family"] == "redshift"
 
     def test_type_hints_mention_distkey_sortkey(self, connector):

--- a/datus-redshift/tests/unit/test_migration_mixin.py
+++ b/datus-redshift/tests/unit/test_migration_mixin.py
@@ -1,0 +1,111 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for Redshift MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_redshift import RedshiftConnector
+
+
+@pytest.fixture
+def connector():
+    return RedshiftConnector.__new__(RedshiftConnector)
+
+
+class TestMixinInheritance:
+    def test_redshift_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        assert connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_postgres_like(self, connector):
+        assert connector.describe_migration_capabilities()["dialect_family"] == "redshift"
+
+    def test_type_hints_mention_distkey_sortkey(self, connector):
+        hints = connector.describe_migration_capabilities()["type_hints"]
+        hints_str = " ".join(hints.values()).upper()
+        assert "DISTKEY" in hints_str or "SORTKEY" in hints_str
+
+    def test_forbids_varchar_max(self, connector):
+        """Redshift does not support VARCHAR(max); length must be explicit."""
+        result = connector.describe_migration_capabilities()
+        forbids_str = " ".join(result["forbids"]).upper()
+        assert "VARCHAR(MAX)" in forbids_str or "VARCHAR MAX" in forbids_str
+
+    def test_example_ddl_references_distkey(self, connector):
+        ddl = connector.describe_migration_capabilities()["example_ddl"].upper()
+        assert "DISTKEY" in ddl
+
+
+class TestValidateDdl:
+    def test_accepts_standard_redshift_ddl(self, connector):
+        ddl = """CREATE TABLE public.t (
+          id BIGINT IDENTITY(1,1),
+          dt DATE
+        ) DISTKEY(id) SORTKEY(dt)"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_serial(self, connector):
+        """Redshift uses IDENTITY instead of SERIAL."""
+        ddl = "CREATE TABLE public.t (id SERIAL PRIMARY KEY, name VARCHAR(255))"
+        errors = connector.validate_ddl(ddl)
+        assert any("SERIAL" in e.upper() or "IDENTITY" in e.upper() for e in errors)
+
+    def test_rejects_varchar_max(self, connector):
+        ddl = "CREATE TABLE public.t (id BIGINT, name VARCHAR(MAX))"
+        errors = connector.validate_ddl(ddl)
+        assert any("VARCHAR" in e.upper() and "MAX" in e.upper() for e in errors)
+
+    def test_rejects_starrocks_distributed_by(self, connector):
+        ddl = "CREATE TABLE t (id BIGINT) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10"
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+    def test_rejects_engine_clickhouse(self, connector):
+        ddl = "CREATE TABLE t (id BIGINT) ENGINE = MergeTree() ORDER BY id"
+        errors = connector.validate_ddl(ddl)
+        assert any("ENGINE" in e.upper() or "CLICKHOUSE" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_suggests_distkey_id_and_sortkey_date(self, connector):
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "event_date", "type": "DATE", "nullable": False},
+            {"name": "amount", "type": "DECIMAL(10,2)", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["distkey"] == "id"
+        assert "event_date" in layout.get("sortkey", [])
+
+    def test_distkey_falls_back_to_first_column(self, connector):
+        columns = [
+            {"name": "region", "type": "VARCHAR", "nullable": False},
+            {"name": "city", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["distkey"] == "region"
+
+    def test_empty_columns_returns_dict(self, connector):
+        assert isinstance(connector.suggest_table_layout([]), dict)
+
+
+class TestMapSourceType:
+    def test_hugeint_to_numeric(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "NUMERIC(38,0)"
+
+    def test_json_to_super(self, connector):
+        """Redshift has SUPER for semi-structured data."""
+        assert connector.map_source_type("postgresql", "JSON") == "SUPER"
+
+    def test_jsonb_to_super(self, connector):
+        assert connector.map_source_type("postgresql", "JSONB") == "SUPER"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -30,6 +30,7 @@ from datus_db_core import (
     ErrorCode,
     ExecuteSQLResult,
     MaterializedViewSupportMixin,
+    MigrationTargetMixin,
     SchemaNamespaceMixin,
     get_logger,
     list_to_in_str,
@@ -88,7 +89,7 @@ def _handle_snowflake_exception(e: Exception, sql: str = "") -> DatusDbException
         return DatusDbException(ErrorCode.DB_FAILED, message_args={"error_message": str(e)})
 
 
-class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedViewSupportMixin):
+class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedViewSupportMixin, MigrationTargetMixin):
     """
     Connector for Snowflake databases using native Snowflake SDK.
 
@@ -962,3 +963,82 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         else:
             full_name = f'"{table_name}"'
         return full_name if not database_name else f'"{database_name}".{full_name}'
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "snowflake",
+            "requires": [],  # Snowflake handles partitioning transparently (micro-partitions)
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH ... BUCKETS (StarRocks-only)",
+                "ENGINE = MergeTree (ClickHouse-only)",
+            ],
+            "type_hints": {
+                "unbounded VARCHAR": "VARCHAR (up to 16MB; length often omitted)",
+                "TEXT": "VARCHAR or TEXT (aliases)",
+                "JSON": "VARIANT (preferred for semi-structured data)",
+                "JSONB": "VARIANT",
+                "MAP": "OBJECT",
+                "ARRAY": "ARRAY",
+                "HUGEINT": "NUMBER(38,0)",
+                "LARGEINT": "NUMBER(38,0)",
+                "DECIMAL(p,s)": "NUMBER(p,s)",
+                "TIMESTAMP WITH TIME ZONE": "TIMESTAMP_TZ",
+                "TIMESTAMP": "TIMESTAMP_NTZ",
+                "BOOLEAN": "BOOLEAN",
+                "UUID": "VARCHAR(36)",
+                "clustering": "Optional WITH CLUSTER BY (<cols>) for large tables queried by date/tenant",
+            },
+            "example_ddl": (
+                "CREATE TABLE db.schema.t (\n"
+                "  id NUMBER(38,0),\n"
+                "  event_date DATE,\n"
+                "  payload VARIANT,\n"
+                "  created_at TIMESTAMP_NTZ\n"
+                ")\n"
+                "CLUSTER BY (event_date)"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Suggest optional CLUSTER BY on date/timestamp columns for larger tables."""
+        if not columns:
+            return {}
+        import re as _re
+
+        for col in columns:
+            base_type = _re.sub(r"\(.*\)", "", str(col.get("type", "")).upper()).strip()
+            if base_type in ("DATE", "DATETIME", "TIMESTAMP", "TIMESTAMP_NTZ", "TIMESTAMP_TZ", "TIMESTAMP_LTZ"):
+                return {"cluster_by": [col["name"]]}
+        # No date column — defer to LLM / user judgment
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; Snowflake uses CLUSTER BY")
+        if "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY is StarRocks/Greenplum syntax; Snowflake uses CLUSTER BY")
+        if "ENGINE =" in upper or "ENGINE=" in upper:
+            errors.append("ENGINE clause is MySQL/ClickHouse syntax; not supported by Snowflake")
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "NUMBER(38,0)",
+            "LARGEINT": "NUMBER(38,0)",
+            "JSON": "VARIANT",
+            "JSONB": "VARIANT",
+            "MAP": "OBJECT",
+            "STRUCT": "OBJECT",
+            "DATETIME": "TIMESTAMP_NTZ",
+            "TIMESTAMPTZ": "TIMESTAMP_TZ",
+        }
+        return overrides.get(base)

--- a/datus-snowflake/tests/test_migration_mixin.py
+++ b/datus-snowflake/tests/test_migration_mixin.py
@@ -1,0 +1,92 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for Snowflake MigrationTargetMixin implementation."""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_snowflake import SnowflakeConnector
+
+
+@pytest.fixture
+def connector():
+    return SnowflakeConnector.__new__(SnowflakeConnector)
+
+
+class TestMixinInheritance:
+    def test_snowflake_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        assert connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_snowflake(self, connector):
+        assert connector.describe_migration_capabilities()["dialect_family"] == "snowflake"
+
+    def test_no_hard_distribution_required(self, connector):
+        """Snowflake handles partitioning transparently (micro-partitions)."""
+        assert connector.describe_migration_capabilities()["requires"] == []
+
+    def test_type_hints_mention_variant(self, connector):
+        hints = connector.describe_migration_capabilities()["type_hints"]
+        hints_str = " ".join(hints.values())
+        assert "VARIANT" in hints_str.upper() or "variant" in hints_str
+
+    def test_example_ddl_has_create_table(self, connector):
+        ddl = connector.describe_migration_capabilities()["example_ddl"].upper()
+        assert "CREATE" in ddl and "TABLE" in ddl
+
+
+class TestValidateDdl:
+    def test_accepts_standard_snowflake_ddl(self, connector):
+        ddl = "CREATE TABLE db.schema.t (id NUMBER(38,0), name VARCHAR(16777216))"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_cluster_by(self, connector):
+        ddl = "CREATE TABLE db.schema.t (id NUMBER, dt DATE) CLUSTER BY (dt)"
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_starrocks_distributed_by(self, connector):
+        ddl = "CREATE TABLE t (id BIGINT) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10"
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "DISTRIBUTED BY" in e.upper() for e in errors)
+
+    def test_rejects_clickhouse_engine_merge_tree(self, connector):
+        ddl = "CREATE TABLE t (id BIGINT) ENGINE = MergeTree() ORDER BY id"
+        errors = connector.validate_ddl(ddl)
+        assert any("ENGINE" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayout:
+    def test_returns_optional_cluster_by_hint(self, connector):
+        """Snowflake CLUSTER BY is optional — prefer date/time columns when present."""
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "event_date", "type": "DATE", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        # Layout may be empty (defer to LLM) OR suggest cluster_by on date column
+        assert isinstance(layout, dict)
+        if layout:
+            assert "cluster_by" in layout
+
+    def test_empty_columns_returns_dict(self, connector):
+        assert isinstance(connector.suggest_table_layout([]), dict)
+
+
+class TestMapSourceType:
+    def test_hugeint_to_number(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "NUMBER(38,0)"
+
+    def test_json_to_variant(self, connector):
+        assert connector.map_source_type("postgresql", "JSON") == "VARIANT"
+
+    def test_jsonb_to_variant(self, connector):
+        assert connector.map_source_type("postgresql", "JSONB") == "VARIANT"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -156,9 +156,10 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
     def close(self):
         """Dispose the engine and its connection pool."""
         try:
-            if self.engine:
-                self.engine.dispose()
-                self.engine = None
+            engine = getattr(self, "engine", None)
+            if engine:
+                engine.dispose()
+            self.engine = None
             self._owns_engine = False
         except Exception as e:
             logger.warning(f"Error disposing engine: {str(e)}")

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -31,6 +31,7 @@ from datus_db_core import (
     DatusDbException,
     ErrorCode,
     ExecuteSQLResult,
+    MigrationTargetMixin,
     SQLType,
     get_logger,
     parse_context_switch,
@@ -40,7 +41,7 @@ from datus_db_core import (
 logger = get_logger(__name__)
 
 
-class SQLAlchemyConnector(BaseSqlConnector):
+class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
     """
     Base SQLAlchemy connector for database adapters.
 
@@ -734,3 +735,49 @@ class SQLAlchemyConnector(BaseSqlConnector):
                     yield from []
         except Exception as e:
             raise self._handle_exception(e) from e
+
+    # ==================== MigrationTargetMixin (generic fallback) ====================
+    #
+    # Conservative OLTP-style defaults. SQLAlchemy-backed adapters that have
+    # specific dialect needs (MySQL/Postgres/ClickHouse/Snowflake/Redshift/...)
+    # should override these methods; their overrides take precedence.
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "sqlalchemy-generic",
+            "requires": [],
+            "forbids": [
+                "DUPLICATE KEY (StarRocks-only)",
+                "DISTRIBUTED BY HASH ... BUCKETS (StarRocks-only)",
+            ],
+            "type_hints": {
+                "unbounded VARCHAR": "VARCHAR with explicit length; many engines reject unbounded VARCHAR",
+                "HUGEINT": "DECIMAL(38,0)",
+                "LARGEINT": "DECIMAL(38,0)",
+            },
+            "example_ddl": "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR(255))",
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # Generic fallback: no distribution / partition hints. LLM decides.
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+        if "DUPLICATE KEY" in upper and "ON DUPLICATE KEY" not in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; not supported by generic SQLAlchemy target")
+        if "BUCKETS" in upper and "DISTRIBUTED BY" in upper:
+            errors.append("DISTRIBUTED BY ... BUCKETS is StarRocks syntax; not supported by generic SQLAlchemy target")
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "DECIMAL(38,0)",
+            "LARGEINT": "DECIMAL(38,0)",
+        }
+        return overrides.get(base)

--- a/datus-sqlalchemy/tests/unit/test_migration_mixin.py
+++ b/datus-sqlalchemy/tests/unit/test_migration_mixin.py
@@ -1,0 +1,123 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for the generic SQLAlchemy MigrationTargetMixin fallback.
+
+This Mixin provides a conservative OLTP-style default. Adapters that inherit
+from SQLAlchemyConnector (MySQL / Postgres / ClickHouse / ...) may override
+any of the Mixin methods to encode their own dialect's contract — their
+overrides take precedence over this generic baseline.
+"""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_sqlalchemy import SQLAlchemyConnector
+
+
+class _ConcreteSQLA(SQLAlchemyConnector):
+    """Minimal concrete subclass so we can exercise SQLAlchemyConnector's
+    Mixin methods. ``SQLAlchemyConnector`` itself is abstract because it
+    inherits several @abstractmethod declarations from ``BaseSqlConnector``
+    (``get_databases``, ``get_tables``, etc). These stubs are never called
+    by the Mixin methods under test."""
+
+    def get_databases(self, *args, **kwargs):
+        return []
+
+    def get_tables(self, *args, **kwargs):
+        return []
+
+    def execute_insert(self, sql):
+        raise NotImplementedError
+
+    def execute_update(self, sql):
+        raise NotImplementedError
+
+    def execute_delete(self, sql):
+        raise NotImplementedError
+
+    def execute_query(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def execute_pandas(self, sql):
+        raise NotImplementedError
+
+    def execute_ddl(self, sql):
+        raise NotImplementedError
+
+    def execute_csv(self, sql):
+        raise NotImplementedError
+
+    def test_connection(self):
+        return True
+
+    def execute_queries(self, queries):
+        return []
+
+    def execute_content_set(self, sql):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def connector():
+    return _ConcreteSQLA.__new__(_ConcreteSQLA)
+
+
+class TestMixinInheritance:
+    def test_sqlalchemy_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_supported_true(self, connector):
+        assert connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_generic_sqlalchemy(self, connector):
+        assert connector.describe_migration_capabilities()["dialect_family"] == "sqlalchemy-generic"
+
+    def test_no_hard_requirements(self, connector):
+        assert connector.describe_migration_capabilities()["requires"] == []
+
+    def test_example_ddl_is_minimal_create_table(self, connector):
+        ddl = connector.describe_migration_capabilities()["example_ddl"].upper()
+        assert "CREATE TABLE" in ddl
+
+
+class TestSuggestTableLayout:
+    def test_returns_empty_dict_by_default(self, connector):
+        """Generic SQLAlchemy fallback defers layout decisions to the LLM."""
+        columns = [{"name": "id", "type": "BIGINT", "nullable": False}]
+        assert connector.suggest_table_layout(columns) == {}
+
+
+class TestValidateDdl:
+    def test_accepts_plain_ddl(self, connector):
+        assert connector.validate_ddl("CREATE TABLE t (id BIGINT)") == []
+
+    def test_flags_starrocks_specific_syntax(self, connector):
+        ddl = "CREATE TABLE t (id BIGINT) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10"
+        errors = connector.validate_ddl(ddl)
+        assert any(
+            "DUPLICATE KEY" in e.upper() or "DISTRIBUTED BY" in e.upper() or "STARROCKS" in e.upper() for e in errors
+        )
+
+
+class TestInheritedOverridesWin:
+    """Adapters that override Mixin methods must take precedence over this generic base."""
+
+    def test_mysql_override_wins(self):
+        from datus_mysql import MySQLConnector
+
+        mysql = MySQLConnector.__new__(MySQLConnector)
+        result = mysql.describe_migration_capabilities()
+        # MySQL's own override sets dialect_family="mysql-like"
+        assert result["dialect_family"] == "mysql-like"
+
+    def test_postgres_override_wins(self):
+        from datus_postgresql import PostgreSQLConnector
+
+        pg = PostgreSQLConnector.__new__(PostgreSQLConnector)
+        result = pg.describe_migration_capabilities()
+        assert result["dialect_family"] == "postgres-like"

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -534,7 +534,8 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         errors: List[str] = []
         upper = ddl.upper()
 
-        if not any(k in upper for k in ("DUPLICATE KEY", "PRIMARY KEY", "UNIQUE KEY", "AGGREGATE KEY")):
+        has_duplicate_key = "DUPLICATE KEY" in upper and "ON DUPLICATE KEY" not in upper
+        if not (has_duplicate_key or any(k in upper for k in ("PRIMARY KEY", "UNIQUE KEY", "AGGREGATE KEY"))):
             errors.append("StarRocks DDL must define one of: DUPLICATE KEY / PRIMARY KEY / UNIQUE KEY / AGGREGATE KEY")
 
         if "DISTRIBUTED BY" not in upper:
@@ -560,8 +561,11 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         # Deterministic overrides for well-known pairings
         overrides = {
             "HUGEINT": "LARGEINT",
+            "TIMESTAMP": "DATETIME",
             "TIMESTAMPTZ": "DATETIME",
             "TIMESTAMP WITH TIME ZONE": "DATETIME",
             "TEXT": "STRING",
+            "TIME": "VARCHAR(20)",
+            "UUID": "VARCHAR(36)",
         }
         return overrides.get(base_noparam)

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -480,9 +480,10 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
                 "CREATE TABLE db.t (\n"
                 "  id BIGINT NOT NULL,\n"
                 "  name VARCHAR(255)\n"
-                ")\n"
+                ") ENGINE=OLAP\n"
                 "DUPLICATE KEY(id)\n"
-                "DISTRIBUTED BY HASH(id) BUCKETS 10"
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n"
+                'PROPERTIES ("replication_num" = "1")'
             ),
         }
 

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -11,6 +11,7 @@ from datus_db_core import (
     CatalogSupportMixin,
     ExecuteSQLResult,
     MaterializedViewSupportMixin,
+    MigrationTargetMixin,
     get_logger,
     list_to_in_str,
     parse_context_switch,
@@ -21,8 +22,10 @@ from .config import StarRocksConfig
 
 logger = get_logger(__name__)
 
+_INTEGER_TYPES = frozenset({"INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "INT2", "INT4", "INT8", "LARGEINT"})
 
-class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSupportMixin):
+
+class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSupportMixin, MigrationTargetMixin):
     """
     StarRocks database connector.
 
@@ -452,3 +455,112 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
                 self.close()
             except Exception as e:
                 logger.debug(f"Ignoring cleanup error during test: {e}")
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "mysql-like",
+            "requires": [
+                "One of DUPLICATE KEY / PRIMARY KEY / UNIQUE KEY / AGGREGATE KEY",
+                "DISTRIBUTED BY HASH(cols) BUCKETS N",
+            ],
+            "forbids": ["AUTO_INCREMENT", "FOREIGN KEY", "FULLTEXT INDEX", "CHECK"],
+            "type_hints": {
+                "unbounded VARCHAR": "VARCHAR(65533)",
+                "TEXT": "STRING",
+                "TIMESTAMP": "DATETIME",
+                "TIMESTAMPTZ": "DATETIME",
+                "TIME": "VARCHAR(20) (StarRocks has no native TIME)",
+                "UUID": "VARCHAR(36)",
+                "HUGEINT": "LARGEINT",
+            },
+            "example_ddl": (
+                "CREATE TABLE db.t (\n"
+                "  id BIGINT NOT NULL,\n"
+                "  name VARCHAR(255)\n"
+                ")\n"
+                "DUPLICATE KEY(id)\n"
+                "DISTRIBUTED BY HASH(id) BUCKETS 10"
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not columns:
+            return {"duplicate_key": [], "distributed_by": [], "buckets": 10}
+
+        keys = self._score_keys(columns, max_keys=3)
+        return {"duplicate_key": keys, "distributed_by": keys, "buckets": 10}
+
+    @staticmethod
+    def _score_keys(columns: List[Dict[str, Any]], max_keys: int = 3) -> List[str]:
+        """Select key columns using priority rules.
+
+        Priority:
+          1. Columns with 'id' or '_id' suffix (+100)
+          2. INT/BIGINT type columns (+50)
+          3. Non-nullable columns preferred (+10)
+          4. Fallback to first column
+        """
+        import re as _re
+
+        scored = []
+        for col in columns:
+            name = col["name"]
+            col_type = str(col.get("type", "")).upper()
+            base_type = _re.sub(r"\(.*\)", "", col_type).strip()
+            nullable = col.get("nullable", True)
+
+            score = 0
+            if name.lower() == "id" or name.lower().endswith("_id"):
+                score += 100
+            if base_type in _INTEGER_TYPES:
+                score += 50
+            if not nullable:
+                score += 10
+
+            scored.append((score, name))
+
+        scored.sort(key=lambda x: (-x[0], x[1]))
+
+        if scored[0][0] == 0:
+            return [columns[0]["name"]]
+
+        return [name for score, name in scored[:max_keys] if score > 0] or [columns[0]["name"]]
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if not any(k in upper for k in ("DUPLICATE KEY", "PRIMARY KEY", "UNIQUE KEY", "AGGREGATE KEY")):
+            errors.append("StarRocks DDL must define one of: DUPLICATE KEY / PRIMARY KEY / UNIQUE KEY / AGGREGATE KEY")
+
+        if "DISTRIBUTED BY" not in upper:
+            errors.append("StarRocks DDL must include a DISTRIBUTED BY clause")
+
+        if "AUTO_INCREMENT" in upper:
+            errors.append("StarRocks does not support AUTO_INCREMENT")
+
+        if "FOREIGN KEY" in upper:
+            errors.append("StarRocks does not support FOREIGN KEY")
+
+        if "FULLTEXT" in upper:
+            errors.append("StarRocks does not support FULLTEXT indexes")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> str | None:
+        base = source_type.strip().upper()
+        # Strip params for matching
+        import re as _re
+
+        base_noparam = _re.sub(r"\(.*\)", "", base).strip()
+        # Deterministic overrides for well-known pairings
+        overrides = {
+            "HUGEINT": "LARGEINT",
+            "TIMESTAMPTZ": "DATETIME",
+            "TIMESTAMP WITH TIME ZONE": "DATETIME",
+            "TEXT": "STRING",
+        }
+        return overrides.get(base_noparam)

--- a/datus-starrocks/tests/unit/test_migration_mixin.py
+++ b/datus-starrocks/tests/unit/test_migration_mixin.py
@@ -1,0 +1,171 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for StarRocks MigrationTargetMixin implementation.
+
+Tests focus on the pure migration-hint/validation logic that does not require
+an active StarRocks connection. Uses StarRocksConnector.__new__ to bypass the
+constructor (which connects to a real server) — the Mixin methods are all
+self-contained state-free static logic.
+"""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_starrocks import StarRocksConnector
+
+
+@pytest.fixture
+def connector():
+    """Return a StarRocksConnector instance without invoking the constructor."""
+    return StarRocksConnector.__new__(StarRocksConnector)
+
+
+class TestMixinInheritance:
+    def test_starrocks_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_returns_supported_dict(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert isinstance(result, dict)
+        assert result["supported"] is True
+
+    def test_dialect_family_is_mysql_like(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["dialect_family"] == "mysql-like"
+
+    def test_requires_key_and_distribution(self, connector):
+        result = connector.describe_migration_capabilities()
+        requires_str = " ".join(result["requires"]).upper()
+        assert "DUPLICATE KEY" in requires_str or "PRIMARY KEY" in requires_str
+        assert "DISTRIBUTED BY" in requires_str
+
+    def test_forbids_auto_increment(self, connector):
+        result = connector.describe_migration_capabilities()
+        forbids_str = " ".join(result["forbids"]).upper()
+        assert "AUTO_INCREMENT" in forbids_str
+
+    def test_type_hints_have_varchar_max(self, connector):
+        result = connector.describe_migration_capabilities()
+        hints_str = " ".join(result["type_hints"].values())
+        assert "65533" in hints_str
+
+    def test_example_ddl_is_complete(self, connector):
+        result = connector.describe_migration_capabilities()
+        ddl = result["example_ddl"].upper()
+        assert "CREATE TABLE" in ddl
+        assert "DUPLICATE KEY" in ddl or "PRIMARY KEY" in ddl
+        assert "DISTRIBUTED BY HASH" in ddl
+
+
+class TestValidateDdl:
+    def test_rejects_missing_key_definition(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert len(errors) > 0
+        assert any("KEY" in e.upper() for e in errors)
+
+    def test_rejects_missing_distributed_by(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)"""
+        errors = connector.validate_ddl(ddl)
+        assert len(errors) > 0
+        assert any("DISTRIBUTED BY" in e.upper() for e in errors)
+
+    def test_rejects_auto_increment(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT AUTO_INCREMENT,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("AUTO_INCREMENT" in e.upper() for e in errors)
+
+    def test_accepts_valid_ddl(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_primary_key_variant(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        PRIMARY KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_aggregate_key(self, connector):
+        ddl = """CREATE TABLE db.t (
+          dt DATE NOT NULL,
+          region VARCHAR(50),
+          total_amount DECIMAL(18,2) SUM
+        )
+        AGGREGATE KEY(dt, region)
+        DISTRIBUTED BY HASH(region) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+
+class TestSuggestTableLayout:
+    def test_picks_id_column_first(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["duplicate_key"] == ["id"]
+        assert layout["distributed_by"] == ["id"]
+        assert layout["buckets"] == 10
+
+    def test_picks_suffix_id_columns(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "order_id", "type": "BIGINT", "nullable": False},
+            {"name": "user_id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        keys = layout["duplicate_key"]
+        assert "order_id" in keys
+        assert "user_id" in keys
+
+    def test_max_three_keys(self, connector):
+        columns = [{"name": f"col{i}_id", "type": "BIGINT", "nullable": False} for i in range(10)]
+        layout = connector.suggest_table_layout(columns)
+        assert len(layout["duplicate_key"]) <= 3
+
+    def test_falls_back_to_first_column_when_no_integer(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "label", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["duplicate_key"] == ["name"]
+
+    def test_empty_columns_returns_dict_with_empty_keys_or_empty(self, connector):
+        layout = connector.suggest_table_layout([])
+        # Either returns empty dict, or dict with empty key lists — both acceptable
+        assert isinstance(layout, dict)
+
+    def test_prefers_non_nullable_over_nullable(self, connector):
+        columns = [
+            {"name": "a_id", "type": "BIGINT", "nullable": True},
+            {"name": "b_id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        # Both have _id suffix and INT type; non-nullable should rank first
+        assert layout["duplicate_key"][0] == "b_id"

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -382,7 +382,14 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
             )
             rows = getattr(result, "sql_return", None) or []
             if rows and isinstance(rows, list) and rows[0]:
-                connector_name = str(rows[0][0] if isinstance(rows[0], (list, tuple)) else rows[0]).lower()
+                first = rows[0]
+                if isinstance(first, dict):
+                    raw = first.get("connector_name", "")
+                elif isinstance(first, (list, tuple)):
+                    raw = first[0] if first else ""
+                else:
+                    raw = first
+                connector_name = str(raw).lower()
                 if "iceberg" in connector_name:
                     return "iceberg"
                 if "delta" in connector_name:

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -7,7 +7,7 @@ from urllib.parse import quote_plus
 
 from sqlalchemy import create_engine
 
-from datus_db_core import CatalogSupportMixin, get_logger
+from datus_db_core import CatalogSupportMixin, MigrationTargetMixin, get_logger
 from datus_sqlalchemy import SQLAlchemyConnector
 
 from .config import TrinoConfig
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 TRINO_DIALECT = "trino"
 
 
-class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
+class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMixin):
     """
     Trino database connector.
 
@@ -361,3 +361,165 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin):
                 self.close()
             except Exception as e:
                 logger.debug(f"Ignoring cleanup error during test: {e}")
+
+    # ==================== MigrationTargetMixin ====================
+
+    def _detect_catalog_type(self) -> str:
+        """Detect the current catalog's underlying connector type.
+
+        Returns one of: ``"hive"``, ``"iceberg"``, ``"delta"``, ``"jdbc"``,
+        ``"unknown"``. Queries ``system.metadata.catalogs`` when possible.
+        Callers may override (or tests monkeypatch) to provide a known type.
+        """
+        catalog = getattr(self, "catalog_name", "") or ""
+        if not catalog:
+            return "unknown"
+        try:
+            # system.metadata.catalogs lists catalog_name and connector_name
+            result = self.execute_query(
+                f"SELECT connector_name FROM system.metadata.catalogs WHERE catalog_name = '{catalog}'",
+                result_format="list",
+            )
+            rows = getattr(result, "sql_return", None) or []
+            if rows and isinstance(rows, list) and rows[0]:
+                connector_name = str(rows[0][0] if isinstance(rows[0], (list, tuple)) else rows[0]).lower()
+                if "iceberg" in connector_name:
+                    return "iceberg"
+                if "delta" in connector_name:
+                    return "delta"
+                if "hive" in connector_name:
+                    return "hive"
+                if any(k in connector_name for k in ("mysql", "postgres", "oracle", "sqlserver", "jdbc")):
+                    return "jdbc"
+        except Exception as e:
+            logger.debug(f"_detect_catalog_type probe failed: {e}")
+        return "unknown"
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        try:
+            catalog_type = self._detect_catalog_type()
+        except Exception as e:
+            logger.debug(f"_detect_catalog_type raised; falling back to generic: {e}")
+            catalog_type = "unknown"
+
+        if catalog_type == "hive":
+            return {
+                "supported": True,
+                "dialect_family": "trino-hive",
+                "requires": [],
+                "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+                "type_hints": {
+                    "format": "Add WITH (format = 'PARQUET') for efficient storage",
+                    "partitioned_by": "Use WITH (partitioned_by = ARRAY['col']) for partitioning",
+                    "bucketed_by": "Use WITH (bucketed_by = ARRAY['col'], bucket_count = N) for bucketing",
+                },
+                "example_ddl": (
+                    "CREATE TABLE catalog.schema.t (\n"
+                    "  id BIGINT,\n"
+                    "  ds VARCHAR\n"
+                    ") WITH (format = 'PARQUET', partitioned_by = ARRAY['ds'])"
+                ),
+            }
+        if catalog_type == "iceberg":
+            return {
+                "supported": True,
+                "dialect_family": "trino-iceberg",
+                "requires": [],
+                "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+                "type_hints": {
+                    "partitioning": "Use WITH (partitioning = ARRAY['month(ds)', 'bucket(id, 4)'])",
+                    "format": "Default format is PARQUET; ORC also supported",
+                    "location": "Optional WITH (location = 's3://...') for custom table location",
+                },
+                "example_ddl": (
+                    "CREATE TABLE catalog.schema.t (\n"
+                    "  id BIGINT,\n"
+                    "  ds DATE\n"
+                    ") WITH (partitioning = ARRAY['month(ds)'])"
+                ),
+            }
+        if catalog_type == "delta":
+            return {
+                "supported": True,
+                "dialect_family": "trino-delta",
+                "requires": [],
+                "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+                "type_hints": {
+                    "partitioned_by": "Use WITH (partitioned_by = ARRAY['col']) for partitioning",
+                    "location": "Optional WITH (location = 's3://...') for custom table location",
+                },
+                "example_ddl": (
+                    "CREATE TABLE catalog.schema.t (\n  id BIGINT,\n  ds DATE\n) WITH (partitioned_by = ARRAY['ds'])"
+                ),
+            }
+        if catalog_type == "jdbc":
+            return {
+                "supported": True,
+                "dialect_family": "trino-jdbc",
+                "requires": [],
+                "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+                "type_hints": {
+                    "note": "Trino JDBC catalogs pass DDL through to the underlying engine; "
+                    "check that engine's own requirements",
+                },
+                "example_ddl": ("CREATE TABLE catalog.schema.t (\n  id BIGINT,\n  name VARCHAR\n)"),
+            }
+        # unknown / generic
+        return {
+            "supported": True,
+            "dialect_family": "trino-generic",
+            "requires": [],
+            "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+            "type_hints": {},
+            "note": f"Catalog connector unknown ({getattr(self, 'catalog_name', '') or 'unset'}); "
+            "DDL requirements depend on underlying engine",
+            "example_ddl": "CREATE TABLE catalog.schema.t (\n  id BIGINT,\n  name VARCHAR\n)",
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not columns:
+            return {}
+        try:
+            catalog_type = self._detect_catalog_type()
+        except Exception:
+            catalog_type = "unknown"
+
+        if catalog_type == "hive":
+            # Suggest partitioned_by only when a conventional partition column exists
+            partition_cols = [c["name"] for c in columns if c["name"].lower() in ("ds", "dt", "partition_date")]
+            layout: Dict[str, Any] = {"format": "PARQUET"}
+            if partition_cols:
+                layout["partitioned_by"] = partition_cols[:1]
+            return layout
+        if catalog_type == "iceberg":
+            partition_cols = [c["name"] for c in columns if c["name"].lower() in ("ds", "dt", "partition_date")]
+            if partition_cols:
+                return {"partitioning": [f"month({partition_cols[0]})"]}
+            return {}
+        return {}
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        if "DUPLICATE KEY" in upper:
+            errors.append("DUPLICATE KEY is StarRocks-only syntax; Trino catalogs do not support it")
+        if "BUCKETS" in upper and "DISTRIBUTED BY" in upper:
+            errors.append(
+                "DISTRIBUTED BY ... BUCKETS is StarRocks syntax; Trino uses WITH (bucketed_by = ARRAY[...]) for Hive"
+            )
+        if "ENGINE =" in upper or "ENGINE=" in upper:
+            errors.append("ENGINE clause is MySQL/ClickHouse syntax; Trino uses WITH (...) table properties")
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:
+        import re as _re
+
+        base = _re.sub(r"\(.*\)", "", source_type.strip().upper()).strip()
+        overrides = {
+            "HUGEINT": "DECIMAL(38,0)",
+            "LARGEINT": "DECIMAL(38,0)",
+            "STRING": "VARCHAR",
+            "TEXT": "VARCHAR",
+        }
+        return overrides.get(base)

--- a/datus-trino/tests/unit/test_migration_mixin.py
+++ b/datus-trino/tests/unit/test_migration_mixin.py
@@ -1,0 +1,152 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for Trino MigrationTargetMixin implementation.
+
+Trino is a federated query engine; its migration capabilities depend on the
+underlying catalog's connector type (hive / iceberg / delta / jdbc).
+Tests inject the catalog type by monkeypatching ``_detect_catalog_type`` —
+no real connection required.
+"""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_trino import TrinoConnector
+
+
+@pytest.fixture
+def connector():
+    return TrinoConnector.__new__(TrinoConnector)
+
+
+class TestMixinInheritance:
+    def test_trino_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilitiesHive:
+    @pytest.fixture
+    def hive_connector(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "hive")
+        return connector
+
+    def test_supported_true(self, hive_connector):
+        assert hive_connector.describe_migration_capabilities()["supported"] is True
+
+    def test_dialect_family_is_trino_hive(self, hive_connector):
+        assert hive_connector.describe_migration_capabilities()["dialect_family"] == "trino-hive"
+
+    def test_mentions_with_format(self, hive_connector):
+        haystack = (
+            " ".join(hive_connector.describe_migration_capabilities().get("type_hints", {}).values())
+            + " "
+            + hive_connector.describe_migration_capabilities().get("example_ddl", "")
+        )
+        assert "format" in haystack.lower() or "PARQUET" in haystack.upper()
+
+
+class TestDescribeMigrationCapabilitiesIceberg:
+    @pytest.fixture
+    def iceberg_connector(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        return connector
+
+    def test_dialect_family_is_trino_iceberg(self, iceberg_connector):
+        assert iceberg_connector.describe_migration_capabilities()["dialect_family"] == "trino-iceberg"
+
+    def test_mentions_partitioning(self, iceberg_connector):
+        haystack = (
+            " ".join(iceberg_connector.describe_migration_capabilities().get("type_hints", {}).values())
+            + " "
+            + iceberg_connector.describe_migration_capabilities().get("example_ddl", "")
+        )
+        assert "partition" in haystack.lower()
+
+
+class TestDescribeMigrationCapabilitiesGeneric:
+    @pytest.fixture
+    def generic_connector(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "unknown")
+        return connector
+
+    def test_supported_with_note(self, generic_connector):
+        result = generic_connector.describe_migration_capabilities()
+        assert result["supported"] is True
+        assert result["dialect_family"] == "trino-generic"
+        assert "note" in result or len(result.get("type_hints", {})) >= 0
+
+    def test_detection_failure_does_not_raise(self, connector, monkeypatch):
+        def _raise():
+            raise RuntimeError("catalog probe failed")
+
+        monkeypatch.setattr(connector, "_detect_catalog_type", _raise)
+        # Should swallow exception and return generic
+        result = connector.describe_migration_capabilities()
+        assert result["supported"] is True
+
+
+class TestValidateDdl:
+    def test_accepts_hive_ddl_with_with_clause(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "hive")
+        ddl = """CREATE TABLE catalog.schema.t (
+          id BIGINT,
+          ds VARCHAR
+        ) WITH (format = 'PARQUET', partitioned_by = ARRAY['ds'])"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_starrocks_distributed_by(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "hive")
+        ddl = """CREATE TABLE catalog.schema.t (id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("DUPLICATE KEY" in e.upper() or "STARROCKS" in e.upper() for e in errors)
+
+    def test_rejects_engine_clickhouse(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "hive")
+        ddl = "CREATE TABLE catalog.schema.t (id BIGINT) ENGINE = MergeTree() ORDER BY id"
+        errors = connector.validate_ddl(ddl)
+        assert any("ENGINE" in e.upper() or "CLICKHOUSE" in e.upper() for e in errors)
+
+
+class TestSuggestTableLayoutHive:
+    def test_hive_returns_partitioned_by(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "hive")
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "ds", "type": "VARCHAR", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        # Hive hints: include format + partitioned_by
+        assert "format" in layout or "partitioned_by" in layout or layout == {}
+
+
+class TestSuggestTableLayoutIceberg:
+    def test_iceberg_returns_partitioning(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        # Iceberg hints: include partitioning
+        assert "partitioning" in layout or layout == {}
+
+
+class TestSuggestTableLayoutGeneric:
+    def test_generic_returns_empty(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "unknown")
+        columns = [{"name": "id", "type": "BIGINT", "nullable": False}]
+        assert connector.suggest_table_layout(columns) == {}
+
+
+class TestMapSourceType:
+    def test_hugeint_to_decimal(self, connector):
+        assert connector.map_source_type("duckdb", "HUGEINT") == "DECIMAL(38,0)"
+
+    def test_largeint_to_decimal(self, connector):
+        assert connector.map_source_type("starrocks", "LARGEINT") == "DECIMAL(38,0)"
+
+    def test_unknown_returns_none(self, connector):
+        assert connector.map_source_type("duckdb", "VARCHAR") is None

--- a/datus-trino/tests/unit/test_migration_mixin.py
+++ b/datus-trino/tests/unit/test_migration_mixin.py
@@ -71,11 +71,10 @@ class TestDescribeMigrationCapabilitiesGeneric:
         monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "unknown")
         return connector
 
-    def test_supported_with_note(self, generic_connector):
+    def test_supported_generic_capabilities(self, generic_connector):
         result = generic_connector.describe_migration_capabilities()
         assert result["supported"] is True
         assert result["dialect_family"] == "trino-generic"
-        assert "note" in result or len(result.get("type_hints", {})) >= 0
 
     def test_detection_failure_does_not_raise(self, connector, monkeypatch):
         def _raise():
@@ -85,6 +84,7 @@ class TestDescribeMigrationCapabilitiesGeneric:
         # Should swallow exception and return generic
         result = connector.describe_migration_capabilities()
         assert result["supported"] is True
+        assert result["dialect_family"] == "trino-generic"
 
 
 class TestValidateDdl:


### PR DESCRIPTION
## Why

Cross-database migration in the agent currently hardcodes DuckDB -> Greenplum/StarRocks mappings in Python. Adding a new source/target requires editing hardcoded dicts and dataclasses. This doesn't scale and doesn't let users plug in their own dialects.

## Solution

Introduce `MigrationTargetMixin` in `datus-db-core` that lets each adapter declare its own dialect-specific migration contract. The agent layer consumes only the Mixin interface — no `if dialect == 'starrocks'` branches. Adapters that don't implement the Mixin get graceful fallback to pure LLM mode on the agent side.

**Mixin methods (all optional except `describe_migration_capabilities`):**
- `describe_migration_capabilities()` — LLM-readable hints (dialect_family, requires, forbids, type_hints, example_ddl)
- `map_source_type(source_dialect, source_type)` — optional deterministic type mapping (default returns `None`, LLM decides)
- `suggest_table_layout(columns)` — OLAP distribution/partition suggestions
- `validate_ddl(ddl)` — static structural check
- `dry_run_ddl(ddl, target_table)` — strongest check, CREATE + DROP to temp

**Also moves** `build_reconciliation_checks` (7 dialect-agnostic checks) into core so any adapter user can reuse it.

**Adapter implementations (this PR):**
- StarRocks — DUPLICATE/PRIMARY/UNIQUE/AGGREGATE KEY + DISTRIBUTED BY HASH required; forbids AUTO_INCREMENT; key scoring logic
- Greenplum — DISTRIBUTED BY recommended (not required); rejects StarRocks DUPLICATE KEY / BUCKETS
- PostgreSQL — OLTP defaults; rejects cross-dialect syntax; HUGEINT -> NUMERIC(38,0)
- MySQL — OLTP; BOOLEAN -> TINYINT(1); rejects StarRocks syntax
- ClickHouse — requires ENGINE + ORDER BY; forbids VARCHAR/BOOLEAN; full type override map
- Trino — catalog-aware (hive/iceberg/delta/jdbc/unknown) with WITH-clause hints

## Test Cases

All implementation is TDD (red -> green): every Mixin method has a failing test written first.

- `datus-db-core/tests/unit/test_migration_mixin.py` — interface contract + default behavior (12 tests)
- `datus-db-core/tests/unit/test_reconciliation.py` — migrated from agent repo (24 tests)
- `datus-<dialect>/tests/unit/test_migration_mixin.py` — per-dialect hints + validation (19 StarRocks, 14 Greenplum, 13 Postgres, 13 MySQL, 25 ClickHouse, 14 Trino)

```
uv run --package datus-db-core pytest datus-db-core/tests/unit/ -q      # 255 passed
uv run --package datus-starrocks pytest datus-starrocks/tests/unit/ -q  # 84 passed
uv run --package datus-greenplum pytest datus-greenplum/tests/unit/ -q  # 72 passed
uv run --package datus-postgresql pytest datus-postgresql/tests/unit/ -q # 72 passed
uv run --package datus-mysql pytest datus-mysql/tests/unit/ -q          # 65 passed
uv run --package datus-clickhouse pytest datus-clickhouse/tests/unit/ -q # 69 passed
uv run --package datus-trino pytest datus-trino/tests/unit/ -q          # 73 passed
```

Total 690 tests green. ruff format + check clean across all packages.

## Follow-up

Downstream PR in Datus-agent will:
1. Delete `datus/tools/migration/{type_mapping,target_profiles}.py` (knowledge now in adapters)
2. Merge `MigrationAgenticNode` into `GenJobAgenticNode`
3. Move `data-migration` skill to be activated on-demand by `gen_job`
4. Add 3 new `gen_job` tools that wrap the Mixin methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added migration-target support across many connectors: capability descriptions, DDL validation, source→target type mappings, and table-layout suggestions; core package now exposes a migration-target interface.
  * Added reconciliation-check generator to produce post-migration verification queries.
* **Tests**
  * Added comprehensive unit tests validating capability descriptions, DDL validation, type mappings, layout suggestions, and reconciliation check output across connectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->