### PR TITLE
[Enhancement] Add adapter CI baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "Run Tests"
+name: Adapter CI
 
 on:
   pull_request:
@@ -6,63 +6,23 @@ on:
       - opened
       - synchronize
       - reopened
-    paths:
-      - 'datus-mysql/**'
-      - 'datus-postgresql/**'
-      - 'datus-sqlalchemy/**'
-      - '.github/workflows/test.yml'
+  merge_group:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
-  group: test-${{ github.event.pull_request.number || github.ref }}
+  group: adapter-ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  detect-changes:
+  unit-tests:
     runs-on: self-hosted
-    outputs:
-      mysql: ${{ steps.filter.outputs.mysql }}
-      postgresql: ${{ steps.filter.outputs.postgresql }}
-      sqlalchemy: ${{ steps.filter.outputs.sqlalchemy }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            mysql:
-              - 'datus-mysql/**'
-              - 'datus-sqlalchemy/**'
-            postgresql:
-              - 'datus-postgresql/**'
-              - 'datus-sqlalchemy/**'
-            sqlalchemy:
-              - 'datus-sqlalchemy/**'
-
-  test-mysql:
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.mysql == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: self-hosted
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: test_password
-          MYSQL_DATABASE: test
-          MYSQL_USER: test_user
-          MYSQL_PASSWORD: test_password
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost -u root -ptest_password"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-          --health-start-period=30s
-
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,96 +30,49 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          uv sync --package datus-mysql
-
-      - name: Run unit tests for datus-mysql
-        run: |
-          uv run pytest datus-mysql/tests/ -m "not integration" -v --cov=datus_mysql --cov-report=term --cov-report=xml
-
-      - name: Run integration tests for datus-mysql
-        env:
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-          MYSQL_USER: test_user
-          MYSQL_PASSWORD: test_password
-          MYSQL_DATABASE: test
-        run: |
-          uv run pytest datus-mysql/tests/integration/ -m integration -v
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        if: always()
+        uses: astral-sh/setup-uv@v5
         with:
-          file: ./coverage.xml
-          flags: datus-mysql
-          name: datus-mysql-coverage
+          enable-cache: true
 
-  test-postgresql:
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.postgresql == 'true' || github.ref == 'refs/heads/main' }}
+      - name: Run unit tests
+        run: ci/run-unit-tests.sh
+
+  integration-tests:
+    needs:
+      - unit-tests
     runs-on: self-hosted
-
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: test
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U test_user -d test"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-          --health-start-period=30s
-
+    timeout-minutes: 90
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.event.pull_request.base.ref }}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          uv sync --package datus-postgresql
-
-      - name: Run unit tests for datus-postgresql
-        run: |
-          uv run pytest datus-postgresql/tests/ -m "not integration" -v --cov=datus_postgresql --cov-report=term --cov-report=xml
-
-      - name: Run integration tests for datus-postgresql
-        env:
-          POSTGRESQL_HOST: 127.0.0.1
-          POSTGRESQL_PORT: 5432
-          POSTGRESQL_USER: test_user
-          POSTGRESQL_PASSWORD: test_password
-          POSTGRESQL_DATABASE: test
-        run: |
-          uv run pytest datus-postgresql/tests/integration/ -m integration -v
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        if: always()
+        uses: astral-sh/setup-uv@v5
         with:
