### PR TITLE
[BugFix] PostgreSQL/Greenplum: case-insensitive fallback in get_schema/_get_metadata

### DIFF
--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -157,41 +157,52 @@ class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
         # Get metadata configuration
         metadata_config = _get_metadata_config(table_type)
 
+        safe_schema = schema_name.replace("'", "''") if schema_name else ""
+        sys_schemas = list(self._sys_schemas())
+
         if table_type == "mv":
             # pg_matviews is scoped to the current database connection.
             # Use a temporary connection if a different database is requested (thread-safe).
-            safe_schema = schema_name.replace("'", "''") if schema_name else ""
-            if schema_name:
-                where = f"schemaname = '{safe_schema}'"
-            else:
-                where = f"{list_to_in_str('schemaname not in', list(self._sys_schemas()))}"
+            base_query = "SELECT schemaname as table_schema, matviewname as table_name FROM pg_matviews"
 
-            query = f"""
-                SELECT schemaname as table_schema, matviewname as table_name
-                FROM pg_matviews
-                WHERE {where}
-            """
-            query_result = self._execute_pandas(query, database_name=database_name)
+            def _build_mv(case_insensitive: bool) -> str:
+                if schema_name:
+                    cmp = (
+                        f"lower(schemaname) = lower('{safe_schema}')"
+                        if case_insensitive
+                        else f"schemaname = '{safe_schema}'"
+                    )
+                else:
+                    cmp = list_to_in_str("schemaname not in", sys_schemas)
+                return f"{base_query} WHERE {cmp}"
+
+            query_result = self._execute_pandas(_build_mv(False), database_name=database_name)
+            if len(query_result) == 0 and schema_name:
+                query_result = self._execute_pandas(_build_mv(True), database_name=database_name)
+                self._raise_if_ambiguous_schema(query_result, schema_name)
         else:
             # Tables and views use information_schema (supports table_catalog filter)
-            safe_schema = schema_name.replace("'", "''") if schema_name else ""
             safe_db = database_name.replace("'", "''") if database_name else ""
-            if schema_name:
-                where = f"table_schema = '{safe_schema}'"
-            else:
-                where = f"{list_to_in_str('table_schema not in', list(self._sys_schemas()))}"
+            type_filter = (
+                list_to_in_str("and table_type in", metadata_config.table_types) if table_type == "table" else ""
+            )
+            base_query = f"SELECT table_schema, table_name FROM information_schema.{metadata_config.info_table}"
 
-            if table_type == "table":
-                type_filter = list_to_in_str("and table_type in", metadata_config.table_types)
-            else:
-                type_filter = ""
+            def _build_tv(case_insensitive: bool) -> str:
+                if schema_name:
+                    cmp = (
+                        f"lower(table_schema) = lower('{safe_schema}')"
+                        if case_insensitive
+                        else f"table_schema = '{safe_schema}'"
+                    )
+                else:
+                    cmp = list_to_in_str("table_schema not in", sys_schemas)
+                return f"{base_query} WHERE table_catalog = '{safe_db}' AND {cmp} {type_filter}"
 
-            query = f"""
-                SELECT table_schema, table_name
-                FROM information_schema.{metadata_config.info_table}
-                WHERE table_catalog = '{safe_db}' AND {where} {type_filter}
-            """
-            query_result = self._execute_pandas(query, database_name=database_name)
+            query_result = self._execute_pandas(_build_tv(False), database_name=database_name)
+            if len(query_result) == 0 and schema_name:
+                query_result = self._execute_pandas(_build_tv(True), database_name=database_name)
+                self._raise_if_ambiguous_schema(query_result, schema_name)
 
         # Format results
         result = []
@@ -390,36 +401,54 @@ class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
         safe_schema = schema_name.replace("'", "''") if schema_name else ""
         safe_table = table_name.replace("'", "''") if table_name else ""
 
