### PR TITLE
[BugFix] Fix StarRocks integration readiness

### DIFF
--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -376,7 +376,53 @@ wait_for_adapter_client_readiness() {
     starrocks)
       uv run --package datus-starrocks python datus-starrocks/scripts/wait_for_starrocks.py --timeout "${STARROCKS_READY_TIMEOUT:-300}"
       ;;
+    greenplum)
+      wait_for_greenplum_client_readiness
+      ;;
   esac
+}
+
+wait_for_greenplum_client_readiness() {
+  local timeout_seconds="${GREENPLUM_READY_TIMEOUT:-300}"
+  local deadline=$((SECONDS + timeout_seconds))
+  local probe_output="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-greenplum-readiness-$$.log"
+
+  echo "Waiting for Greenplum client readiness at ${GREENPLUM_HOST:-127.0.0.1}:${GREENPLUM_PORT:-5432}/${GREENPLUM_DATABASE:-test}"
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if uv run --package datus-greenplum python - <<'PY' >"$probe_output" 2>&1; then
+import os
+
+import psycopg2
+
+conn = psycopg2.connect(
+    host=os.getenv("GREENPLUM_HOST", "127.0.0.1"),
+    port=int(os.getenv("GREENPLUM_PORT", "5432")),
+    user=os.getenv("GREENPLUM_USER", "gpadmin"),
+    password=os.getenv("GREENPLUM_PASSWORD", "pivotal"),
+    dbname=os.getenv("GREENPLUM_DATABASE", "test"),
+    connect_timeout=5,
+)
+try:
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT 1")
+        row = cursor.fetchone()
+        if not row or row[0] != 1:
+            raise RuntimeError(f"unexpected readiness result: {row!r}")
+finally:
+    conn.close()
+PY
+      echo "Greenplum client readiness probe succeeded"
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "Timed out waiting for Greenplum client readiness" >&2
+  if [ -s "$probe_output" ]; then
+    echo "Last Greenplum readiness probe output:" >&2
+    sed 's/^/  /' "$probe_output" >&2
+  fi
+  return 1
 }
 
 adapters_from_changed_files() {

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -373,53 +373,162 @@ wait_for_adapter_client_readiness() {
   local adapter="$1"
 
   case "$adapter" in
+    postgresql)
+      wait_for_python_connector_readiness "postgresql" "datus-postgresql"
+      ;;
+    mysql)
+      wait_for_python_connector_readiness "mysql" "datus-mysql"
+      ;;
+    clickhouse)
+      wait_for_python_connector_readiness "clickhouse" "datus-clickhouse"
+      ;;
     starrocks)
       uv run --package datus-starrocks python datus-starrocks/scripts/wait_for_starrocks.py --timeout "${STARROCKS_READY_TIMEOUT:-300}"
       ;;
+    trino)
+      wait_for_python_connector_readiness "trino" "datus-trino"
+      ;;
     greenplum)
-      wait_for_greenplum_client_readiness
+      wait_for_python_connector_readiness "greenplum" "datus-greenplum"
+      ;;
+    hive)
+      wait_for_python_connector_readiness "hive" "datus-hive"
+      ;;
+    spark)
+      wait_for_python_connector_readiness "spark" "datus-spark"
       ;;
   esac
 }
 
