### PR TITLE
[Tool] Release DB adapter package versions

### DIFF
--- a/datus-db-core/pyproject.toml
+++ b/datus-db-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-db-core"
-version = "0.1.3"
+version = "0.1.4"
 description = "Core database abstractions for Datus adapters"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-greenplum/pyproject.toml
+++ b/datus-greenplum/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.3",
+    "datus-db-core>=0.1.4",
     "datus-sqlalchemy>=0.1.6",
-    "datus-postgresql>=0.1.5",
+    "datus-postgresql>=0.1.6",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",
 ]

--- a/datus-postgresql/pyproject.toml
+++ b/datus-postgresql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-postgresql"
-version = "0.1.5"
+version = "0.1.6"
 description = "PostgreSQL database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "datus-db-core>=0.1.3",
+    "datus-db-core>=0.1.4",
     "datus-sqlalchemy>=0.1.6",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Why

Publish the latest upstream DB adapter changes to PyPI so datus-agent can depend on released packages instead of unpublished source state.

## Solution

- bump `datus-db-core` to `0.1.4`
- bump `datus-postgresql` to `0.1.6` and require `datus-db-core>=0.1.4`
- keep `datus-greenplum` at `0.1.3` and update its lower bounds to the newly published DB packages

## Published Packages

- https://pypi.org/project/datus-db-core/0.1.4/
- https://pypi.org/project/datus-postgresql/0.1.6/
- https://pypi.org/project/datus-greenplum/0.1.3/

## Validation

- `uv run --group dev pytest datus-db-core/tests -q`
- `uv run --group dev pytest datus-postgresql/tests -m 'not integration' -q`
- `uv run --group dev pytest datus-greenplum/tests -m 'not integration' -q`
- `uv build --package datus-db-core --out-dir dist-release`
- `uv build --package datus-postgresql --out-dir dist-release`
- `uv build --package datus-greenplum --out-dir dist-release`
- `uvx twine check dist-release/*`
- clean install smoke from PyPI for `datus-greenplum==0.1.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions and dependency constraints across adapter packages to maintain compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->