-        # Use INFORMATION_SCHEMA to get schema with comments
-        sql = f"""
-            SELECT
-                c.column_name as field,
-                c.data_type as type,
-                c.is_nullable as nullable,
-                c.column_default as default_value,
-                CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_pk,
-                pgd.description as comment
-            FROM information_schema.columns c
-            LEFT JOIN (
-                SELECT kcu.column_name
-                FROM information_schema.table_constraints tc
-                JOIN information_schema.key_column_usage kcu
-                    ON tc.constraint_name = kcu.constraint_name
-                    AND tc.table_schema = kcu.table_schema
-                WHERE tc.constraint_type = 'PRIMARY KEY'
-                    AND tc.table_schema = '{safe_schema}'
-                    AND tc.table_name = '{safe_table}'
-            ) pk ON c.column_name = pk.column_name
-            LEFT JOIN pg_catalog.pg_statio_all_tables st
-                ON st.schemaname = c.table_schema AND st.relname = c.table_name
-            LEFT JOIN pg_catalog.pg_description pgd
-                ON pgd.objoid = st.relid AND pgd.objsubid = c.ordinal_position
-            WHERE c.table_catalog = '{safe_db}'
-              AND c.table_schema = '{safe_schema}'
-              AND c.table_name = '{safe_table}'
-            ORDER BY c.ordinal_position
-        """
-        query_result = self._execute_pandas(sql)
+        def _build_sql(case_insensitive: bool) -> str:
+            if case_insensitive:
+                schema_cmp = f"lower(c.table_schema) = lower('{safe_schema}')"
+                table_cmp = f"lower(c.table_name) = lower('{safe_table}')"
+                pk_schema_cmp = f"lower(tc.table_schema) = lower('{safe_schema}')"
+                pk_table_cmp = f"lower(tc.table_name) = lower('{safe_table}')"
+            else:
+                schema_cmp = f"c.table_schema = '{safe_schema}'"
+                table_cmp = f"c.table_name = '{safe_table}'"
+                pk_schema_cmp = f"tc.table_schema = '{safe_schema}'"
+                pk_table_cmp = f"tc.table_name = '{safe_table}'"
+            return f"""
+                SELECT
+                    c.table_schema as table_schema,
+                    c.table_name as table_name,
+                    c.column_name as field,
+                    c.data_type as type,
+                    c.is_nullable as nullable,
+                    c.column_default as default_value,
+                    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_pk,
+                    pgd.description as comment
+                FROM information_schema.columns c
+                LEFT JOIN (
+                    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+                    FROM information_schema.table_constraints tc
+                    JOIN information_schema.key_column_usage kcu
+                        ON tc.constraint_name = kcu.constraint_name
+                        AND tc.table_schema = kcu.table_schema
+                    WHERE tc.constraint_type = 'PRIMARY KEY'
+                        AND {pk_schema_cmp}
+                        AND {pk_table_cmp}
+                ) pk ON pk.table_schema = c.table_schema
+                    AND pk.table_name = c.table_name
+                    AND pk.column_name = c.column_name
+                LEFT JOIN pg_catalog.pg_statio_all_tables st
+                    ON st.schemaname = c.table_schema AND st.relname = c.table_name
+                LEFT JOIN pg_catalog.pg_description pgd
+                    ON pgd.objoid = st.relid AND pgd.objsubid = c.ordinal_position
+                WHERE c.table_catalog = '{safe_db}'
+                  AND {schema_cmp}
+                  AND {table_cmp}
+                ORDER BY c.table_schema, c.table_name, c.ordinal_position
+            """
+
+        query_result = self._execute_pandas(_build_sql(False))
+        if len(query_result) == 0:
+            query_result = self._execute_pandas(_build_sql(True))
+            self._raise_if_ambiguous_table(query_result, schema_name, table_name)
 
         result = []
         for i in range(len(query_result)):
@@ -435,6 +464,39 @@ class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
                 }
             )
         return result
+
+    # ==================== Case-insensitive Fallback Helpers ====================
+
+    @staticmethod
+    def _raise_if_ambiguous_schema(query_result, schema_name: str) -> None:
+        """Raise if a case-insensitive schema fallback matches more than one stored schema name.
+
+        Why: PostgreSQL stores identifiers in their literal case in information_schema. When a
+        case-insensitive fallback finds e.g. both ``Foo`` and ``foo`` schemas, returning their
+        union would silently mix unrelated objects.
+        """
+        if len(query_result) == 0:
+            return
+        distinct = set(query_result["table_schema"].unique())
+        if len(distinct) > 1:
+            raise DatusDbException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                f"Ambiguous schema_name '{schema_name}': case-insensitive match resolves to "
+                f"multiple stored schemas {sorted(distinct)}. Pass the exact (case-sensitive) name.",
+            )
+
+    @staticmethod
+    def _raise_if_ambiguous_table(query_result, schema_name: str, table_name: str) -> None:
+        """Raise if a case-insensitive table fallback matches more than one stored (schema,table)."""
+        if len(query_result) == 0:
+            return
+        distinct = set(zip(query_result["table_schema"], query_result["table_name"]))
+        if len(distinct) > 1:
+            raise DatusDbException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                f"Ambiguous table '{schema_name}.{table_name}': case-insensitive match resolves to "
+                f"multiple stored tables {sorted(distinct)}. Pass the exact (case-sensitive) name.",
+            )
 
     # ==================== Database/Schema Management ====================
 