-wait_for_greenplum_client_readiness() {
-  local timeout_seconds="${GREENPLUM_READY_TIMEOUT:-300}"
-  local deadline=$((SECONDS + timeout_seconds))
-  local probe_output="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-greenplum-readiness-$$.log"
+wait_for_python_connector_readiness() {
+  local adapter="$1"
+  local package="$2"
+  local timeout_env_name
+  local timeout_seconds
+  local deadline
+  local probe_output
 
-  echo "Waiting for Greenplum client readiness at ${GREENPLUM_HOST:-127.0.0.1}:${GREENPLUM_PORT:-5432}/${GREENPLUM_DATABASE:-test}"
+  timeout_env_name="$(echo "${adapter}_READY_TIMEOUT" | tr '[:lower:]' '[:upper:]')"
+  timeout_seconds="${!timeout_env_name:-300}"
+  deadline=$((SECONDS + timeout_seconds))
+  probe_output="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-${adapter}-readiness-$$.log"
+
+  echo "Waiting for ${adapter} client readiness"
   while [ "$SECONDS" -lt "$deadline" ]; do
-    if uv run --package datus-greenplum python - <<'PY' >"$probe_output" 2>&1; then
+    if uv run --package "$package" --with pandas --with pyarrow python - "$adapter" <<'PY' >"$probe_output" 2>&1; then
 import os
+import sys
 
-import psycopg2
+adapter = sys.argv[1]
 
-conn = psycopg2.connect(
-    host=os.getenv("GREENPLUM_HOST", "127.0.0.1"),
-    port=int(os.getenv("GREENPLUM_PORT", "5432")),
-    user=os.getenv("GREENPLUM_USER", "gpadmin"),
-    password=os.getenv("GREENPLUM_PASSWORD", "pivotal"),
-    dbname=os.getenv("GREENPLUM_DATABASE", "test"),
-    connect_timeout=5,
-)
+if adapter == "postgresql":
+    from datus_postgresql import PostgreSQLConfig, PostgreSQLConnector
+
+    config = PostgreSQLConfig(
+        host=os.getenv("POSTGRESQL_HOST", "127.0.0.1"),
+        port=int(os.getenv("POSTGRESQL_PORT", "5432")),
+        username=os.getenv("POSTGRESQL_USER", "test_user"),
+        password=os.getenv("POSTGRESQL_PASSWORD", "test_password"),
+        database=os.getenv("POSTGRESQL_DATABASE", "test"),
+        schema_name=os.getenv("POSTGRESQL_SCHEMA", "public"),
+        timeout_seconds=5,
+    )
+    connector = PostgreSQLConnector(config)
+elif adapter == "mysql":
+    from datus_mysql import MySQLConfig, MySQLConnector
+
+    config = MySQLConfig(
+        host=os.getenv("MYSQL_HOST", "127.0.0.1"),
+        port=int(os.getenv("MYSQL_PORT", "3306")),
+        username=os.getenv("MYSQL_USER", "test_user"),
+        password=os.getenv("MYSQL_PASSWORD", "test_password"),
+        database=os.getenv("MYSQL_DATABASE", "test"),
+        timeout_seconds=5,
+    )
+    connector = MySQLConnector(config)
+elif adapter == "clickhouse":
+    from datus_clickhouse import ClickHouseConfig, ClickHouseConnector
+
+    config = ClickHouseConfig(
+        host=os.getenv("CLICKHOUSE_HOST", "127.0.0.1"),
+        port=int(os.getenv("CLICKHOUSE_PORT", "8123")),
+        username=os.getenv("CLICKHOUSE_USER", "default_user"),
+        password=os.getenv("CLICKHOUSE_PASSWORD", "default_test"),
+        database=os.getenv("CLICKHOUSE_DATABASE", "default_test"),
+        timeout_seconds=5,
+    )
+    connector = ClickHouseConnector(config)
+elif adapter == "trino":
+    from datus_trino import TrinoConfig, TrinoConnector
+
+    config = TrinoConfig(
+        host=os.getenv("TRINO_HOST", "127.0.0.1"),
+        port=int(os.getenv("TRINO_PORT", "8080")),
+        username=os.getenv("TRINO_USER", "trino"),
+        password=os.getenv("TRINO_PASSWORD", ""),
+        catalog=os.getenv("TRINO_CATALOG", "tpch"),
+        schema_name=os.getenv("TRINO_SCHEMA", "tiny"),
+        http_scheme=os.getenv("TRINO_HTTP_SCHEME", "http"),
+        timeout_seconds=5,
+    )
+    connector = TrinoConnector(config)
+elif adapter == "greenplum":
+    from datus_greenplum import GreenplumConfig, GreenplumConnector
+
+    config = GreenplumConfig(
+        host=os.getenv("GREENPLUM_HOST", "127.0.0.1"),
+        port=int(os.getenv("GREENPLUM_PORT", "5432")),
+        username=os.getenv("GREENPLUM_USER", "gpadmin"),
+        password=os.getenv("GREENPLUM_PASSWORD", "pivotal"),
+        database=os.getenv("GREENPLUM_DATABASE", "test"),
+        schema_name=os.getenv("GREENPLUM_SCHEMA", "public"),
+        timeout_seconds=5,
+    )
+    connector = GreenplumConnector(config)
+elif adapter == "hive":
+    from datus_hive import HiveConfig, HiveConnector
+
+    config = HiveConfig(
+        host=os.getenv("HIVE_HOST", "127.0.0.1"),
+        port=int(os.getenv("HIVE_PORT", "10000")),
+        username=os.getenv("HIVE_USERNAME", "hive"),
+        password=os.getenv("HIVE_PASSWORD", ""),
+        database=os.getenv("HIVE_DATABASE", "default"),
+        auth=os.getenv("HIVE_AUTH") or None,
+        timeout_seconds=5,
+    )
+    connector = HiveConnector(config)
+elif adapter == "spark":
+    from datus_spark import SparkConfig, SparkConnector
+
+    config = SparkConfig(
+        host=os.getenv("SPARK_HOST", "127.0.0.1"),
+        port=int(os.getenv("SPARK_PORT", "10000")),
+        username=os.getenv("SPARK_USER", "spark"),
+        password=os.getenv("SPARK_PASSWORD", ""),
+        database=os.getenv("SPARK_DATABASE", "default"),
+        auth_mechanism=os.getenv("SPARK_AUTH_MECHANISM", "NONE"),
+        timeout_seconds=5,
+    )
+    connector = SparkConnector(config)
+else:
+    raise RuntimeError(f"unsupported adapter readiness probe: {adapter}")
+
 try:
-    with conn.cursor() as cursor:
-        cursor.execute("SELECT 1")
-        row = cursor.fetchone()
-        if not row or row[0] != 1:
-            raise RuntimeError(f"unexpected readiness result: {row!r}")
+    if not connector.test_connection():
+        raise RuntimeError(f"{adapter} connector readiness test returned false")
 finally:
-    conn.close()
+    connector.close()
 PY
-      echo "Greenplum client readiness probe succeeded"
+      echo "${adapter} client readiness probe succeeded"
       return 0
     fi
     sleep 5
   done
 
-  echo "Timed out waiting for Greenplum client readiness" >&2
+  echo "Timed out waiting for ${adapter} client readiness" >&2
   if [ -s "$probe_output" ]; then
-    echo "Last Greenplum readiness probe output:" >&2
+    echo "Last ${adapter} readiness probe output:" >&2
     sed 's/^/  /' "$probe_output" >&2
   fi
   return 1

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -369,6 +369,16 @@ wait_for_service_health() {
   return 1
 }
 
+wait_for_adapter_client_readiness() {
+  local adapter="$1"
+
+  case "$adapter" in
+    starrocks)
+      uv run --package datus-starrocks python datus-starrocks/scripts/wait_for_starrocks.py --timeout "${STARROCKS_READY_TIMEOUT:-300}"
+      ;;
+  esac
+}
+
 adapters_from_changed_files() {
   local base_ref="$1"
   local changed_files=""
@@ -443,6 +453,7 @@ trap cleanup_started EXIT
 for adapter in "${selected_adapters[@]}"; do
   compose_file="$(adapter_compose "$adapter")"
   test_path="$(adapter_test_path "$adapter")"
+  package="$(adapter_package "$adapter")"
 
   if [ ! -f "$compose_file" ]; then
     echo "Missing compose file for $adapter: $compose_file" >&2
@@ -465,8 +476,9 @@ for adapter in "${selected_adapters[@]}"; do
     timeout_seconds="${spec##*:}"
     wait_for_service_health "$compose_file" "$service_name" "$timeout_seconds"
   done
+  wait_for_adapter_client_readiness "$adapter"
 
-  uv run --all-packages --with pytest --with pandas --with pyarrow pytest "$test_path" -m integration --tb=short --verbose
+  uv run --package "$package" --with pytest --with pandas --with pyarrow pytest "$test_path" -m integration --tb=short --verbose
 
   compose_down "$adapter"
 done

--- a/datus-starrocks/README.md
+++ b/datus-starrocks/README.md
@@ -161,9 +161,8 @@ result = connector.execute_query(f"SELECT * FROM {full_name} LIMIT 10")
 
 ```bash
 # 1. Start StarRocks test container
-docker compose up -d && sleep 60
-docker exec datus-starrocks-test mysql -h127.0.0.1 -P9030 -uroot \
-  -e "CREATE DATABASE IF NOT EXISTS test;"
+docker compose up -d
+uv run python scripts/wait_for_starrocks.py
 
 # 2. Run tests
 ./scripts/test.sh unit         # Unit tests (60 tests, ~0.03s)
@@ -178,9 +177,8 @@ TPC-H integration tests use a simplified TPC-H dataset (5 tables: region, nation
 
 ```bash
 # Start StarRocks and create test database
-docker compose up -d && sleep 60
-docker exec datus-starrocks-test mysql -h127.0.0.1 -P9030 -uroot \
-  -e "CREATE DATABASE IF NOT EXISTS test;"
+docker compose up -d
+uv run python scripts/wait_for_starrocks.py
 
 # Initialize TPC-H test data
 uv run python scripts/init_tpch_data.py

--- a/datus-starrocks/scripts/init_tpch_data.py
+++ b/datus-starrocks/scripts/init_tpch_data.py
@@ -88,6 +88,7 @@ def main():
         port=args.port,
         username=args.username,
         password=args.password,
+        catalog=args.catalog,
         database=args.database,
     )
     try:

--- a/datus-starrocks/scripts/init_tpch_data.py
+++ b/datus-starrocks/scripts/init_tpch_data.py
@@ -8,11 +8,7 @@ Initialize TPC-H sample data in StarRocks.
 
 Usage:
     # Start StarRocks first:
-    cd datus-starrocks && docker compose up -d && sleep 60
-
-    # Create test database:
-    docker exec datus-starrocks-test mysql -h127.0.0.1 -P9030 -uroot \
-        -e "CREATE DATABASE IF NOT EXISTS test;"
+    cd datus-starrocks && docker compose up -d
 
     # Then run this script:
     uv run python scripts/init_tpch_data.py
@@ -25,9 +21,16 @@ import argparse
 import logging
 import os
 import sys
+from pathlib import Path
 
 # Suppress adapter registry warnings in workspace dev environment
 logging.getLogger("datus.tools.db_tools.registry").setLevel(logging.ERROR)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from wait_for_starrocks import StarRocksReadinessConfig, wait_for_starrocks_ready  # noqa: E402
 
 from datus_starrocks import StarRocksConfig, StarRocksConnector  # noqa: E402
 from datus_starrocks.tpch_data import ROW_COUNTS, TPCH_DATA, TPCH_DDL, TPCH_TABLES  # noqa: E402
@@ -71,9 +74,30 @@ def main():
         action="store_true",
         help="Drop existing TPC-H tables before creating",
     )
