### PR TITLE
[Others] Bump datus-db-core and 12 db adapters for 2026-04-24 release

### DIFF
--- a/datus-clickhouse/pyproject.toml
+++ b/datus-clickhouse/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-clickhouse"
-version = "0.1.1"
+version = "0.1.2"
 description = "ClickHouse database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.0",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "clickhouse-sqlalchemy>=0.3.2",
 ]
 

--- a/datus-clickzetta/pyproject.toml
+++ b/datus-clickzetta/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-clickzetta"
-version = "0.1.3"
+version = "0.1.4"
 description = "ClickZetta database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
+    "datus-db-core>=0.1.3",
     "clickzetta-connector-python",
     "clickzetta-zettapark-python",
     "pandas>=2.0.0",

--- a/datus-db-core/pyproject.toml
+++ b/datus-db-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-db-core"
-version = "0.1.2"
+version = "0.1.3"
 description = "Core database abstractions for Datus adapters"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-greenplum/pyproject.toml
+++ b/datus-greenplum/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-greenplum"
-version = "0.1.0"
+version = "0.1.2"
 description = "Greenplum database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,9 +18,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.2",
-    "datus-postgresql>=0.1.2",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
+    "datus-postgresql>=0.1.5",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",
 ]

--- a/datus-hive/pyproject.toml
+++ b/datus-hive/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-hive"
-version = "0.1.1"
+version = "0.1.2"
 description = "Hive database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.0",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "pyhive>=0.7.0",
     "pure-sasl>=0.6.2",
     "thrift>=0.16.0",

--- a/datus-mysql/pyproject.toml
+++ b/datus-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-mysql"
-version = "0.1.6"
+version = "0.1.7"
 description = "MySQL database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.2",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "pymysql>=1.1.1",
     "cryptography>=41.0.0",
     "pydantic>=2.0.0",

--- a/datus-postgresql/pyproject.toml
+++ b/datus-postgresql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-postgresql"
-version = "0.1.4"
+version = "0.1.5"
 description = "PostgreSQL database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.2",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",
 ]

--- a/datus-redshift/pyproject.toml
+++ b/datus-redshift/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datus-redshift"
-version = "0.1.2"
+version = "0.1.3"
 description = "Amazon Redshift adapter for Datus Agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -14,7 +14,7 @@ authors = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
+    "datus-db-core>=0.1.3",
     "redshift_connector>=2.0.0",
     "pydantic>=2.0.0",
 ]

--- a/datus-snowflake/pyproject.toml
+++ b/datus-snowflake/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datus-snowflake"
-version = "0.1.2"
+version = "0.1.3"
 description = "Snowflake adapter for Datus Agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ authors = [
     {name = "DatusAI", email = "support@datus.ai"}
 ]
 dependencies = [
-    "datus-db-core>=0.1.0",
+    "datus-db-core>=0.1.3",
     "snowflake-connector-python>=3.6.0",
     "pydantic>=2.0.0",
 ]

--- a/datus-spark/pyproject.toml
+++ b/datus-spark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-spark"
-version = "0.1.1"
+version = "0.1.2"
 description = "Spark SQL database adapter for Datus"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
@@ -17,8 +17,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.0",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "pyhive>=0.7.0",
     "thrift>=0.16.0",
     "thrift-sasl>=0.4.3",

--- a/datus-sqlalchemy/pyproject.toml
+++ b/datus-sqlalchemy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-sqlalchemy"
-version = "0.1.5"
+version = "0.1.6"
 description = "SQLAlchemy base connector for Datus database adapters"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
+    "datus-db-core>=0.1.3",
     "sqlalchemy>=2.0.23",
     "pyarrow>=14.0.0,<19.0.0",
     "pandas>=2.1.4",

--- a/datus-starrocks/pyproject.toml
+++ b/datus-starrocks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-starrocks"
-version = "0.1.5"
+version = "0.1.6"
 description = "StarRocks database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-mysql>=0.1.3",
