### PR TITLE
[Tool] Add direct package publish workflow

### DIFF
--- a/.github/workflows/package-release-readiness.yml
+++ b/.github/workflows/package-release-readiness.yml
@@ -4,9 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: "Workspace package to validate, for example one tool.uv.workspace member"
+        description: "Workspace adapter package to validate"
         required: true
-        type: string
+        type: choice
+        options:
+          - datus-db-core
+          - datus-sqlalchemy
+          - datus-mysql
+          - datus-postgresql
+          - datus-starrocks
+          - datus-snowflake
+          - datus-clickzetta
+          - datus-clickhouse
+          - datus-hive
+          - datus-redshift
+          - datus-spark
+          - datus-trino
+          - datus-greenplum
       expected_version:
         description: "Expected package version, for example 0.1.5"
         required: true

--- a/.github/workflows/prepare-package-release-pr.yml
+++ b/.github/workflows/prepare-package-release-pr.yml
@@ -4,9 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: "Workspace package to release, for example one tool.uv.workspace member"
+        description: "Workspace adapter package to release"
         required: true
-        type: string
+        type: choice
+        options:
+          - datus-db-core
+          - datus-sqlalchemy
+          - datus-mysql
+          - datus-postgresql
+          - datus-starrocks
+          - datus-snowflake
+          - datus-clickzetta
+          - datus-clickhouse
+          - datus-hive
+          - datus-redshift
+          - datus-spark
+          - datus-trino
+          - datus-greenplum
       version:
         description: "New canonical package version, for example 0.1.5"
         required: true