-          file: ./coverage.xml
-          flags: datus-postgresql
-          name: datus-postgresql-coverage
+          enable-cache: true
+
+      - name: Run impacted integration tests
+        if: github.event_name == 'pull_request'
+        run: ci/run-integration-tests.sh --changed "origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Run full integration tests
+        if: github.event_name != 'pull_request'
+        run: ci/run-integration-tests.sh
+
+      - name: Stop integration services
+        if: always()
+        run: ci/run-integration-tests.sh --cleanup-only

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -1,0 +1,464 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ALL_ADAPTERS=(postgresql mysql clickhouse starrocks trino greenplum hive spark)
+DOCKER_COMPOSE=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ci/run-integration-tests.sh [--list] [--dry-run] [--changed base-ref] [adapter ...]
+       ci/run-integration-tests.sh --cleanup-only
+
+Runs Docker-backed DB adapter integration tests.
+
+Options:
+  --changed REF    Select impacted adapters from git diff REF...HEAD.
+  --list           List configured adapter targets.
+  --dry-run        Print selected adapters without starting Docker.
+  --cleanup-only   Stop all configured integration compose projects.
+  -h, --help       Show this help.
+USAGE
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 127
+  fi
+}
+
+detect_docker_compose() {
+  if docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE=(docker compose)
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE=(docker-compose)
+    return 0
+  fi
+  return 1
+}
+
+install_docker_compose() {
+  local version="${DOCKER_COMPOSE_VERSION:-v2.32.4}"
+  local os
+  local machine
+  local arch
+  local bin_dir
+  local bin_path
+  local url
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "Missing required command: curl; cannot install Docker Compose." >&2
+    return 1
+  fi
+
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$os" in
+    linux|darwin) ;;
+    *)
+      echo "Unsupported OS for automatic Docker Compose install: $os" >&2
+      return 1
+      ;;
+  esac
+
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) arch="x86_64" ;;
+    aarch64|arm64) arch="aarch64" ;;
+    *)
+      echo "Unsupported architecture for automatic Docker Compose install: $machine" >&2
+      return 1
+      ;;
+  esac
+
+  bin_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-docker-compose"
+  bin_path="$bin_dir/docker-compose-$version-$os-$arch"
+  url="https://github.com/docker/compose/releases/download/$version/docker-compose-$os-$arch"
+
+  mkdir -p "$bin_dir"
+  if [ ! -x "$bin_path" ]; then
+    echo "Installing Docker Compose $version to $bin_path"
+    curl -fsSL --retry 3 -o "$bin_path" "$url"
+    chmod +x "$bin_path"
+  fi
+
+  DOCKER_COMPOSE=("$bin_path")
+}
+
+ensure_docker_compose() {
+  detect_docker_compose || install_docker_compose
+}
+
+docker_compose() {
+  if [ "${#DOCKER_COMPOSE[@]}" -eq 0 ]; then
+    if ! ensure_docker_compose; then
+      echo "Docker Compose is not available through 'docker compose' or 'docker-compose'." >&2
+      return 127
+    fi
+  fi
+  "${DOCKER_COMPOSE[@]}" "$@"
+}
+
+preflight() {
+  require_command uv
+  require_command docker
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon is not reachable. Start Docker and retry." >&2
+    exit 1
+  fi
+  if ! ensure_docker_compose; then
+    echo "Docker Compose is not available through 'docker compose' or 'docker-compose'." >&2
+    exit 1
+  fi
+}
+
+is_known_adapter() {
+  local requested="$1"
+  local adapter
+  for adapter in "${ALL_ADAPTERS[@]}"; do
+    if [ "$adapter" = "$requested" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+adapter_package() {
+  echo "datus-$1"
+}
+
+adapter_compose() {
+  echo "datus-$1/docker-compose.yml"
+}
+
+adapter_test_path() {
+  echo "datus-$1/tests/integration"
+}
+
+adapter_services() {
+  case "$1" in
+    postgresql) echo "postgres:300" ;;
+    mysql) echo "mysql:300" ;;
+    clickhouse) echo "clickhouse:300" ;;
+    starrocks) echo "starrocks:600" ;;
+    trino) echo "trino:300" ;;
+    greenplum) echo "greenplum:600" ;;
+    hive) echo "hive-metastore:600 hive-server:900" ;;
+    spark) echo "spark-thrift:900" ;;
+    *) echo "Unknown adapter '$1'" >&2; return 1 ;;
+  esac
+}
+
+list_adapters() {
+  local adapter
+  for adapter in "${ALL_ADAPTERS[@]}"; do
+    printf '%s\t%s\t%s\t%s\n' \
+      "$adapter" \
+      "$(adapter_package "$adapter")" \
+      "$(adapter_compose "$adapter")" \
+      "$(adapter_test_path "$adapter")"
+  done
+}
+
+export_adapter_env() {
+  case "$1" in
+    postgresql)
+      export POSTGRESQL_HOST_PORT="${POSTGRESQL_HOST_PORT:-25432}"
+      export POSTGRESQL_HOST="127.0.0.1"
+      export POSTGRESQL_PORT="$POSTGRESQL_HOST_PORT"
+      export POSTGRESQL_USER="test_user"
+      export POSTGRESQL_PASSWORD="test_password"
+      export POSTGRESQL_DATABASE="test"
+      export POSTGRESQL_SCHEMA="public"
+      ;;
+    mysql)
+      export MYSQL_HOST_PORT="${MYSQL_HOST_PORT:-23306}"
+      export MYSQL_HOST="127.0.0.1"
+      export MYSQL_PORT="$MYSQL_HOST_PORT"
+      export MYSQL_USER="test_user"
+      export MYSQL_PASSWORD="test_password"
+      export MYSQL_DATABASE="test"
+      ;;
+    clickhouse)
+      export CLICKHOUSE_HTTP_HOST_PORT="${CLICKHOUSE_HTTP_HOST_PORT:-28123}"
+      export CLICKHOUSE_NATIVE_HOST_PORT="${CLICKHOUSE_NATIVE_HOST_PORT:-29000}"
+      export CLICKHOUSE_HOST="127.0.0.1"
+      export CLICKHOUSE_PORT="$CLICKHOUSE_HTTP_HOST_PORT"
+      export CLICKHOUSE_USER="default_user"
+      export CLICKHOUSE_PASSWORD="default_test"
+      export CLICKHOUSE_DATABASE="default_test"
+      ;;
+    starrocks)
+      export STARROCKS_QUERY_HOST_PORT="${STARROCKS_QUERY_HOST_PORT:-29030}"
+      export STARROCKS_HTTP_HOST_PORT="${STARROCKS_HTTP_HOST_PORT:-28030}"
+      export STARROCKS_HOST="127.0.0.1"
+      export STARROCKS_PORT="$STARROCKS_QUERY_HOST_PORT"
+      export STARROCKS_USER="root"
+      export STARROCKS_PASSWORD=""
+      export STARROCKS_CATALOG="default_catalog"
+      export STARROCKS_DATABASE="test"
+      ;;
+    trino)
+      export TRINO_HOST_PORT="${TRINO_HOST_PORT:-28080}"
+      export TRINO_HOST="127.0.0.1"
+      export TRINO_PORT="$TRINO_HOST_PORT"
+      export TRINO_USER="trino"
+      export TRINO_PASSWORD=""
+      export TRINO_CATALOG="tpch"
+      export TRINO_SCHEMA="tiny"
+      export TRINO_HTTP_SCHEME="http"
+      ;;
+    greenplum)
+      export GREENPLUM_HOST_PORT="${GREENPLUM_HOST_PORT:-25433}"
+      export GREENPLUM_HOST="127.0.0.1"
+      export GREENPLUM_PORT="$GREENPLUM_HOST_PORT"
+      export GREENPLUM_USER="gpadmin"
+      export GREENPLUM_PASSWORD="pivotal"
+      export GREENPLUM_DATABASE="test"
+      export GREENPLUM_SCHEMA="public"
+      ;;
+    hive)
+      export HIVE_METASTORE_HOST_PORT="${HIVE_METASTORE_HOST_PORT:-29083}"
+      export HIVE_THRIFT_HOST_PORT="${HIVE_THRIFT_HOST_PORT:-20000}"
+      export HIVE_WEBUI_HOST_PORT="${HIVE_WEBUI_HOST_PORT:-20002}"
+      export HIVE_HOST="127.0.0.1"
+      export HIVE_PORT="$HIVE_THRIFT_HOST_PORT"
+      export HIVE_USERNAME="hive"
+      export HIVE_PASSWORD=""
+      export HIVE_DATABASE="default"
+      ;;
+    spark)
+      export SPARK_THRIFT_HOST_PORT="${SPARK_THRIFT_HOST_PORT:-21000}"
+      export SPARK_UI_HOST_PORT="${SPARK_UI_HOST_PORT:-24040}"
+      export SPARK_HOST="127.0.0.1"
+      export SPARK_PORT="$SPARK_THRIFT_HOST_PORT"
+      export SPARK_USER="spark"
+      export SPARK_PASSWORD=""
+      export SPARK_DATABASE="default"
+      export SPARK_AUTH_MECHANISM="NONE"
+      ;;
+  esac
+}
+
+adapter_env_summary() {
+  case "$1" in
+    postgresql) echo "env: POSTGRESQL_HOST=$POSTGRESQL_HOST POSTGRESQL_PORT=$POSTGRESQL_PORT POSTGRESQL_DATABASE=$POSTGRESQL_DATABASE POSTGRESQL_SCHEMA=$POSTGRESQL_SCHEMA" ;;
+    mysql) echo "env: MYSQL_HOST=$MYSQL_HOST MYSQL_PORT=$MYSQL_PORT MYSQL_DATABASE=$MYSQL_DATABASE" ;;
+    clickhouse) echo "env: CLICKHOUSE_HOST=$CLICKHOUSE_HOST CLICKHOUSE_PORT=$CLICKHOUSE_PORT CLICKHOUSE_DATABASE=$CLICKHOUSE_DATABASE" ;;
+    starrocks) echo "env: STARROCKS_HOST=$STARROCKS_HOST STARROCKS_PORT=$STARROCKS_PORT STARROCKS_CATALOG=$STARROCKS_CATALOG STARROCKS_DATABASE=$STARROCKS_DATABASE" ;;
+    trino) echo "env: TRINO_HOST=$TRINO_HOST TRINO_PORT=$TRINO_PORT TRINO_CATALOG=$TRINO_CATALOG TRINO_SCHEMA=$TRINO_SCHEMA" ;;
+    greenplum) echo "env: GREENPLUM_HOST=$GREENPLUM_HOST GREENPLUM_PORT=$GREENPLUM_PORT GREENPLUM_DATABASE=$GREENPLUM_DATABASE GREENPLUM_SCHEMA=$GREENPLUM_SCHEMA" ;;
+    hive) echo "env: HIVE_HOST=$HIVE_HOST HIVE_PORT=$HIVE_PORT HIVE_DATABASE=$HIVE_DATABASE" ;;
+    spark) echo "env: SPARK_HOST=$SPARK_HOST SPARK_PORT=$SPARK_PORT SPARK_DATABASE=$SPARK_DATABASE SPARK_AUTH_MECHANISM=$SPARK_AUTH_MECHANISM" ;;
+  esac
+}
+
+compose_down() {
+  local adapter="$1"
+  local compose_file
+  compose_file="$(adapter_compose "$adapter")"
+  if [ -f "$compose_file" ]; then
+    docker_compose -f "$compose_file" down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_all() {
+  local adapter
+  for adapter in "${ALL_ADAPTERS[@]}"; do
+    compose_down "$adapter"
+  done
+}
+
+cleanup_only=0
+dry_run=0
+changed_mode=0
+changed_base=""
+requested_adapters=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cleanup-only)
+      cleanup_only=1
+      shift
+      ;;
+    --list)
+      list_adapters
+      exit 0
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --changed)
+      changed_mode=1
+      if [ -z "${2:-}" ]; then
+        echo "--changed requires a base ref" >&2
+        exit 2
+      fi
+      changed_base="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [ "$#" -gt 0 ]; do
+        requested_adapters+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      requested_adapters+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "$cleanup_only" -eq 1 ]; then
+  cleanup_all
+  exit 0
+fi
+
+wait_for_service_health() {
+  local compose_file="$1"
+  local service_name="$2"
+  local timeout_seconds="$3"
+  local container_id=""
+  local status=""
+  local deadline=$((SECONDS + timeout_seconds))
+
+  container_id="$(docker_compose -f "$compose_file" ps -q "$service_name")"
+  if [ -z "$container_id" ]; then
+    echo "No container found for service '$service_name' in $compose_file" >&2
+    docker_compose -f "$compose_file" ps || true
+    return 1
+  fi
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || echo unknown)"
+    if [ "$status" = "healthy" ] || [ "$status" = "running" ]; then
+      echo "Service '$service_name' is $status"
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "Timed out waiting for service '$service_name' from $compose_file" >&2
+  docker_compose -f "$compose_file" ps || true
+  docker_compose -f "$compose_file" logs --tail=200 || true
+  return 1
+}
+
+adapters_from_changed_files() {
+  local base_ref="$1"
+  local changed_files=""
+  changed_files="$(
+    {
+      git diff --name-only "${base_ref}...HEAD"
+      git diff --name-only --cached
+      git diff --name-only
+      git ls-files --others --exclude-standard
+    } | awk 'NF && !seen[$0]++'
+  )"
+
+  if [ -z "$changed_files" ]; then
+    return 0
+  fi
+
+  if echo "$changed_files" | grep -Eq '^(pyproject\.toml|ci/|\.github/workflows/|datus-db-core/|datus-sqlalchemy/)'; then
+    printf '%s\n' "${ALL_ADAPTERS[@]}"
+    return 0
+  fi
+
+  local adapter
+  for adapter in "${ALL_ADAPTERS[@]}"; do
+    if echo "$changed_files" | grep -Eq "^datus-${adapter}/"; then
+      echo "$adapter"
+    fi
+  done
+}
+
+selected_adapters=()
+if [ "$changed_mode" -eq 1 ]; then
+  while IFS= read -r adapter; do
+    [ -n "$adapter" ] && selected_adapters+=("$adapter")
+  done < <(adapters_from_changed_files "$changed_base" | awk '!seen[$0]++')
+else
+  selected_adapters=("${requested_adapters[@]}")
+fi
+
+if [ "${#selected_adapters[@]}" -eq 0 ] && [ "$changed_mode" -eq 1 ]; then
+  echo "No local compose-backed adapter changes detected; skipping integration tests."
+  exit 0
+fi
+
+if [ "${#selected_adapters[@]}" -eq 0 ]; then
+  selected_adapters=("${ALL_ADAPTERS[@]}")
+fi
+
+for adapter in "${selected_adapters[@]}"; do
+  if ! is_known_adapter "$adapter"; then
+    echo "Unknown adapter '$adapter'. Use --list to see valid adapter names." >&2
+    exit 2
+  fi
+done
+
+if [ "$dry_run" -eq 1 ]; then
+  for adapter in "${selected_adapters[@]}"; do
+    export_adapter_env "$adapter"
+    echo ""
+    echo "=== Integration tests: $adapter ==="
+    echo "package: $(adapter_package "$adapter")"
+    echo "compose: $(adapter_compose "$adapter")"
+    echo "tests: $(adapter_test_path "$adapter")"
+    echo "services: $(adapter_services "$adapter")"
+    adapter_env_summary "$adapter"
+  done
+  exit 0
+fi
+
+preflight
+trap cleanup_all EXIT
+
+for adapter in "${selected_adapters[@]}"; do
+  compose_file="$(adapter_compose "$adapter")"
+  package="$(adapter_package "$adapter")"
+  test_path="$(adapter_test_path "$adapter")"
+
+  if [ ! -f "$compose_file" ]; then
+    echo "Missing compose file for $adapter: $compose_file" >&2
+    exit 1
+  fi
+  if [ ! -d "$test_path" ]; then
+    echo "Missing integration test path for $adapter: $test_path" >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "=== Integration tests: $adapter ==="
+  compose_down "$adapter"
+  export_adapter_env "$adapter"
+  docker_compose -f "$compose_file" up -d --build
+
+  for spec in $(adapter_services "$adapter"); do
+    service_name="${spec%%:*}"
+    timeout_seconds="${spec##*:}"
+    wait_for_service_health "$compose_file" "$service_name" "$timeout_seconds"
+  done
+
+  uv run --all-packages --with pytest --with pandas --with pyarrow pytest "$test_path" -m integration --tb=short --verbose
+
+  compose_down "$adapter"
+done

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 ALL_ADAPTERS=(postgresql mysql clickhouse starrocks trino greenplum hive spark)
 DOCKER_COMPOSE=()