+    parser.add_argument(
+        "--wait-timeout",
+        type=int,
+        default=int(os.getenv("STARROCKS_READY_TIMEOUT", "300")),
+        help="Seconds to wait for StarRocks FE/BE readiness before loading data (default: 300)",
+    )
     args = parser.parse_args()
 
     print(f"Connecting to StarRocks at {args.host}:{args.port}...")
+    readiness_config = StarRocksReadinessConfig(
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        database=args.database,
+    )
+    try:
+        detail = wait_for_starrocks_ready(readiness_config, timeout=args.wait_timeout, interval=5)
+        print(f"StarRocks readiness check passed: {detail}")
+    except TimeoutError as e:
+        print(f"Failed to connect to StarRocks: {e}")
+        print("  Start it with: cd datus-starrocks && docker compose up -d")
+        sys.exit(1)
+
     config = StarRocksConfig(
         host=args.host,
         port=args.port,
@@ -86,7 +110,7 @@ def main():
 
     if not conn.test_connection():
         print("Failed to connect to StarRocks. Is the server running?")
-        print("  Start it with: cd datus-starrocks && docker compose up -d && sleep 60")
+        print("  Start it with: cd datus-starrocks && docker compose up -d")
         sys.exit(1)
 
     print("Connected successfully!")

--- a/datus-starrocks/scripts/test.sh
+++ b/datus-starrocks/scripts/test.sh
@@ -4,19 +4,27 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PACKAGE_DIR"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Force set test environment variables (override production values)
-export STARROCKS_HOST="localhost"
-export STARROCKS_PORT="9030"
-export STARROCKS_USER="root"
-export STARROCKS_PASSWORD=""
-export STARROCKS_CATALOG="default_catalog"
-export STARROCKS_DATABASE="test"
+# Set test defaults without overriding caller-provided values.
+export STARROCKS_HOST="${STARROCKS_HOST:-localhost}"
+export STARROCKS_PORT="${STARROCKS_PORT:-9030}"
+export STARROCKS_USER="${STARROCKS_USER:-root}"
+export STARROCKS_PASSWORD="${STARROCKS_PASSWORD:-}"
+export STARROCKS_CATALOG="${STARROCKS_CATALOG:-default_catalog}"
+export STARROCKS_DATABASE="${STARROCKS_DATABASE:-test}"
+
+wait_for_starrocks() {
+    uv run python scripts/wait_for_starrocks.py --timeout "${STARROCKS_READY_TIMEOUT:-300}"
+}
 
 # Function to run tests
 run_unit_tests() {
@@ -27,6 +35,7 @@ run_unit_tests() {
 run_integration_tests() {
     echo -e "${GREEN}Running integration tests (requires StarRocks)...${NC}"
     echo -e "${YELLOW}Using: ${STARROCKS_USER}@${STARROCKS_HOST}:${STARROCKS_PORT}/${STARROCKS_DATABASE}${NC}"
+    wait_for_starrocks
     uv run pytest tests/integration -v
 }
 
@@ -35,6 +44,7 @@ run_acceptance_tests() {
     echo -e "${YELLOW}Unit tests:${NC}"
     uv run pytest tests/ -m "acceptance and not integration" -v
     echo -e "\n${YELLOW}Integration tests:${NC}"
+    wait_for_starrocks
     uv run pytest tests/ -m "acceptance and integration" -v
 }
 

--- a/datus-starrocks/scripts/wait_for_starrocks.py
+++ b/datus-starrocks/scripts/wait_for_starrocks.py
@@ -86,7 +86,8 @@ def check_starrocks_ready(config: StarRocksReadinessConfig) -> str:
                     """
                 )
                 cursor.execute(f"DROP TABLE IF EXISTS {quote_identifier(probe_table)}")
-            return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+                return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+            return f"{backend_detail}; no database DDL probe requested"
     finally:
         conn.close()
 

--- a/datus-starrocks/scripts/wait_for_starrocks.py
+++ b/datus-starrocks/scripts/wait_for_starrocks.py
@@ -22,6 +22,7 @@ class StarRocksReadinessConfig:
     port: int
     username: str
     password: str
+    catalog: str
     database: str
 
 
@@ -29,8 +30,27 @@ def quote_identifier(identifier: str) -> str:
     return "`" + identifier.replace("`", "``") + "`"
 
 
+def table_identifier(catalog: str, database: str, table: str) -> str:
+    parts = [part for part in (catalog, database, table) if part]
+    return ".".join(quote_identifier(part) for part in parts)
+
+
 def is_alive(value: object) -> bool:
     return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
 
 
 def check_starrocks_ready(config: StarRocksReadinessConfig) -> str:
@@ -72,11 +92,13 @@ def check_starrocks_ready(config: StarRocksReadinessConfig) -> str:
                 backend_detail = f"{len(alive_rows)} alive backend(s)"
 
             if config.database:
+                if config.catalog:
+                    cursor.execute(f"SET CATALOG {quote_identifier(config.catalog)}")
                 cursor.execute(f"CREATE DATABASE IF NOT EXISTS {quote_identifier(config.database)}")
-                cursor.execute(f"USE {quote_identifier(config.database)}")
+                full_probe_table = table_identifier(config.catalog, config.database, probe_table)
                 cursor.execute(
                     f"""
-                    CREATE TABLE {quote_identifier(probe_table)} (
+                    CREATE TABLE {full_probe_table} (
                         `id` INT
                     )
                     ENGINE=OLAP
@@ -85,7 +107,7 @@ def check_starrocks_ready(config: StarRocksReadinessConfig) -> str:
                     PROPERTIES ("replication_num" = "1")
                     """
                 )
-                cursor.execute(f"DROP TABLE IF EXISTS {quote_identifier(probe_table)}")
+                cursor.execute(f"DROP TABLE IF EXISTS {full_probe_table}")
                 return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
             return f"{backend_detail}; no database DDL probe requested"
     finally:
@@ -115,9 +137,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=int(os.getenv("STARROCKS_PORT", "9030")))
     parser.add_argument("--username", default=os.getenv("STARROCKS_USER", "root"))
     parser.add_argument("--password", default=os.getenv("STARROCKS_PASSWORD", ""))
+    parser.add_argument("--catalog", default=os.getenv("STARROCKS_CATALOG", "default_catalog"))
     parser.add_argument("--database", default=os.getenv("STARROCKS_DATABASE", "test"))
-    parser.add_argument("--timeout", type=int, default=int(os.getenv("STARROCKS_READY_TIMEOUT", "300")))
-    parser.add_argument("--interval", type=float, default=float(os.getenv("STARROCKS_READY_INTERVAL", "5")))
+    parser.add_argument(
+        "--timeout", type=positive_int, default=positive_int(os.getenv("STARROCKS_READY_TIMEOUT", "300"))
+    )
+    parser.add_argument(
+        "--interval",
+        type=positive_float,
+        default=positive_float(os.getenv("STARROCKS_READY_INTERVAL", "5")),
+    )
     return parser
 
 
@@ -128,10 +157,11 @@ def main() -> int:
         port=args.port,
         username=args.username,
         password=args.password,
+        catalog=args.catalog,
         database=args.database,
     )
 
-    print(f"Waiting for StarRocks at {config.host}:{config.port}/{config.database}...", flush=True)
+    print(f"Waiting for StarRocks at {config.host}:{config.port}/{config.catalog}/{config.database}...", flush=True)
     try:
         detail = wait_for_starrocks_ready(config, timeout=args.timeout, interval=args.interval)
     except TimeoutError as exc:

--- a/datus-starrocks/scripts/wait_for_starrocks.py
+++ b/datus-starrocks/scripts/wait_for_starrocks.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Wait until StarRocks can run test DDL safely."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+
+import pymysql
+
+
+@dataclass(frozen=True)
+class StarRocksReadinessConfig:
+    host: str
+    port: int
+    username: str
+    password: str
+    database: str
+
+
+def quote_identifier(identifier: str) -> str:
+    return "`" + identifier.replace("`", "``") + "`"
+
+
+def is_alive(value: object) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def check_starrocks_ready(config: StarRocksReadinessConfig) -> str:
+    backend_detail = "backend status not checked"
+    probe_table = f"__datus_starrocks_readiness_probe_{os.getpid()}_{int(time.time() * 1000)}"
+    conn = pymysql.connect(
+        host=config.host,
+        port=config.port,
+        user=config.username,
+        password=config.password,
+        charset="utf8mb4",
+        autocommit=True,
+        connect_timeout=5,
+        read_timeout=5,
+        write_timeout=5,
+    )
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            row = cursor.fetchone()
+            if not row or row[0] != 1:
+                raise RuntimeError(f"unexpected SELECT 1 result: {row!r}")
+
+            try:
+                cursor.execute("SHOW BACKENDS")
+            except pymysql.err.OperationalError as exc:
+                if not exc.args or exc.args[0] != 5203:
+                    raise
+                backend_detail = "backend status unavailable without SYSTEM OPERATE/NODE privilege"
+            else:
+                rows = cursor.fetchall()
+                columns = [description[0] for description in cursor.description or []]
+                alive_index = next((index for index, column in enumerate(columns) if column.lower() == "alive"), None)
+                if alive_index is None:
+                    raise RuntimeError(f"SHOW BACKENDS did not return an Alive column: {columns!r}")
+                alive_rows = [row for row in rows if is_alive(row[alive_index])]
+                if not alive_rows:
+                    raise RuntimeError(f"SHOW BACKENDS has no alive backend: columns={columns!r} rows={rows!r}")
+                backend_detail = f"{len(alive_rows)} alive backend(s)"
+
+            if config.database:
+                cursor.execute(f"CREATE DATABASE IF NOT EXISTS {quote_identifier(config.database)}")
+                cursor.execute(f"USE {quote_identifier(config.database)}")
+                cursor.execute(
+                    f"""
+                    CREATE TABLE {quote_identifier(probe_table)} (
+                        `id` INT
+                    )
+                    ENGINE=OLAP
+                    DUPLICATE KEY(`id`)
+                    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                    PROPERTIES ("replication_num" = "1")
+                    """
+                )
+                cursor.execute(f"DROP TABLE IF EXISTS {quote_identifier(probe_table)}")
+            return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+    finally:
+        conn.close()
+
+
+def wait_for_starrocks_ready(config: StarRocksReadinessConfig, timeout: int, interval: float) -> str:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            return check_starrocks_ready(config)
+        except Exception as exc:  # noqa: BLE001 - readiness probes report the last failure.
+            last_error = exc
+            time.sleep(interval)
+
+    if last_error is None:
+        raise TimeoutError(f"timed out after {timeout}s waiting for StarRocks readiness")
+    message = f"timed out after {timeout}s waiting for StarRocks readiness; last error: {last_error}"
+    raise TimeoutError(message) from last_error
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("STARROCKS_HOST", "localhost"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("STARROCKS_PORT", "9030")))
+    parser.add_argument("--username", default=os.getenv("STARROCKS_USER", "root"))
+    parser.add_argument("--password", default=os.getenv("STARROCKS_PASSWORD", ""))
+    parser.add_argument("--database", default=os.getenv("STARROCKS_DATABASE", "test"))
+    parser.add_argument("--timeout", type=int, default=int(os.getenv("STARROCKS_READY_TIMEOUT", "300")))
+    parser.add_argument("--interval", type=float, default=float(os.getenv("STARROCKS_READY_INTERVAL", "5")))
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    config = StarRocksReadinessConfig(
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        database=args.database,
+    )
+
+    print(f"Waiting for StarRocks at {config.host}:{config.port}/{config.database}...", flush=True)
+    try:
+        detail = wait_for_starrocks_ready(config, timeout=args.timeout, interval=args.interval)
+    except TimeoutError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"StarRocks readiness check passed: {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a StarRocks readiness helper that waits for the service to accept real OLAP DDL, not just TCP/SELECT 1.
- Use the helper from the StarRocks test runner, TPC-H data loader, and workspace integration runner.
- Run integration tests with the selected adapter package instead of `--all-packages`, avoiding unrelated package dependency failures.
- Update StarRocks README test instructions to use the readiness helper instead of fixed sleeps.

## Root cause
The StarRocks compose healthcheck could pass before FE had a live BE heartbeat, so test DDL could fail with `Current alive backend is []`. The workspace integration runner also installed every package even for a single adapter, which made unrelated dependencies part of the adapter signal.

## Validation
- `bash -n ci/run-integration-tests.sh`
- `bash -n datus-starrocks/scripts/test.sh`
- `uv run --package datus-starrocks python -m py_compile datus-starrocks/scripts/wait_for_starrocks.py datus-starrocks/scripts/init_tpch_data.py`
- `uv run --package datus-starrocks --with ruff==0.15.6 ruff check datus-starrocks/scripts/wait_for_starrocks.py datus-starrocks/scripts/init_tpch_data.py`
- `STARROCKS_READY_TIMEOUT=420 ci/run-integration-tests.sh starrocks` -> 40 passed, 7 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by adding adapter-specific readiness checks (StarRocks and Greenplum) and running tests per-adapter after readiness.

* **New Features**
  * Added a reusable StarRocks readiness probe with configurable timeout and retries.

* **Documentation**
  * Updated testing instructions to use readiness checks instead of fixed sleeps.

* **Chores**
  * Made StarRocks test configuration more flexible via environment-variable defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/59)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->