+    "datus-db-core>=0.1.3",
+    "datus-mysql>=0.1.7",
     "pydantic>=2.0.0",
 ]
 

--- a/datus-trino/pyproject.toml
+++ b/datus-trino/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-trino"
-version = "0.1.1"
+version = "0.1.2"
 description = "Trino database adapter for Datus"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
@@ -17,8 +17,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.0",
-    "datus-sqlalchemy>=0.1.0",
+    "datus-db-core>=0.1.3",
+    "datus-sqlalchemy>=0.1.6",
     "trino[sqlalchemy]>=0.328.0",
     "pydantic>=2.0.0",
 ]


### PR DESCRIPTION
## Why

Sync source versions with what's on PyPI. All 13 packages just went live on PyPI.

## Solution

### Per-package bumps (PyPI latest + 0.0.1)

| Package | PyPI was | New | Tag |
|---|---|---|---|
| datus-db-core | 0.1.2 | 0.1.3 | [datus-db-core-v0.1.3](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-db-core-v0.1.3) |
| datus-sqlalchemy | 0.1.5 | 0.1.6 | [datus-sqlalchemy-v0.1.6](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-sqlalchemy-v0.1.6) |
| datus-mysql | 0.1.6 | 0.1.7 | [datus-mysql-v0.1.7](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-mysql-v0.1.7) |
| datus-postgresql | 0.1.4 | 0.1.5 | [datus-postgresql-v0.1.5](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-postgresql-v0.1.5) |
| datus-clickhouse | 0.1.1 | 0.1.2 | [datus-clickhouse-v0.1.2](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-clickhouse-v0.1.2) |
| datus-clickzetta | 0.1.3 | 0.1.4 | [datus-clickzetta-v0.1.4](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-clickzetta-v0.1.4) |
| datus-greenplum | 0.1.1rc2 | 0.1.2 | [datus-greenplum-v0.1.2](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-greenplum-v0.1.2) |
| datus-hive | 0.1.1 | 0.1.2 | [datus-hive-v0.1.2](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-hive-v0.1.2) |
| datus-redshift | 0.1.2 | 0.1.3 | [datus-redshift-v0.1.3](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-redshift-v0.1.3) |
| datus-snowflake | 0.1.2 | 0.1.3 | [datus-snowflake-v0.1.3](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-snowflake-v0.1.3) |
| datus-spark | 0.1.1 | 0.1.2 | [datus-spark-v0.1.2](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-spark-v0.1.2) |
| datus-starrocks | 0.1.5 | 0.1.6 | [datus-starrocks-v0.1.6](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-starrocks-v0.1.6) |
| datus-trino | 0.1.1 | 0.1.2 | [datus-trino-v0.1.2](https://github.com/Datus-ai/datus-db-adapters/releases/tag/datus-trino-v0.1.2) |

`datus-bigquery` skipped (no pyproject.toml).

### Inter-package dependency constraints re-floored

- `datus-db-core>=0.1.3` (in all 12 adapter pyprojects)
- `datus-sqlalchemy>=0.1.6` (clickhouse, greenplum, hive, mysql, postgresql, spark, trino)
- `datus-postgresql>=0.1.5` (greenplum)
- `datus-mysql>=0.1.7` (starrocks)

## Test Cases

Release is already live on PyPI; this PR reconciles the source. Pre-upload verifications:

- `uv build --package <each>` → 26 artifacts built cleanly (13 wheels + 13 sdists)
- `uv run --with twine twine check dist/*` → all PASSED
- `twine upload` in 4 dependency layers:
  1. `datus-db-core` (no datus-* deps)
  2. `datus-sqlalchemy` (needs db-core)
  3. `datus-mysql`, `datus-postgresql` (need sqlalchemy; consumed by starrocks/greenplum)
  4. remaining 9 adapters
- All 13 PyPI project pages confirm new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)