### PR TITLE
[BugFix] Tighten MySQL compose readiness check

### DIFF
--- a/datus-mysql/docker-compose.yml
+++ b/datus-mysql/docker-compose.yml
@@ -9,7 +9,11 @@ services:
     ports:
       - "${MYSQL_HOST_PORT:-3306}:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ptest_password"]
+      test:
+        [
+          "CMD-SHELL",
+          "mysql --protocol=TCP -h 127.0.0.1 -P 3306 -u\"$${MYSQL_USER}\" -p\"$${MYSQL_PASSWORD}\" \"$${MYSQL_DATABASE}\" --connect-timeout=5 -e \"SELECT 1\" >/dev/null 2>&1",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Why

The MySQL compose healthcheck used `mysqladmin ping` with the root account inside the container. That can report healthy before the actual integration-test path (`test_user` against the `test` database over TCP) is ready.

## Solution

Update the MySQL healthcheck to run `SELECT 1` over TCP with `MYSQL_USER`, `MYSQL_PASSWORD`, and `MYSQL_DATABASE`, matching the adapter integration-test contract more closely.

## Test Cases

- `docker compose -f datus-mysql/docker-compose.yml config`
- Verified from Datus-agent nightly harness with `MYSQL_HOST_PORT=33306`; `tests/integration/adapters/test_mysql.py` passed all 6 cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved MySQL container health check to use configured database credentials and direct database connectivity verification instead of admin-based ping checks, enhancing reliability and security of deployment health monitoring.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->