### PR TITLE
[Feature] Snowflake: add RSA key pair (SNOWFLAKE_JWT) authentication

### DIFF
--- a/datus-snowflake/README.md
+++ b/datus-snowflake/README.md
@@ -30,18 +30,48 @@ from datus_snowflake import SnowflakeConnector
 
 # Create connector
 connector = SnowflakeConnector(
-    account="myaccount",
-    user="myuser",
-    password="mypassword",
-    warehouse="my_warehouse",
-    database="my_database",
-    schema="my_schema"
+    {
+        "account": "myaccount",
+        "username": "myuser",
+        "password": "mypassword",
+        "warehouse": "my_warehouse",
+        "database": "my_database",
+        "schema": "my_schema",
+    }
 )
 
 # Test connection
 result = connector.test_connection()
 print(result)  # {'success': True, 'message': 'Connection successful', 'databases': ''}
 ```
+
+### Key Pair Authentication (recommended for MFA accounts and CI)
+
+Snowflake accounts with MFA enabled reject plain password logins from non-interactive
+clients. Use RSA key pair authentication (`SNOWFLAKE_JWT`) instead — it bypasses MFA
+and is Snowflake's recommended path for programmatic access. Register the public key
+on your Snowflake user once (`ALTER USER <u> SET RSA_PUBLIC_KEY = '<base64>'`), then
+point the connector at the matching private key file:
+
+```python
+from datus_snowflake import SnowflakeConnector
+
+connector = SnowflakeConnector(
+    {
+        "account": "myaccount",
+        "username": "myuser",
+        "private_key_file": "/path/to/rsa_key.p8",
+        # Only needed if the key file is encrypted:
+        "private_key_file_pwd": "key-passphrase",
+        "warehouse": "my_warehouse",
+        "database": "my_database",
+        "schema": "my_schema",
+    }
+)
+```
+
+Exactly one of `password` or `private_key_file` must be provided; passing both (or
+neither) raises a `ValueError`.
 
 ### Execute Queries
 
@@ -187,12 +217,25 @@ connector.do_switch_context(
 When using with Datus Agent, the adapter is automatically discovered via entry points:
 
 ```yaml
-# config.yaml
+# config.yaml — password authentication
 database:
   type: snowflake
   account: myaccount
   username: myuser
   password: mypassword
+  warehouse: my_warehouse
+  database: my_database
+  schema: my_schema
+```
+
+```yaml
+# config.yaml — key pair authentication (MFA-friendly)
+database:
+  type: snowflake
+  account: myaccount
+  username: myuser
+  private_key_file: /path/to/rsa_key.p8
+  # private_key_file_pwd: key-passphrase   # only for encrypted keys
   warehouse: my_warehouse
   database: my_database
   schema: my_schema

