### PR TITLE
[Enhancement] Add CUSTOM auth mechanism support to datus-spark

### DIFF
--- a/datus-spark/datus_spark/config.py
+++ b/datus-spark/datus_spark/config.py
@@ -21,7 +21,7 @@ class SparkConfig(BaseModel):
         json_schema_extra={"input_type": "password"},
     )
     database: Optional[str] = Field(default=None, description="Default database name")
-    auth_mechanism: Literal["NONE", "PLAIN", "KERBEROS"] = Field(
-        default="NONE", description="Authentication mechanism (NONE, PLAIN, KERBEROS)"
+    auth_mechanism: Literal["NONE", "PLAIN", "KERBEROS", "CUSTOM"] = Field(
+        default="NONE", description="Authentication mechanism (NONE, PLAIN, KERBEROS, CUSTOM)"
     )
     timeout_seconds: int = Field(default=30, description="Connection timeout in seconds")


### PR DESCRIPTION
## Why

PyHive requires `auth='CUSTOM'` when a password is provided over HiveServer2/Thrift. The current `SparkConfig` only accepts `NONE`, `PLAIN`, and `KERBEROS`:

- `auth='NONE'` rejects passwords outright (`ValueError: Password should be set if and only if in LDAP or CUSTOM mode`)
- `auth='PLAIN'` is only valid for LDAP/CUSTOM modes in PyHive

Without the `CUSTOM` option, Spark Thrift servers that require username+password authentication cannot be connected.

## Solution

Extend `SparkConfig.auth_mechanism` Literal to include `'CUSTOM'`. The existing connector logic already appends `?auth={mechanism}` to the SQLAlchemy connection string whenever the value is not `"NONE"`, so no changes to `connector.py` are needed.

## Test Cases

Manually verified against a live Spark Thrift Server (HiveServer2) requiring username+password auth:

```python
from pyhive.hive import connect
conn = connect(host='...', port=10000, username='root',
               password='...', database='...', auth='CUSTOM')
```

Connection succeeds and `SHOW DATABASES` returns expected results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced custom authentication mode for Spark connections, expanding available authentication mechanisms to support users with specialized or non-standard authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->