--- a/datus-postgresql/tests/unit/test_connector_unit.py
+++ b/datus-postgresql/tests/unit/test_connector_unit.py
@@ -510,3 +510,181 @@ def test_close_disposes_all_cached_engines():
     for e in mock_engines:
         e.dispose.assert_called_once()
     assert len(connector._engines) == 0
+
+
+# ==================== Case-insensitive Fallback Tests ====================
+
+
+def _make_pg_connector_for_metadata(schema_name="public", database_name="testdb"):
+    """Helper: PostgreSQLConnector with mocked parent __init__ and a no-op connect()."""
+    config = PostgreSQLConfig(username="u", password="p", database=database_name, schema_name=schema_name)
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.__init__", return_value=None):
+        connector = PostgreSQLConnector(config)
+    connector.database_name = database_name
+    connector.schema_name = schema_name
+    connector.connect = MagicMock()
+    return connector
+
+
+_SCHEMA_COLS = [
+    "table_schema",
+    "table_name",
+    "field",
+    "type",
+    "nullable",
+    "default_value",
+    "is_pk",
+    "comment",
+]
+
+
+def _df(rows, columns):
+    import pandas as pd
+
+    return pd.DataFrame(rows, columns=columns)
+
+
+def test_get_schema_strict_match_hits_no_fallback():
+    """Exact case match returns rows from first query and never executes the lower() fallback."""
+    connector = _make_pg_connector_for_metadata()
+    df = _df(
+        [
+            ("public", "users", "id", "integer", "NO", None, True, None),
+            ("public", "users", "name", "text", "YES", None, False, None),
+        ],
+        _SCHEMA_COLS,
+    )
+    connector._execute_pandas = MagicMock(return_value=df)
+
+    result = connector.get_schema(schema_name="public", table_name="users")
+
+    assert connector._execute_pandas.call_count == 1
+    assert [c["name"] for c in result] == ["id", "name"]
+    assert result[0]["pk"] is True
+
+
+def test_get_schema_falls_back_to_lower_when_strict_empty():
+    """If strict match returns empty, fallback to lower() and use those rows."""
+    connector = _make_pg_connector_for_metadata()
+    empty = _df([], _SCHEMA_COLS)
+    fallback = _df(
+        [("public", "users", "id", "integer", "NO", None, True, None)],
+        _SCHEMA_COLS,
+    )
+    connector._execute_pandas = MagicMock(side_effect=[empty, fallback])
+
+    result = connector.get_schema(schema_name="PUBLIC", table_name="USERS")
+
+    assert connector._execute_pandas.call_count == 2
+    second_sql = connector._execute_pandas.call_args_list[1][0][0]
+    assert "lower(c.table_schema)" in second_sql
+    assert "lower(c.table_name)" in second_sql
+    assert len(result) == 1
+    assert result[0]["name"] == "id"
+
+
+def test_get_schema_lower_fallback_ambiguous_raises():
+    """If lower() fallback resolves to two distinct (schema,table) pairs, raise."""
+    connector = _make_pg_connector_for_metadata()
+    empty = _df([], _SCHEMA_COLS)
+    ambiguous = _df(
+        [
+            ("public", "Users", "id", "integer", "NO", None, True, None),
+            ("public", "users", "id", "integer", "NO", None, True, None),
+        ],
+        _SCHEMA_COLS,
+    )
+    connector._execute_pandas = MagicMock(side_effect=[empty, ambiguous])
+
+    with pytest.raises(DatusDbException, match="Ambiguous table"):
+        connector.get_schema(schema_name="public", table_name="USERS")
+
+
+def test_get_schema_both_queries_empty_returns_empty():
+    """If neither strict nor lower() fallback returns rows, return []."""
+    connector = _make_pg_connector_for_metadata()
+    empty = _df([], _SCHEMA_COLS)
+    connector._execute_pandas = MagicMock(side_effect=[empty, empty])
+
+    result = connector.get_schema(schema_name="public", table_name="missing")
+
+    assert result == []
+    assert connector._execute_pandas.call_count == 2
+
+
+def test_get_schema_empty_table_name_short_circuit():
+    """Empty table_name short-circuits before any SQL is executed."""
+    connector = _make_pg_connector_for_metadata()
+    connector._execute_pandas = MagicMock()
+
+    assert connector.get_schema(schema_name="public", table_name="") == []
+    connector._execute_pandas.assert_not_called()
+
+
+def test_get_metadata_strict_hit_no_fallback():
+    """_get_metadata uses only the strict query when it returns rows."""
+    connector = _make_pg_connector_for_metadata(schema_name="public")
+    df = _df([("public", "t1"), ("public", "t2")], ["table_schema", "table_name"])
+    connector._execute_pandas = MagicMock(return_value=df)
+
+    result = connector._get_metadata("table", schema_name="public")
+
+    assert connector._execute_pandas.call_count == 1
+    assert [m["table_name"] for m in result] == ["t1", "t2"]
+
+
+def test_get_metadata_falls_back_to_lower_when_strict_empty():
+    """_get_metadata falls back to lower() when strict returns empty and schema_name is provided."""
+    connector = _make_pg_connector_for_metadata(schema_name="public")
+    empty = _df([], ["table_schema", "table_name"])
+    fallback = _df([("public", "t1")], ["table_schema", "table_name"])
+    connector._execute_pandas = MagicMock(side_effect=[empty, fallback])
+
+    result = connector._get_metadata("table", schema_name="PUBLIC")
+
+    assert connector._execute_pandas.call_count == 2
+    second_sql = connector._execute_pandas.call_args_list[1][0][0]
+    assert "lower(table_schema)" in second_sql
+    assert [m["table_name"] for m in result] == ["t1"]
+
+
+def test_get_metadata_lower_fallback_ambiguous_raises():
+    """_get_metadata raises when lower() fallback resolves to multiple distinct schemas."""
+    connector = _make_pg_connector_for_metadata(schema_name="public")
+    empty = _df([], ["table_schema", "table_name"])
+    ambiguous = _df([("Public", "t1"), ("public", "t2")], ["table_schema", "table_name"])
+    connector._execute_pandas = MagicMock(side_effect=[empty, ambiguous])
+
+    with pytest.raises(DatusDbException, match="Ambiguous schema_name"):
+        connector._get_metadata("table", schema_name="PUBLIC")
+
+
+def test_get_metadata_no_schema_no_fallback():
+    """When schema_name is empty, _get_metadata excludes sys schemas and never falls back."""
+    connector = _make_pg_connector_for_metadata(schema_name="")
+    connector.schema_name = ""
+    df = _df([], ["table_schema", "table_name"])
+    connector._execute_pandas = MagicMock(return_value=df)
+
+    result = connector._get_metadata("table", schema_name="")
+
+    # Strict query already excludes sys schemas; no fallback for empty input
+    assert connector._execute_pandas.call_count == 1
+    sql = connector._execute_pandas.call_args_list[0][0][0]
+    assert "lower(" not in sql
+    assert result == []
+
+
+def test_get_metadata_mv_falls_back_to_lower_when_strict_empty():
+    """MV branch in _get_metadata also honors the case-insensitive fallback."""
+    connector = _make_pg_connector_for_metadata(schema_name="public")
+    empty = _df([], ["table_schema", "table_name"])
+    fallback = _df([("public", "mv1")], ["table_schema", "table_name"])
+    connector._execute_pandas = MagicMock(side_effect=[empty, fallback])
+
+    result = connector._get_metadata("mv", schema_name="PUBLIC")
+
+    assert connector._execute_pandas.call_count == 2
+    second_sql = connector._execute_pandas.call_args_list[1][0][0]
+    assert "lower(schemaname)" in second_sql
+    assert [m["table_name"] for m in result] == ["mv1"]


### PR DESCRIPTION

PostgreSQL stores identifiers in their literal case in information_schema, so the previous strict `=` comparisons silently returned empty results when callers passed a differently-cased schema/table name (e.g. "USERS" vs the stored "users" produced by unquoted CREATE TABLE).

Both methods now first run the strict-equality query and, only if it returns no rows, retry with `lower(...) = lower(...)`. If the fallback resolves to more than one stored (schema) or (schema, table) pair (rare; only happens when double-quoted mixed-case names coexist), raise DatusDbException so the caller is forced to pass the exact name rather than silently mixing unrelated objects.

Greenplum inherits PostgreSQLConnector and benefits automatically.

Adds 10 unit tests covering: strict hit, lower fallback hit, ambiguous fallback raise, both empty, empty input short-circuit, MV branch fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL connector now supports case-insensitive schema and table name matching, automatically falling back when exact-match queries return no results.

* **Bug Fixes**
  * Added ambiguity detection to raise clear errors when case-insensitive fallback resolves to multiple matches.

* **Tests**
  * Added comprehensive unit tests covering case-insensitive fallback scenarios and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->