### PR TITLE
[BugFix] Pass Snowflake role to connector

### DIFF
--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -130,6 +130,8 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             "network_timeout": config.timeout_seconds,
             "socket_timeout": config.timeout_seconds,
         }
+        if config.role:
+            connect_kwargs["role"] = config.role
         if config.private_key_file:
             connect_kwargs["authenticator"] = "SNOWFLAKE_JWT"
             connect_kwargs["private_key_file"] = config.private_key_file

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -4,9 +4,11 @@
 
 """Pure-Pydantic SnowflakeConfig tests — no live Snowflake required."""
 
+from unittest.mock import patch
+
 import pytest
 
-from datus_snowflake import SnowflakeConfig
+from datus_snowflake import SnowflakeConfig, SnowflakeConnector
 
 
 def test_config_requires_password_or_key():
@@ -59,3 +61,18 @@ def test_config_coerces_numeric_credentials(tmp_path):
         account="a", username="u", warehouse="w", private_key_file=str(key_file), private_key_file_pwd=5678
     )
     assert cfg_key.private_key_file_pwd.get_secret_value() == "5678"
+
+
+def test_connector_passes_role_to_snowflake_connect():
+    cfg = SnowflakeConfig(
+        account="a",
+        username="u",
+        warehouse="w",
+        password="p",
+        role="ANALYST",
+    )
+
+    with patch("datus_snowflake.connector.Connect") as connect:
+        SnowflakeConnector(cfg)
+
+    assert connect.call_args.kwargs["role"] == "ANALYST"

--- a/datus-snowflake/tests/test_key_pair_auth.py
+++ b/datus-snowflake/tests/test_key_pair_auth.py
@@ -36,6 +36,7 @@ def test_connection_with_key_pair():
         private_key_file_pwd=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE_PWD"),
         database=os.getenv("SNOWFLAKE_DATABASE"),
         schema=os.getenv("SNOWFLAKE_SCHEMA"),
+        role=os.getenv("SNOWFLAKE_ROLE"),
     )
     conn = SnowflakeConnector(cfg)
     try:


### PR DESCRIPTION
## Summary
- pass configured Snowflake role through to snowflake.connector.Connect
- include role in the live key-pair smoke config
- add a unit test covering connector kwargs

## Tests
- uv run --package datus-snowflake pytest datus-snowflake/tests/test_config.py datus-snowflake/tests/test_key_pair_auth.py -q