+STARTED_ADAPTERS=()
 
 usage() {
   cat <<'USAGE'
@@ -274,6 +275,13 @@ cleanup_all() {
   done
 }
 
+cleanup_started() {
+  local adapter
+  for adapter in "${STARTED_ADAPTERS[@]}"; do
+    compose_down "$adapter"
+  done
+}
+
 cleanup_only=0
 dry_run=0
 changed_mode=0
@@ -430,11 +438,10 @@ if [ "$dry_run" -eq 1 ]; then
 fi
 
 preflight
-trap cleanup_all EXIT
+trap cleanup_started EXIT
 
 for adapter in "${selected_adapters[@]}"; do
   compose_file="$(adapter_compose "$adapter")"
-  package="$(adapter_package "$adapter")"
   test_path="$(adapter_test_path "$adapter")"
 
   if [ ! -f "$compose_file" ]; then
@@ -449,6 +456,7 @@ for adapter in "${selected_adapters[@]}"; do
   echo ""
   echo "=== Integration tests: $adapter ==="
   compose_down "$adapter"
+  STARTED_ADAPTERS+=("$adapter")
   export_adapter_env "$adapter"
   docker_compose -f "$compose_file" up -d --build
 

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PACKAGE_SPECS=(
+  "datus-db-core:datus-db-core/tests/unit"
+  "datus-sqlalchemy:datus-sqlalchemy/tests/unit"
+  "datus-mysql:datus-mysql/tests/unit"
+  "datus-postgresql:datus-postgresql/tests/unit"
+  "datus-clickhouse:datus-clickhouse/tests/unit"
+  "datus-starrocks:datus-starrocks/tests/unit"
+  "datus-trino:datus-trino/tests/unit"
+  "datus-greenplum:datus-greenplum/tests/unit"
+  "datus-hive:datus-hive/tests/unit"
+  "datus-spark:datus-spark/tests/unit"
+  "datus-redshift:datus-redshift/tests/unit"
+  "datus-snowflake:datus-snowflake/tests"
+  "datus-clickzetta:datus-clickzetta/tests/unit"
+)
+
+usage() {
+  cat <<'USAGE'
+Usage: ci/run-unit-tests.sh [--list] [--dry-run] [package ...]
+
+Runs deterministic unit tests for DB adapter workspace packages.
+
+Options:
+  --list      List configured package targets.
+  --dry-run   Print selected package targets without running pytest.
+  -h, --help  Show this help.
+USAGE
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 127
+  fi
+}
+
+list_packages() {
+  local spec package test_path
+  for spec in "${PACKAGE_SPECS[@]}"; do
+    package="${spec%%:*}"
+    test_path="${spec#*:}"
+    printf '%s\t%s\n' "$package" "$test_path"
+  done
+}
+
+requested_packages=()
+dry_run=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --list)
+      list_packages
+      exit 0
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [ "$#" -gt 0 ]; do
+        requested_packages+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      requested_packages+=("$1")
+      shift
+      ;;
+  esac
+done
+
+should_run_package() {
+  local package="$1"
+  if [ "${#requested_packages[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  local requested
+  for requested in "${requested_packages[@]}"; do
+    if [ "$requested" = "$package" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+require_command uv
+
+for spec in "${PACKAGE_SPECS[@]}"; do
+  package="${spec%%:*}"
+  test_path="${spec#*:}"
+
+  if ! should_run_package "$package"; then
+    continue
+  fi
+
+  if [ ! -e "$test_path" ]; then
+    echo "Skipping $package: missing test path $test_path"
+    continue
+  fi
+
+  echo ""
+  echo "=== Unit tests: $package ==="
+  if [ "$dry_run" -eq 1 ]; then
+    echo "pytest target: $test_path"
+    continue
+  fi
+
+  uv run --all-packages --with pytest --with pandas --with pyarrow pytest "$test_path" -m "not integration" --tb=short --verbose
+done

--- a/datus-clickhouse/docker-compose.yml
+++ b/datus-clickhouse/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
   clickhouse:
     image: clickhouse/clickhouse-server:24.8
-    container_name: datus-clickhouse-test
     ports:
-      - "8123:8123"
-      - "9000:9000"
+      - "${CLICKHOUSE_HTTP_HOST_PORT:-8123}:8123"
+      - "${CLICKHOUSE_NATIVE_HOST_PORT:-9000}:9000"
     environment:
       - CLICKHOUSE_USER=default_user
       - CLICKHOUSE_PASSWORD=default_test

--- a/datus-greenplum/docker-compose.yml
+++ b/datus-greenplum/docker-compose.yml
@@ -1,12 +1,12 @@
 # Greenplum test environment
 # Usage: docker compose up -d
-# Connect: PGPASSWORD=pivotal psql -h localhost -p 15432 -U gpadmin -d test
+# Connect: PGPASSWORD=pivotal psql -h localhost -p ${GREENPLUM_HOST_PORT:-15432} -U gpadmin -d test
 
 services:
   greenplum:
     image: woblerr/greenplum:6.27.1
     ports:
-      - "15432:5432"
+      - "${GREENPLUM_HOST_PORT:-15432}:5432"
     environment:
       GREENPLUM_PASSWORD: pivotal
       GREENPLUM_DATABASE_NAME: test

--- a/datus-greenplum/tests/integration/test_sql_execution.py
+++ b/datus-greenplum/tests/integration/test_sql_execution.py
@@ -163,14 +163,14 @@ def test_exception_on_nonexistent_table(connector: GreenplumConnector):
 def test_full_name_with_schema(connector: GreenplumConnector):
     """Test full_name with schema."""
     full_name = connector.full_name(schema_name="myschema", table_name="mytable")
-    assert full_name == '"test"."myschema"."mytable"'
+    assert full_name == f'"{connector.database_name}"."myschema"."mytable"'
 
 
 @pytest.mark.integration
 def test_identifier(connector: GreenplumConnector):
     """Test identifier generation."""
     identifier = connector.identifier(schema_name="myschema", table_name="mytable")
-    assert identifier == "test.myschema.mytable"
+    assert identifier == f"{connector.database_name}.myschema.mytable"
 
 
 # ==================== Greenplum-Specific Tests ====================

--- a/datus-hive/docker-compose.yml
+++ b/datus-hive/docker-compose.yml
@@ -1,11 +1,10 @@
 services:
   hive-metastore:
     image: apache/hive:4.0.1
-    container_name: datus-hive-metastore
     environment:
       SERVICE_NAME: metastore
     ports:
-      - "9083:9083"
+      - "${HIVE_METASTORE_HOST_PORT:-9083}:9083"
     volumes:
       - hive_warehouse:/opt/hive/data/warehouse
     healthcheck:
@@ -17,14 +16,13 @@ services:
 
   hive-server:
     image: apache/hive:4.0.1
-    container_name: datus-hive-server
     environment:
       SERVICE_NAME: hiveserver2
       SERVICE_OPTS: "-Dhive.metastore.uris=thrift://hive-metastore:9083"
       IS_RESUME: "true"
     ports:
-      - "10000:10000"
-      - "10002:10002"
+      - "${HIVE_THRIFT_HOST_PORT:-10000}:10000"
+      - "${HIVE_WEBUI_HOST_PORT:-10002}:10002"
     depends_on:
       hive-metastore:
         condition: service_healthy

--- a/datus-mysql/docker-compose.yml
+++ b/datus-mysql/docker-compose.yml
@@ -1,16 +1,13 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0
-    container_name: datus-mysql-test
     environment:
       MYSQL_ROOT_PASSWORD: test_password
       MYSQL_DATABASE: test
       MYSQL_USER: test_user
       MYSQL_PASSWORD: test_password
     ports:
-      - "3306:3306"
+      - "${MYSQL_HOST_PORT:-3306}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ptest_password"]
       interval: 10s

--- a/datus-postgresql/docker-compose.yml
+++ b/datus-postgresql/docker-compose.yml
@@ -1,15 +1,12 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:16
-    container_name: datus-postgres-test
     environment:
       POSTGRES_DB: test
       POSTGRES_USER: test_user
       POSTGRES_PASSWORD: test_password
     ports:
-      - "5432:5432"
+      - "${POSTGRESQL_HOST_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U test_user -d test"]
       interval: 10s

--- a/datus-spark/docker-compose.yml
+++ b/datus-spark/docker-compose.yml
@@ -1,15 +1,14 @@
 services:
   spark-thrift:
     image: apache/spark:3.5.0
-    container_name: datus-spark-test
     command: >
       /opt/spark/sbin/start-thriftserver.sh
       --master local[*]
       --hiveconf hive.server2.thrift.port=10000
       --hiveconf hive.server2.thrift.bind.host=0.0.0.0
     ports:
-      - "10000:10000"  # Thrift port
-      - "4040:4040"    # Spark UI
+      - "${SPARK_THRIFT_HOST_PORT:-10000}:10000"  # Thrift port
+      - "${SPARK_UI_HOST_PORT:-4040}:4040"    # Spark UI
     environment:
       - SPARK_NO_DAEMONIZE=true
     healthcheck:

--- a/datus-starrocks/docker-compose.yml
+++ b/datus-starrocks/docker-compose.yml
@@ -1,12 +1,11 @@
 services:
   starrocks:
     image: starrocks/allin1-ubuntu:3.3.0
-    container_name: datus-starrocks-test
     environment:
       - TZ=Asia/Shanghai
     ports:
-      - "9030:9030"  # MySQL protocol port
-      - "8030:8030"  # HTTP port
+      - "${STARROCKS_QUERY_HOST_PORT:-9030}:9030"  # MySQL protocol port
+      - "${STARROCKS_HTTP_HOST_PORT:-8030}:8030"  # HTTP port
     healthcheck:
       test: ["CMD-SHELL", "mysql -h127.0.0.1 -P9030 -uroot -e 'SELECT 1' || exit 1"]
       interval: 10s

--- a/datus-starrocks/tests/integration/conftest.py
+++ b/datus-starrocks/tests/integration/conftest.py
@@ -48,6 +48,10 @@ def hive_catalog_setup() -> Generator[str, None, None]:
             )
             """
         )
+        try:
+            conn.get_databases(catalog_name=HIVE_CATALOG_NAME)
+        except Exception as e:
+            pytest.skip(f"Hive catalog not available: {e}")
         yield HIVE_CATALOG_NAME
     except Exception as e:
         pytest.skip(f"Failed to create Hive catalog: {e}")

--- a/datus-trino/docker-compose.yml
+++ b/datus-trino/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   trino:
     image: trinodb/trino:479
-    container_name: datus-trino-test
     ports:
       - "${TRINO_HOST_PORT:-8080}:8080"  # HTTP port
     healthcheck:


### PR DESCRIPTION
## Summary
- Replace the adapter test workflow with PR, merge_group, main, and manual entrypoints.
- Add repo-local unit and integration runners with impacted-adapter selection for PRs.
- Make integration docker-compose fixtures CI-safe with configurable ports and deterministic adapter setup.

## Validation
- bash -n ci/run-unit-tests.sh ci/run-integration-tests.sh
- ci/run-unit-tests.sh --list
- ci/run-integration-tests.sh --list
- ci/run-integration-tests.sh --dry-run --changed upstream/main
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck= -pyflakes= .github/workflows/test.yml
- Full unit runner passed.
- Integration slices passed locally: PostgreSQL 33, MySQL 31, ClickHouse 29, StarRocks 39 with 7 skipped, Trino 26, Greenplum 35, Hive 18, Spark 24.
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI pipeline for improved efficiency with separated unit and integration test jobs.
  * Enhanced integration test framework with automatic detection of changed adapters to optimize test execution.
  * Updated database adapter Docker configurations to use environment-variable-driven ports for greater flexibility in testing environments.
  * Improved test fixture reliability for database connectivity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->