--- a/datus-snowflake/datus_snowflake/config.py
+++ b/datus-snowflake/datus_snowflake/config.py
@@ -4,19 +4,28 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class SnowflakeConfig(BaseModel):
     """Snowflake-specific configuration."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, coerce_numbers_to_str=True)
 
     account: str = Field(..., description="Snowflake account identifier")
     username: str = Field(..., description="Snowflake username")
-    password: str = Field(
-        ...,
-        description="Snowflake password",
+    password: Optional[str] = Field(
+        default=None,
+        description="Snowflake password (omit when using key pair authentication)",
+        json_schema_extra={"input_type": "password"},
+    )
+    private_key_file: Optional[str] = Field(
+        default=None,
+        description="Path to PEM-encoded RSA private key for key pair authentication (SNOWFLAKE_JWT)",
+    )
+    private_key_file_pwd: Optional[str] = Field(
+        default=None,
+        description="Passphrase for the encrypted private key file (omit for unencrypted keys)",
         json_schema_extra={"input_type": "password"},
     )
     warehouse: str = Field(..., description="Snowflake warehouse name")
@@ -24,3 +33,14 @@ class SnowflakeConfig(BaseModel):
     schema_name: Optional[str] = Field(default=None, alias="schema", description="Default schema name")
     role: Optional[str] = Field(default=None, description="Snowflake role to use")
     timeout_seconds: int = Field(default=30, description="Connection timeout in seconds")
+
+    @model_validator(mode="after")
+    def _require_exactly_one_credential(self) -> "SnowflakeConfig":
+        has_password = bool(self.password)
+        has_key = bool(self.private_key_file)
+        if has_password == has_key:
+            raise ValueError(
+                "SnowflakeConfig requires exactly one of `password` or `private_key_file` "
+                "(use key pair authentication for MFA-enforced accounts)"
+            )
+        return self

--- a/datus-snowflake/datus_snowflake/config.py
+++ b/datus-snowflake/datus_snowflake/config.py
@@ -4,7 +4,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 
 class SnowflakeConfig(BaseModel):
@@ -14,7 +14,7 @@ class SnowflakeConfig(BaseModel):
 
     account: str = Field(..., description="Snowflake account identifier")
     username: str = Field(..., description="Snowflake username")
-    password: Optional[str] = Field(
+    password: Optional[SecretStr] = Field(
         default=None,
         description="Snowflake password (omit when using key pair authentication)",
         json_schema_extra={"input_type": "password"},
@@ -23,7 +23,7 @@ class SnowflakeConfig(BaseModel):
         default=None,
         description="Path to PEM-encoded RSA private key for key pair authentication (SNOWFLAKE_JWT)",
     )
-    private_key_file_pwd: Optional[str] = Field(
+    private_key_file_pwd: Optional[SecretStr] = Field(
         default=None,
         description="Passphrase for the encrypted private key file (omit for unencrypted keys)",
         json_schema_extra={"input_type": "password"},

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -119,17 +119,26 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
 
         conn_config = ConnectionConfig(timeout_seconds=config.timeout_seconds)
         super().__init__(config=conn_config, dialect="snowflake")
-        self.connection: SnowflakeConnection = Connect(
-            account=config.account,
-            user=config.username,
-            password=config.password,
-            warehouse=config.warehouse,
-            database=config.database if config.database else None,
-            schema=config.schema_name if config.schema_name else None,
-            login_timeout=config.timeout_seconds,
-            network_timeout=config.timeout_seconds,
-            socket_timeout=config.timeout_seconds,
-        )
+
+        connect_kwargs: Dict[str, Any] = {
+            "account": config.account,
+            "user": config.username,
+            "warehouse": config.warehouse,
+            "database": config.database if config.database else None,
+            "schema": config.schema_name if config.schema_name else None,
+            "login_timeout": config.timeout_seconds,
+            "network_timeout": config.timeout_seconds,
+            "socket_timeout": config.timeout_seconds,
+        }
+        if config.private_key_file:
+            connect_kwargs["authenticator"] = "SNOWFLAKE_JWT"
+            connect_kwargs["private_key_file"] = config.private_key_file
+            if config.private_key_file_pwd:
+                connect_kwargs["private_key_file_pwd"] = config.private_key_file_pwd
+        else:
+            connect_kwargs["password"] = config.password
+
+        self.connection: SnowflakeConnection = Connect(**connect_kwargs)
         self.database_name = config.database or ""
         self.schema_name = config.schema_name or ""
 

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -134,9 +134,9 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             connect_kwargs["authenticator"] = "SNOWFLAKE_JWT"
             connect_kwargs["private_key_file"] = config.private_key_file
             if config.private_key_file_pwd:
-                connect_kwargs["private_key_file_pwd"] = config.private_key_file_pwd
+                connect_kwargs["private_key_file_pwd"] = config.private_key_file_pwd.get_secret_value()
         else:
-            connect_kwargs["password"] = config.password
+            connect_kwargs["password"] = config.password.get_secret_value()
 
         self.connection: SnowflakeConnection = Connect(**connect_kwargs)
         self.database_name = config.database or ""

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -1,0 +1,41 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Pure-Pydantic SnowflakeConfig tests — no live Snowflake required."""
+
+import pytest
+
+from datus_snowflake import SnowflakeConfig
+
+
+def test_config_requires_password_or_key():
+    with pytest.raises(ValueError, match="exactly one of `password` or `private_key_file`"):
+        SnowflakeConfig(account="a", username="u", warehouse="w")
+
+
+def test_config_rejects_both_password_and_key(tmp_path):
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+    with pytest.raises(ValueError, match="exactly one of `password` or `private_key_file`"):
+        SnowflakeConfig(
+            account="a",
+            username="u",
+            warehouse="w",
+            password="p",
+            private_key_file=str(key_file),
+        )
+
+
+def test_config_accepts_password_only():
+    cfg = SnowflakeConfig(account="a", username="u", warehouse="w", password="p")
+    assert cfg.password == "p"
+    assert cfg.private_key_file is None
+
+
+def test_config_accepts_key_pair_only(tmp_path):
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+    cfg = SnowflakeConfig(account="a", username="u", warehouse="w", private_key_file=str(key_file))
+    assert cfg.private_key_file == str(key_file)
+    assert cfg.password is None

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -29,7 +29,7 @@ def test_config_rejects_both_password_and_key(tmp_path):
 
 def test_config_accepts_password_only():
     cfg = SnowflakeConfig(account="a", username="u", warehouse="w", password="p")
-    assert cfg.password == "p"
+    assert cfg.password.get_secret_value() == "p"
     assert cfg.private_key_file is None
 
 
@@ -39,3 +39,23 @@ def test_config_accepts_key_pair_only(tmp_path):
     cfg = SnowflakeConfig(account="a", username="u", warehouse="w", private_key_file=str(key_file))
     assert cfg.private_key_file == str(key_file)
     assert cfg.password is None