@@ -107,7 +121,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout -B "${branch}"
-          git add */pyproject.toml
+          git add -- ./*/pyproject.toml
           git commit -m "chore: prepare ${PACKAGE} ${VERSION} release"
           git push --force-with-lease origin "${branch}"
 

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -1,0 +1,280 @@
+name: "Publish Package Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Workspace adapter package to release"
+        required: true
+        type: choice
+        options:
+          - datus-db-core
+          - datus-sqlalchemy
+          - datus-mysql
+          - datus-postgresql
+          - datus-starrocks
+          - datus-snowflake
+          - datus-clickzetta
+          - datus-clickhouse
+          - datus-hive
+          - datus-redshift
+          - datus-spark
+          - datus-trino
+          - datus-greenplum
+      version:
+        description: "Release version. Use auto to publish the latest PyPI version + 0.0.1 without downgrading main."
+        required: false
+        default: "auto"
+        type: string
+      update_dependent_bounds:
+        description: "Update lower bounds in workspace packages that depend on this package"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-package-release-${{ inputs.package }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: Pypi Publish
+    steps:
+      - name: Checkout latest main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install release tooling
+        run: pip install packaging twine
+
+      - name: Resolve release version
+        id: resolve
+        env:
+          PACKAGE_NAME: ${{ inputs.package }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          from packaging.version import Version
+
+          from ci.package_release import (
+              load_workspace_packages,
+              parse_canonical_version,
+              require_package,
+          )
+
+          package_name = os.environ["PACKAGE_NAME"].strip()
+          requested_version = os.environ.get("REQUESTED_VERSION", "").strip()
+
+
+          def pypi_json(path: str) -> dict | None:
+              url = f"https://pypi.org/pypi/{path}/json"
+              try:
+                  with urllib.request.urlopen(url, timeout=20) as response:
+                      return json.loads(response.read().decode("utf-8"))
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return None
+                  raise
+
+
+          def latest_pypi_version(package: str) -> Version | None:
+              payload = pypi_json(package)
+              if payload is None:
+                  return None
+              return Version(payload["info"]["version"])
+
+
+          def pypi_version_exists(package: str, version: Version) -> bool:
+              return pypi_json(f"{package}/{version}") is not None
+
+
+          def bump_patch(version: Version) -> Version:
+              release = list(version.release)
+              while len(release) < 3:
+                  release.append(0)
+              release[2] += 1
+              return Version(".".join(str(part) for part in release[:3]))
+
+
+          packages = load_workspace_packages()
+          target = require_package(packages, package_name)
+          current_version = target.version
+          latest_version = latest_pypi_version(target.name)
+
+          if requested_version and requested_version.lower() != "auto":
+              target_version = parse_canonical_version(requested_version)
+          else:
+              default_base = latest_version or current_version
+              target_version = max(bump_patch(default_base), current_version)
+
+          if target_version < current_version:
+              raise ValueError(
+                  f"Refusing to downgrade {target.name}: pyproject has {current_version}, requested {target_version}"
+              )
+          if pypi_version_exists(target.name, target_version):
+              raise ValueError(f"{target.name} {target_version} already exists on PyPI")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"package={target.name}", file=output)
+              print(f"version={target_version}", file=output)
+              print(f"tag={target.name}-v{target_version}", file=output)
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              print(f"### {target.name} release", file=summary)
+              print(f"- Current main version: `{current_version}`", file=summary)
+              print(f"- Latest PyPI version: `{latest_version or '<none>'}`", file=summary)
+              print(f"- Release version: `{target_version}`", file=summary)
+          PY
+
+      - name: Prepare release metadata
+        run: |
+          set -euo pipefail
+          args=(
+            --package "${{ steps.resolve.outputs.package }}"
+            --version "${{ steps.resolve.outputs.version }}"
+            --allow-current-version
+            --allow-no-changes
+          )
+          if [[ "${{ inputs.update_dependent_bounds }}" == "true" ]]; then
+            args+=(--update-dependent-bounds)
+          else
+            args+=(--no-update-dependent-bounds)
+          fi
+          python3 ci/prepare_package_release.py "${args[@]}"
+
+      - name: Validate package release
+        run: |
+          set -euo pipefail
+          args=(
+            --package "${{ steps.resolve.outputs.package }}"
+            --expected-version "${{ steps.resolve.outputs.version }}"
+            --check-tag-available
+            --build
+          )
+          if [[ "${{ inputs.update_dependent_bounds }}" == "true" ]]; then
+            args+=(--check-dependent-bounds)
+          fi
+          python3 ci/check_package_release_readiness.py "${args[@]}"
+
+          if ci/run-unit-tests.sh --list | awk '{print $1}' | grep -Fx "${{ steps.resolve.outputs.package }}" >/dev/null; then
+            ci/run-unit-tests.sh "${{ steps.resolve.outputs.package }}"
+          else
+            echo "No package-scoped unit-test target configured for ${{ steps.resolve.outputs.package }}"
+          fi
+
+          git diff --check
+
+      - name: Build release artifacts
+        run: |
+          set -euo pipefail
+          rm -rf dist/release
+          uv build --package "${{ steps.resolve.outputs.package }}" --out-dir dist/release
+          python -m twine check dist/release/*
+
+      - name: Commit version and tag release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ steps.resolve.outputs.package }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git diff --check
+          git add -- ./*/pyproject.toml
+          if git diff --cached --quiet; then
+            echo "${PACKAGE} already declares ${VERSION}"
+          else
+            git commit -m "chore: release ${PACKAGE} ${VERSION}"
+          fi
+
+          git fetch --tags origin
+          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists" >&2
+            exit 1
+          fi
+
+          git tag -a "${TAG}" -m "Release ${PACKAGE} ${VERSION}"
+          git push --atomic origin HEAD:main "refs/tags/${TAG}"
+
+      - name: Publish to PyPI
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          password="${PYPI_PASSWORD:-${PYPI_API_TOKEN:-${PYPI_TOKEN:-}}}"
+          if [ -z "${password}" ]; then
+            echo "Missing PyPI password/token secret" >&2
+            exit 1
+          fi
+
+          if [ -n "${PYPI_USERNAME:-}" ]; then
+            username="${PYPI_USERNAME}"
+          elif [ -n "${PYPI_PASSWORD:-}" ]; then
+            username="transform_data"
+          else
+            username="__token__"
+          fi
+
+          python -m twine upload --non-interactive --username "${username}" --password "${password}" dist/release/*
+
+      - name: Verify PyPI release
+        env:
+          PACKAGE: ${{ steps.resolve.outputs.package }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          import time
+          import urllib.request
+
+          package = os.environ["PACKAGE"]
+          version = os.environ["VERSION"]
+          url = f"https://pypi.org/pypi/{package}/{version}/json"
+          for attempt in range(12):
+              try:
+                  with urllib.request.urlopen(url, timeout=20) as response:
+                      response.read()
+                  print(f"Verified {package} {version} on PyPI")
+                  break
+              except Exception as exc:
+                  if attempt == 11:
+                      raise
+                  print(f"PyPI verification attempt {attempt + 1} failed: {exc}")
+                  time.sleep(10)
+          PY

--- a/ci/prepare_package_release.py
+++ b/ci/prepare_package_release.py
@@ -31,6 +31,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=True,
         help="Update lower bounds in workspace packages that depend on the released package",
     )
+    parser.add_argument(
+        "--allow-current-version",
+        action="store_true",
+        help="Allow release preparation when the target package already declares the requested version",
+    )
+    parser.add_argument(
+        "--allow-no-changes",
+        action="store_true",
+        help="Treat already-prepared release metadata as success",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Validate and print planned changes without writing")
     return parser
 
@@ -42,7 +52,7 @@ def main(argv: list[str] | None = None) -> int:
         version = parse_canonical_version(args.version)
         packages = load_workspace_packages(repo_root)
         target = require_package(packages, args.package)
-        if version <= target.version:
+        if version < target.version or (version == target.version and not args.allow_current_version):
             raise ValueError(
                 f"Release version must advance current {target.name} version {target.version}; got {version}"
             )
@@ -69,7 +79,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Release preparation failed: {exc}", file=sys.stderr)
         return 1
 
-    if not changed:
+    if not changed and not args.allow_no_changes:
         print(f"Release preparation produced no changes for {args.package} {args.version}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Why

Adapter repos need the same direct package release path as metricflow and datus-semantic-adapter, while still selecting one concrete workspace adapter/package per run.

## Solution

- add a manual Publish Package Release workflow
- expose a repo-specific package choice list for each release/readiness workflow
- support auto version resolution from latest PyPI + patch
- update dependent workspace lower bounds before publishing when requested
- allow publishing an already-prepared main version without forcing a separate PR

## Test Cases

- actionlint publish/prepare/readiness workflows
- YAML parse and py_compile release helper scripts
- package release readiness build/smoke for datus-db-core
- unit-test target dry-run for datus-postgresql