### PR TITLE
[BugFix] Fix PostgreSQL schema lookup for requested database

### DIFF
--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -519,7 +519,9 @@ class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
         database_name = database_name or self.database_name
         safe_db = database_name.replace("'", "''") if database_name else ""
         sql = f"SELECT schema_name FROM information_schema.schemata WHERE catalog_name = '{safe_db}'"
-        result = self._execute_pandas(sql)
+        result = self._execute_pandas(sql, database_name=database_name)
+        if "schema_name" not in result.columns:
+            return []
         schemas = result["schema_name"].tolist()
 
         if not include_sys:

--- a/datus-postgresql/tests/unit/test_connector_unit.py
+++ b/datus-postgresql/tests/unit/test_connector_unit.py
@@ -544,6 +544,30 @@ def _df(rows, columns):
     return pd.DataFrame(rows, columns=columns)
 
 
+def test_get_schemas_uses_requested_database_and_handles_empty_result():
+    """Schema lookup must query the requested database and tolerate empty metadata."""
+    connector = _make_pg_connector_for_metadata(database_name="ccks_fund")
+    empty = _df([], [])
+    connector._execute_pandas = MagicMock(return_value=empty)
+
+    result = connector.get_schemas(database_name="databasetest")
+
+    assert result == []
+    connector._execute_pandas.assert_called_once()
+    assert connector._execute_pandas.call_args.kwargs["database_name"] == "databasetest"
+
+
+def test_get_schemas_filters_system_schemas():
+    connector = _make_pg_connector_for_metadata()
+    df = _df(
+        [("public",), ("information_schema",), ("pg_catalog",)],
+        ["schema_name"],
+    )
+    connector._execute_pandas = MagicMock(return_value=df)
+
+    assert connector.get_schemas(database_name="testdb") == ["public"]
+
+
 def test_get_schema_strict_match_hits_no_fallback():
     """Exact case match returns rows from first query and never executes the lower() fallback."""
     connector = _make_pg_connector_for_metadata()


### PR DESCRIPTION
`PostgreSQLConnector.get_schemas(database_name=...)` accepted a database override but did not pass it to `_execute_pandas()`. As a result, schema lookup could run against the default database while filtering `information_schema.schemata` by another catalog, producing an empty DataFrame and raising `KeyError: 'schema_name'`.

## Solution

  - Pass `database_name` through to `_execute_pandas()` in `get_schemas()`.
  - Return an empty schema list if the metadata result has no `schema_name` column.

## Test Cases

  - `uv run pytest tests/unit/test_connector_unit.py -q`
  - Added unit coverage for requested-database schema lookup and empty metadata handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema retrieval to handle edge cases and explicitly specify database context.
  * System schemas are now filtered out from retrieval results.

* **Tests**
  * Added comprehensive unit tests for schema retrieval functionality covering edge cases and filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/datus-db-adapters/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->