+
+
+def test_config_masks_secret_repr():
+    """Secrets must not leak through repr/str of the config object."""
+    cfg = SnowflakeConfig(account="a", username="u", warehouse="w", password="topsecret")
+    assert "topsecret" not in repr(cfg)
+    assert "topsecret" not in str(cfg)
+
+
+def test_config_coerces_numeric_credentials(tmp_path):
+    """YAML parses unquoted numeric secrets as int; they must coerce to str."""
+    cfg_pwd = SnowflakeConfig(account="a", username="u", warehouse="w", password=1234)
+    assert cfg_pwd.password.get_secret_value() == "1234"
+
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+    cfg_key = SnowflakeConfig(
+        account="a", username="u", warehouse="w", private_key_file=str(key_file), private_key_file_pwd=5678
+    )
+    assert cfg_key.private_key_file_pwd.get_secret_value() == "5678"

--- a/datus-snowflake/tests/test_key_pair_auth.py
+++ b/datus-snowflake/tests/test_key_pair_auth.py
@@ -1,0 +1,47 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Live key pair authentication smoke test.
+
+Requires SNOWFLAKE_PRIVATE_KEY_FILE pointing to a PEM key whose public half is
+registered on the Snowflake user (`ALTER USER ... SET RSA_PUBLIC_KEY = '...'`).
+"""
+
+import os
+
+import pytest
+
+from datus_snowflake import SnowflakeConfig, SnowflakeConnector
+
+pytestmark = pytest.mark.skipif(
+    not all(
+        [
+            os.getenv("SNOWFLAKE_ACCOUNT"),
+            os.getenv("SNOWFLAKE_USER"),
+            os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+            os.getenv("SNOWFLAKE_WAREHOUSE"),
+        ]
+    ),
+    reason="Snowflake key pair credentials (SNOWFLAKE_PRIVATE_KEY_FILE) not provided",
+)
+
+
+def test_connection_with_key_pair():
+    cfg = SnowflakeConfig(
+        account=os.getenv("SNOWFLAKE_ACCOUNT", ""),
+        username=os.getenv("SNOWFLAKE_USER", ""),
+        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE", ""),
+        private_key_file=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE", ""),
+        private_key_file_pwd=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE_PWD"),
+        database=os.getenv("SNOWFLAKE_DATABASE"),
+        schema=os.getenv("SNOWFLAKE_SCHEMA"),
+    )
+    conn = SnowflakeConnector(cfg)
+    try:
+        assert conn.test_connection()["success"] is True
+        result = conn.execute_query("SELECT 1 as num", result_format="list")
+        assert result.success
+        assert result.sql_return == [{"num": 1}]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Why

MFA-enforced Snowflake accounts cannot connect through the adapter today — it only supports username + password, with no `authenticator` parameter. Snowflake is also phasing out single-password logins. This adds RSA **key pair authentication** (`SNOWFLAKE_JWT`), Snowflake's recommended programmatic auth that bypasses MFA and works for both local dev and CI/service accounts.

## What

- **config** (`datus_snowflake/config.py`)
  - `password` is now optional (was required) — backward compatible
  - new `private_key_file` (PEM path) and `private_key_file_pwd` (passphrase) fields
  - `@model_validator` enforces exactly one of `password` / `private_key_file`
  - `coerce_numbers_to_str=True` so numeric passwords/passphrases coming from YAML (parsed as int) don't fail validation
- **connector** (`datus_snowflake/connector.py`)
  - builds `Connect()` kwargs conditionally; sets `authenticator="SNOWFLAKE_JWT"` + `private_key_file[_pwd]` when a key file is provided, otherwise falls back to `password`
- **tests**
  - `tests/test_config.py` — credential-free validator tests (run in CI unit suite)
  - `tests/test_key_pair_auth.py` — live key-pair smoke test, gated on `SNOWFLAKE_PRIVATE_KEY_FILE` (skips without creds)
- **README** — key pair usage section + YAML config examples

No new dependency: `snowflake-connector-python` already vendors `cryptography` for JWT signing.

## Testing

- `ruff format --check` + `ruff check` clean on `datus-snowflake/`
- `pytest datus-snowflake/tests/ -m "not integration"` → 20 passed, 28 skipped (credential-gated)
- Verified end-to-end against a live MFA-enabled Snowflake account through the Datus CLI (`datus --datasource ... -p "SELECT 1"`) — connects without triggering MFA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RSA key-pair authentication option for Snowflake connections and validation that exactly one credential method (password or key-pair) is provided.

* **Documentation**
  * Updated README with examples for password and key-pair (MFA/CI-friendly) configurations and YAML sample.

* **Tests**
  * Added unit and integration tests covering key-pair auth, credential validation, secret masking, and numeric-to-string coercion for credential inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->