### PR TITLE
[BugFix] Support Greenplum 6 distribution policy catalog

### DIFF
--- a/datus-greenplum/README.md
+++ b/datus-greenplum/README.md
@@ -34,6 +34,9 @@ cd datus-greenplum && python -m pytest tests/unit/ -v
 
 # Integration tests (requires running Greenplum)
 cd datus-greenplum
-docker-compose up -d
+docker compose up -d
 python -m pytest tests/integration/ -v
 ```
+
+The compose environment uses Greenplum 6.27.1 and exposes
+`localhost:15432` with `gpadmin/pivotal` and database `test`.

--- a/datus-greenplum/datus_greenplum/connector.py
+++ b/datus-greenplum/datus_greenplum/connector.py
@@ -45,6 +45,7 @@ class GreenplumConnector(PostgreSQLConnector, MigrationTargetMixin):
         super().__init__(config)
         # Keep reference to the original Greenplum config
         self.config = config
+        self._distribution_policy_key_column: Optional[str] = None
 
     # ==================== System Resources ====================
 
@@ -73,6 +74,31 @@ class GreenplumConnector(PostgreSQLConnector, MigrationTargetMixin):
 
     # ==================== DDL Generation ====================
 
+    def _get_distribution_policy_key_column(self) -> str:
+        """Return the catalog column that stores distribution key attnums."""
+        if self._distribution_policy_key_column is not None:
+            return self._distribution_policy_key_column
+
+        sql = """
+            SELECT attname
+            FROM pg_attribute
+            WHERE attrelid = 'pg_catalog.gp_distribution_policy'::regclass
+              AND attname IN ('distkey', 'attrnums')
+              AND NOT attisdropped
+            ORDER BY CASE attname WHEN 'distkey' THEN 0 ELSE 1 END
+            LIMIT 1
+        """
+        result = self._execute_pandas(sql)
+        if result.empty:
+            raise RuntimeError("Could not find distribution key column in gp_distribution_policy")
+
+        policy_key_column = str(result["attname"].iloc[0])
+        if policy_key_column not in {"distkey", "attrnums"}:
+            raise RuntimeError(f"Unexpected distribution key column: {policy_key_column}")
+
+        self._distribution_policy_key_column = policy_key_column
+        return policy_key_column
+
     def _get_distribution_policy(self, schema_name: str, table_name: str) -> Optional[str]:
         """Get distribution policy clause for a Greenplum table.
 
@@ -87,14 +113,15 @@ class GreenplumConnector(PostgreSQLConnector, MigrationTargetMixin):
         safe_table = _escape_literal(table_name)
 
         try:
-            # GP 4.x uses `attrnums` (int2vector); GP 5+ uses `distkey` (int2[])
+            # GP 5 and older use `attrnums`; GP 6+ renamed it to `distkey`.
+            policy_key_column = self._get_distribution_policy_key_column()
             sql = f"""
                 SELECT a.attname
                 FROM gp_distribution_policy dp
                 JOIN pg_class c ON dp.localoid = c.oid
                 JOIN pg_namespace n ON c.relnamespace = n.oid
                 LEFT JOIN pg_attribute a ON a.attrelid = c.oid
-                    AND a.attnum = ANY(dp.attrnums)
+                    AND a.attnum = ANY(dp.{policy_key_column})
                 WHERE n.nspname = '{safe_schema}'
                   AND c.relname = '{safe_table}'
                 ORDER BY a.attnum

--- a/datus-greenplum/datus_greenplum/connector.py
+++ b/datus-greenplum/datus_greenplum/connector.py
@@ -120,11 +120,13 @@ class GreenplumConnector(PostgreSQLConnector, MigrationTargetMixin):
                 FROM gp_distribution_policy dp
                 JOIN pg_class c ON dp.localoid = c.oid
                 JOIN pg_namespace n ON c.relnamespace = n.oid
+                LEFT JOIN LATERAL unnest(dp.{policy_key_column}) WITH ORDINALITY AS dist(attnum, ord)
+                    ON TRUE
                 LEFT JOIN pg_attribute a ON a.attrelid = c.oid
-                    AND a.attnum = ANY(dp.{policy_key_column})
+                    AND a.attnum = dist.attnum
                 WHERE n.nspname = '{safe_schema}'
                   AND c.relname = '{safe_table}'
-                ORDER BY a.attnum
+                ORDER BY dist.ord
             """
             result = self._execute_pandas(sql)
 

--- a/datus-greenplum/docker-compose.yml
+++ b/datus-greenplum/docker-compose.yml
@@ -1,16 +1,17 @@
 # Greenplum test environment
-# Usage: docker-compose up -d
-# Connect: psql -h localhost -p 15432 -U gpadmin -d postgres
+# Usage: docker compose up -d
+# Connect: PGPASSWORD=pivotal psql -h localhost -p 15432 -U gpadmin -d test
 
 services:
   greenplum:
-    image: datagrip/greenplum:latest
+    image: woblerr/greenplum:6.27.1
     ports:
       - "15432:5432"
     environment:
-      - ALLOW_HOST_CONNECTION=yes
+      GREENPLUM_PASSWORD: pivotal
+      GREENPLUM_DATABASE_NAME: test
     healthcheck:
-      test: ["CMD-SHELL", "psql -U gpadmin -d postgres -c 'SELECT 1'"]
+      test: ["CMD-SHELL", "su - gpadmin -c \"source /usr/local/greenplum-db/greenplum_path.sh && PGPASSWORD=pivotal psql -h localhost -p 5432 -U gpadmin -d test -c 'SELECT 1'\""]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/datus-greenplum/pyproject.toml
+++ b/datus-greenplum/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-greenplum"
-version = "0.1.2"
+version = "0.1.3"
 description = "Greenplum database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-greenplum/tests/integration/test_sql_execution.py
+++ b/datus-greenplum/tests/integration/test_sql_execution.py
@@ -222,6 +222,32 @@ def test_distribution_policy_by_column(connector: GreenplumConnector, config: Gr
 
 
 @pytest.mark.integration
+@pytest.mark.acceptance
+def test_distribution_policy_preserves_multi_column_order(connector: GreenplumConnector, config: GreenplumConfig):
+    """Test DDL preserves declared multi-column distribution key order."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"test_dist_col_order_{suffix}"
+
+    connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+    connector.execute_ddl(
+        f"""
+        CREATE TABLE {table_name} (
+            id INTEGER,
+            name VARCHAR(50)
+        ) DISTRIBUTED BY (name, id)
+    """
+    )
+
+    try:
+        tables = connector.get_tables_with_ddl(schema_name=config.schema_name, tables=[table_name])
+        assert len(tables) == 1
+        ddl = tables[0]["definition"]
+        assert 'DISTRIBUTED BY ("name", "id")' in ddl
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+@pytest.mark.integration
 def test_distribution_policy_random(connector: GreenplumConnector, config: GreenplumConfig):
     """Test DDL includes DISTRIBUTED RANDOMLY for randomly distributed tables."""
     suffix = uuid.uuid4().hex[:8]

--- a/datus-greenplum/tests/integration/test_sql_execution.py
+++ b/datus-greenplum/tests/integration/test_sql_execution.py
@@ -178,6 +178,25 @@ def test_identifier(connector: GreenplumConnector):
 
 @pytest.mark.integration
 @pytest.mark.acceptance
+def test_distribution_policy_catalog_uses_distkey(connector: GreenplumConnector):
+    """Test the integration image covers the Greenplum 6+ distribution catalog."""
+    result = connector._execute_pandas(
+        """
+        SELECT attname
+        FROM pg_attribute
+        WHERE attrelid = 'pg_catalog.gp_distribution_policy'::regclass
+          AND attname IN ('distkey', 'attrnums')
+          AND NOT attisdropped
+        ORDER BY attname
+        """
+    )
+
+    columns = set(result["attname"].tolist())
+    assert columns == {"distkey"}
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
 def test_distribution_policy_by_column(connector: GreenplumConnector, config: GreenplumConfig):
     """Test DDL includes DISTRIBUTED BY for tables with explicit distribution key."""
     suffix = uuid.uuid4().hex[:8]

--- a/datus-greenplum/tests/unit/test_connector_unit.py
+++ b/datus-greenplum/tests/unit/test_connector_unit.py
@@ -319,27 +319,55 @@ def test_get_distribution_policy_by_column():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = GreenplumConnector(config)
-        mock_df = pd.DataFrame({"attname": ["id", "name"]})
-        connector._execute_pandas = MagicMock(return_value=mock_df)
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["distkey"]}),
+                pd.DataFrame({"attname": ["id", "name"]}),
+            ]
+        )
 
         result = connector._get_distribution_policy("public", "test_table")
 
         assert result == 'DISTRIBUTED BY ("id", "name")'
-        # Verify attrnums is used in query (not distkey)
-        sql_arg = connector._execute_pandas.call_args[0][0]
+        sql_arg = connector._execute_pandas.call_args_list[1][0][0]
+        assert "dp.distkey" in sql_arg
+        assert "dp.attrnums" not in sql_arg
+
+
+def test_get_distribution_policy_uses_attrnums_for_older_greenplum():
+    """Test _get_distribution_policy supports older Greenplum catalog shape."""
+    config = GreenplumConfig(username="gpadmin")
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
+        connector = GreenplumConnector(config)
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["attrnums"]}),
+                pd.DataFrame({"attname": ["id"]}),
+            ]
+        )
+
+        result = connector._get_distribution_policy("public", "test_table")
+
+        assert result == 'DISTRIBUTED BY ("id")'
+        sql_arg = connector._execute_pandas.call_args_list[1][0][0]
         assert "dp.attrnums" in sql_arg
         assert "dp.distkey" not in sql_arg
 
 
 @pytest.mark.acceptance
 def test_get_distribution_policy_random():
-    """Test _get_distribution_policy returns DISTRIBUTED RANDOMLY for null attrnums."""
+    """Test _get_distribution_policy returns DISTRIBUTED RANDOMLY for null keys."""
     config = GreenplumConfig(username="gpadmin")
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = GreenplumConnector(config)
-        mock_df = pd.DataFrame({"attname": [None]})
-        connector._execute_pandas = MagicMock(return_value=mock_df)
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["distkey"]}),
+                pd.DataFrame({"attname": [None]}),
+            ]
+        )
 
         result = connector._get_distribution_policy("public", "test_table")
 
@@ -352,8 +380,12 @@ def test_get_distribution_policy_empty_result():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = GreenplumConnector(config)
-        mock_df = pd.DataFrame({"attname": []})
-        connector._execute_pandas = MagicMock(return_value=mock_df)
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["distkey"]}),
+                pd.DataFrame({"attname": []}),
+            ]
+        )
 
         result = connector._get_distribution_policy("public", "test_table")
 
@@ -367,7 +399,12 @@ def test_get_distribution_policy_error_returns_none():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = GreenplumConnector(config)
-        connector._execute_pandas = MagicMock(side_effect=Exception("catalog error"))
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["distkey"]}),
+                Exception("catalog error"),
+            ]
+        )
 
         result = connector._get_distribution_policy("public", "test_table")
 
@@ -380,12 +417,16 @@ def test_get_distribution_policy_escapes_input():
 
     with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
         connector = GreenplumConnector(config)
-        mock_df = pd.DataFrame({"attname": ["id"]})
-        connector._execute_pandas = MagicMock(return_value=mock_df)
+        connector._execute_pandas = MagicMock(
+            side_effect=[
+                pd.DataFrame({"attname": ["distkey"]}),
+                pd.DataFrame({"attname": ["id"]}),
+            ]
+        )
 
         connector._get_distribution_policy("it's", "tab'le")
 
-        sql_arg = connector._execute_pandas.call_args[0][0]
+        sql_arg = connector._execute_pandas.call_args_list[1][0][0]
         assert "it''s" in sql_arg
         assert "tab''le" in sql_arg
 

--- a/datus-greenplum/tests/unit/test_connector_unit.py
+++ b/datus-greenplum/tests/unit/test_connector_unit.py
@@ -332,6 +332,9 @@ def test_get_distribution_policy_by_column():
         sql_arg = connector._execute_pandas.call_args_list[1][0][0]
         assert "dp.distkey" in sql_arg
         assert "dp.attrnums" not in sql_arg
+        assert "WITH ORDINALITY AS dist(attnum, ord)" in sql_arg
+        assert "ORDER BY dist.ord" in sql_arg
+        assert "ORDER BY a.attnum" not in sql_arg
 
 
 def test_get_distribution_policy_uses_attrnums_for_older_greenplum():


### PR DESCRIPTION
## Summary

- Detect whether `gp_distribution_policy` stores distribution keys in `distkey` or legacy `attrnums` before building Greenplum distribution-policy DDL.
- Switch the Greenplum integration compose image to Greenplum 6.27.1 so tests cover the `distkey` catalog shape reported by users.
- Add unit coverage for both Greenplum 6+ and older catalog shapes, plus an integration assertion that the test image exposes `distkey`.
- Bump `datus-greenplum` to 0.1.3 for the fix release.

## Root Cause

Greenplum 6+ renamed the distribution key catalog column from `attrnums` to `distkey`. The adapter hard-coded `dp.attrnums`, so schema introspection failed on newer Greenplum with `column dp.attrnums does not exist`.

## Validation

- `uv run ruff check datus-greenplum/datus_greenplum/connector.py datus-greenplum/tests/unit/test_connector_unit.py datus-greenplum/tests/integration/test_sql_execution.py`
- `uv run pytest datus-greenplum/tests/unit/test_connector_unit.py -q` (`38 passed`)
- `uv run pytest datus-greenplum/tests/integration/ -q` (`36 passed`)
- Verified `woblerr/greenplum:6.27.1` compose service is healthy on `localhost:15432`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker setup with new `docker compose` command syntax and Greenplum 6.27.1 image
  * Added test environment configuration documentation including connection details and credentials

* **New Features**
  * Improved Greenplum compatibility by supporting distribution policy detection across multiple Greenplum versions

* **Chores**
  * Patch version released as 0.1.3

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->