### PR TITLE
[Enhancement] Limit adapter CI to PR and merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
       - synchronize
       - reopened
   merge_group:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         run: ci/run-unit-tests.sh
 
   integration-tests:
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     needs:
       - unit-tests
     runs-on: self-hosted
@@ -47,10 +48,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Fetch base branch
-        if: github.event_name == 'pull_request'
-        run: git fetch origin "${{ github.event.pull_request.base.ref }}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,12 +59,7 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Run impacted integration tests
-        if: github.event_name == 'pull_request'
-        run: ci/run-integration-tests.sh --changed "origin/${{ github.event.pull_request.base.ref }}"
-
       - name: Run full integration tests
-        if: github.event_name != 'pull_request'
         run: ci/run-integration-tests.sh
 
       - name: Stop integration services


### PR DESCRIPTION
## Summary
- Remove the main push trigger from Adapter CI.
- Keep pull request, merge queue, and manual dispatch triggers.
- Run PR Adapter CI as unit-only feedback.
- Run Docker-backed full integration only for merge queue and manual dispatch.

## Testing
- actionlint .github/workflows/test.yml
- git diff --check