### PR TITLE
[BugFix] Remove Snowflake catalog namespace support

### DIFF
--- a/datus-snowflake/datus_snowflake/__init__.py
+++ b/datus-snowflake/datus_snowflake/__init__.py
@@ -15,5 +15,5 @@ def register():
         "snowflake",
         SnowflakeConnector,
         config_class=SnowflakeConfig,
-        capabilities={"catalog", "database", "schema"},
+        capabilities={"database", "schema"},
     )

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -165,14 +165,19 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
 
     def _sys_databases(self) -> Set[str]:
         """Return set of system databases to filter out."""
-        return {"SNOWFLAKE", "SNOWFLAKE_SAMPLE_DATA"}
+        return {"SNOWFLAKE"}
 
     def _sys_schemas(self) -> Set[str]:
         """Return set of system schemas to filter out."""
         return {"INFORMATION_SCHEMA"}
 
+    def _reject_catalog(self, catalog_name: str = "") -> None:
+        if catalog_name:
+            raise ValueError("Snowflake does not support a catalog namespace; use database_name instead.")
+
     def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         """Switch database or schema context."""
+        self._reject_catalog(catalog_name)
         try:
             with self.connection.cursor() as cursor:
                 if not schema_name:
@@ -316,12 +321,13 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
     def execute_content_set(self, sql_query: str) -> ExecuteSQLResult:
         """Execute context switch statement (USE DATABASE/SCHEMA)."""
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute(sql_query)
             switch_context = parse_context_switch(sql=sql_query, dialect=self.dialect)
             if switch_context:
                 if catalog_name := switch_context.get("catalog_name"):
-                    self.catalog_name = catalog_name
+                    self._reject_catalog(catalog_name)
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql_query)
+            if switch_context:
                 if database_name := switch_context.get("database_name"):
                     self.database_name = database_name
                 if schema_name := switch_context.get("schema_name"):
@@ -457,6 +463,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
     @override
     def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
         """Get list of databases."""
+        self._reject_catalog(catalog_name)
         res = self._execute_show(sql="SHOW DATABASES", result_format="arrow").sql_return
         databases = res["name"]
 
@@ -472,6 +479,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
     @override
     def get_schemas(self, catalog_name: str = "", database_name: str = "", include_sys: bool = False) -> List[str]:
         """Get list of schemas using SHOW SCHEMAS command."""
+        self._reject_catalog(catalog_name)
         database_name = database_name or self.database_name
 
         if database_name:
@@ -518,6 +526,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
     @override
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
+        self._reject_catalog(catalog_name)
         tables = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -528,6 +537,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of view names."""
+        self._reject_catalog(catalog_name)
         views = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -540,6 +550,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
     ) -> List[str]:
         """Get list of materialized view names."""
+        self._reject_catalog(catalog_name)
         mvs = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -557,7 +568,8 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         table_type: TABLE_TYPE = "",
     ) -> List[Dict[str, str]]:
         """Get table metadata (excluding DDL)."""
-        catalog_name = catalog_name or self.catalog_name
+        self._reject_catalog(catalog_name)
+        catalog_name = ""
         database_name = database_name or self.database_name
         result = []
 
@@ -719,7 +731,8 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         if not table_name:
             return []
 
-        catalog_name = catalog_name or self.catalog_name
+        self._reject_catalog(catalog_name)
+        catalog_name = ""
         database_name = database_name or self.database_name
         schema_name = schema_name or self.schema_name
 
@@ -818,6 +831,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         tables: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """Get table metadata with DDL definitions."""
+        self._reject_catalog(catalog_name)
         table_entries = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -843,6 +857,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
     ) -> List[Dict[str, str]]:
         """Get view metadata with DDL definitions."""
+        self._reject_catalog(catalog_name)
         view_entries = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -867,6 +882,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
     ) -> List[Dict[str, str]]:
         """Get materialized view metadata with DDL definitions."""
+        self._reject_catalog(catalog_name)
         mv_entries = self._get_tables_per_db(
             catalog_name=catalog_name,
             database_name=database_name,
@@ -899,7 +915,8 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
     ) -> List[Dict[str, Any]]:
         """Get sample rows from tables."""
         result = []
-        catalog_name = catalog_name or self.catalog_name
+        self._reject_catalog(catalog_name)
+        catalog_name = ""
         database_name = database_name or self.database_name
         schema_name = schema_name or self.schema_name
 
@@ -969,6 +986,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         table_name: str = "",
     ) -> str:
         """Build fully qualified table name."""
+        self._reject_catalog(catalog_name)
         if schema_name:
             full_name = f'"{schema_name}"."{table_name}"'
         else:

--- a/datus-snowflake/pyproject.toml
+++ b/datus-snowflake/pyproject.toml
@@ -32,5 +32,10 @@ snowflake = "datus_snowflake:register"
 [tool.uv.sources]
 datus-db-core = { workspace = true }
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["datus_snowflake"]

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -76,3 +76,38 @@ def test_connector_passes_role_to_snowflake_connect():
         SnowflakeConnector(cfg)
 
     assert connect.call_args.kwargs["role"] == "ANALYST"
+
+
+def test_connector_uses_password_auth_kwargs():
+    cfg = SnowflakeConfig(account="a", username="u", warehouse="w", password="p")
+
+    with patch("datus_snowflake.connector.Connect") as connect:
+        SnowflakeConnector(cfg)
+
+    kwargs = connect.call_args.kwargs
+    assert kwargs["password"] == "p"
+    assert "authenticator" not in kwargs
+    assert "private_key_file" not in kwargs
+
+
+def test_connector_uses_key_pair_auth_kwargs(tmp_path):
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+    cfg = SnowflakeConfig(
+        account="a",
+        username="u",
+        warehouse="w",
+        private_key_file=str(key_file),
+        private_key_file_pwd="secret",
+        role="ANALYST",
+    )
+
+    with patch("datus_snowflake.connector.Connect") as connect:
+        SnowflakeConnector(cfg)
+
+    kwargs = connect.call_args.kwargs
+    assert kwargs["authenticator"] == "SNOWFLAKE_JWT"
+    assert kwargs["private_key_file"] == str(key_file)
+    assert kwargs["private_key_file_pwd"] == "secret"
+    assert kwargs["role"] == "ANALYST"
+    assert "password" not in kwargs

--- a/datus-snowflake/tests/test_connector.py
+++ b/datus-snowflake/tests/test_connector.py
@@ -7,34 +7,44 @@ from typing import Generator
 
 import pytest
 
-from datus_db_core import MaterializedViewSupportMixin, SchemaNamespaceMixin
 from datus_snowflake import SnowflakeConfig, SnowflakeConnector
 
-# Skip all tests if Snowflake credentials are not provided
-pytestmark = pytest.mark.skipif(
-    not all(
-        [
-            os.getenv("SNOWFLAKE_ACCOUNT"),
-            os.getenv("SNOWFLAKE_USER"),
-            os.getenv("SNOWFLAKE_PASSWORD"),
-            os.getenv("SNOWFLAKE_WAREHOUSE"),
-        ]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (
+            os.getenv("SNOWFLAKE_ACCOUNT")
+            and os.getenv("SNOWFLAKE_USER")
+            and os.getenv("SNOWFLAKE_WAREHOUSE")
+            and (os.getenv("SNOWFLAKE_PASSWORD") or os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"))
+        ),
+        reason="Snowflake live credentials not provided in environment variables",
     ),
-    reason="Snowflake credentials not provided in environment variables",
-)
+]
 
 
 @pytest.fixture
-def config() -> SnowflakeConfig:
+def config_dict() -> dict:
     """Create Snowflake configuration from environment."""
-    return SnowflakeConfig(
-        account=os.getenv("SNOWFLAKE_ACCOUNT", ""),
-        username=os.getenv("SNOWFLAKE_USER", ""),
-        password=os.getenv("SNOWFLAKE_PASSWORD", ""),
-        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE", ""),
-        database=os.getenv("SNOWFLAKE_DATABASE"),
-        schema=os.getenv("SNOWFLAKE_SCHEMA"),
-    )
+    cfg = {
+        "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
+        "username": os.getenv("SNOWFLAKE_USER", ""),
+        "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE", ""),
+        "database": os.getenv("SNOWFLAKE_DATABASE"),
+        "schema": os.getenv("SNOWFLAKE_SCHEMA"),
+        "role": os.getenv("SNOWFLAKE_ROLE"),
+    }
+    if os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"):
+        cfg["private_key_file"] = os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE")
+        cfg["private_key_file_pwd"] = os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE_PWD")
+    else:
+        cfg["password"] = os.getenv("SNOWFLAKE_PASSWORD", "")
+    return {key: value for key, value in cfg.items() if value is not None}
+
+
+@pytest.fixture
+def config(config_dict: dict) -> SnowflakeConfig:
+    return SnowflakeConfig(**config_dict)
 
 
 @pytest.fixture
@@ -45,17 +55,18 @@ def connector(config: SnowflakeConfig) -> Generator[SnowflakeConnector, None, No
     conn.close()
 
 
-# ==================== Mixin Tests ====================
+@pytest.fixture
+def database_name(config: SnowflakeConfig) -> str:
+    if not config.database:
+        pytest.skip("SNOWFLAKE_DATABASE not provided")
+    return config.database
 
 
-def test_connector_implements_schema_namespace_mixin(connector: SnowflakeConnector):
-    """Verify Snowflake connector implements SchemaNamespaceMixin."""
-    assert isinstance(connector, SchemaNamespaceMixin)
-
-
-def test_connector_implements_materialized_view_mixin(connector: SnowflakeConnector):
-    """Verify Snowflake connector implements MaterializedViewSupportMixin."""
-    assert isinstance(connector, MaterializedViewSupportMixin)
+@pytest.fixture
+def schema_name(config: SnowflakeConfig) -> str:
+    if not config.schema_name:
+        pytest.skip("SNOWFLAKE_SCHEMA not provided")
+    return config.schema_name
 
 
 # ==================== Connection Tests ====================
@@ -69,16 +80,9 @@ def test_connection_with_config_object(config: SnowflakeConfig):
     conn.close()
 
 
-def test_connection_with_dict():
+def test_connection_with_dict(config_dict: dict):
     """Test connection using dict config."""
-    conn = SnowflakeConnector(
-        {
-            "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
-            "username": os.getenv("SNOWFLAKE_USER", ""),
-            "password": os.getenv("SNOWFLAKE_PASSWORD", ""),
-            "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE", ""),
-        }
-    )
+    conn = SnowflakeConnector(config_dict)
     result = conn.test_connection()
     assert result["success"] is True
     conn.close()
@@ -97,7 +101,7 @@ def test_get_databases(connector: SnowflakeConnector):
 def test_get_databases_exclude_system(connector: SnowflakeConnector):
     """Test that system databases are excluded by default."""
     databases = connector.get_databases(include_sys=False)
-    system_dbs = {"SNOWFLAKE", "SNOWFLAKE_SAMPLE_DATA"}
+    system_dbs = {"SNOWFLAKE"}
     for db in databases:
         assert db.upper() not in system_dbs
 
@@ -105,129 +109,118 @@ def test_get_databases_exclude_system(connector: SnowflakeConnector):
 # ==================== Schema Tests (SchemaNamespaceMixin) ====================
 
 
-def test_get_schemas(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_schemas(connector: SnowflakeConnector, database_name: str):
     """Test getting list of schemas."""
-    if config.database:
-        schemas = connector.get_schemas(database_name=config.database)
-        assert isinstance(schemas, list)
+    schemas = connector.get_schemas(database_name=database_name)
+    assert isinstance(schemas, list)
 
 
-def test_get_schemas_exclude_system(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_schemas_exclude_system(connector: SnowflakeConnector, database_name: str):
     """Test that system schemas are excluded by default."""
-    if config.database:
-        schemas = connector.get_schemas(database_name=config.database, include_sys=False)
-        for schema in schemas:
-            assert schema.upper() != "INFORMATION_SCHEMA"
+    schemas = connector.get_schemas(database_name=database_name, include_sys=False)
+    for schema in schemas:
+        assert schema.upper() != "INFORMATION_SCHEMA"
 
 
 # ==================== Table Metadata Tests ====================
 
 
-def test_get_tables(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_tables(connector: SnowflakeConnector, database_name: str):
     """Test getting table list."""
-    if config.database:
-        tables = connector.get_tables(database_name=config.database)
-        assert isinstance(tables, list)
+    tables = connector.get_tables(database_name=database_name)
+    assert isinstance(tables, list)
 
 
-def test_get_tables_with_ddl(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_tables_with_ddl(connector: SnowflakeConnector, database_name: str, schema_name: str):
     """Test getting tables with DDL."""
-    if config.database and config.schema_name:
-        tables = connector.get_tables_with_ddl(database_name=config.database, schema_name=config.schema_name)
+    tables = connector.get_tables_with_ddl(database_name=database_name, schema_name=schema_name)
 
-        if len(tables) > 0:
-            table = tables[0]
-            assert "table_name" in table
-            assert "definition" in table
-            assert table["table_type"] == "table"
-            assert "database_name" in table
-            assert "schema_name" in table
-            assert "identifier" in table
+    if len(tables) > 0:
+        table = tables[0]
+        assert "table_name" in table
+        assert "definition" in table
+        assert table["table_type"] == "table"
+        assert "database_name" in table
+        assert "schema_name" in table
+        assert "identifier" in table
 
 
 # ==================== View Tests ====================
 
 
-def test_get_views(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_views(connector: SnowflakeConnector, database_name: str):
     """Test getting view list."""
-    if config.database:
-        views = connector.get_views(database_name=config.database)
-        assert isinstance(views, list)
+    views = connector.get_views(database_name=database_name)
+    assert isinstance(views, list)
 
 
-def test_get_views_with_ddl(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_views_with_ddl(connector: SnowflakeConnector, database_name: str, schema_name: str):
     """Test getting views with DDL."""
-    if config.database and config.schema_name:
-        views = connector.get_views_with_ddl(database_name=config.database, schema_name=config.schema_name)
+    views = connector.get_views_with_ddl(database_name=database_name, schema_name=schema_name)
 
-        if len(views) > 0:
-            view = views[0]
-            assert "table_name" in view
-            assert "definition" in view
-            assert view["table_type"] == "view"
+    if len(views) > 0:
+        view = views[0]
+        assert "table_name" in view
+        assert "definition" in view
+        assert view["table_type"] == "view"
 
 
 # ==================== Materialized View Tests (MaterializedViewSupportMixin) ====================
 
 
-def test_get_materialized_views(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_materialized_views(connector: SnowflakeConnector, database_name: str):
     """Test getting materialized view list."""
-    if config.database:
-        mvs = connector.get_materialized_views(database_name=config.database)
-        assert isinstance(mvs, list)
+    mvs = connector.get_materialized_views(database_name=database_name)
+    assert isinstance(mvs, list)
 
 
-def test_get_materialized_views_with_ddl(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_materialized_views_with_ddl(connector: SnowflakeConnector, database_name: str, schema_name: str):
     """Test getting materialized views with DDL."""
-    if config.database and config.schema_name:
-        mvs = connector.get_materialized_views_with_ddl(database_name=config.database, schema_name=config.schema_name)
+    mvs = connector.get_materialized_views_with_ddl(database_name=database_name, schema_name=schema_name)
 
-        if len(mvs) > 0:
-            mv = mvs[0]
-            assert "table_name" in mv
-            assert "definition" in mv
-            assert mv["table_type"] == "mv"
+    if len(mvs) > 0:
+        mv = mvs[0]
+        assert "table_name" in mv
+        assert "definition" in mv
+        assert mv["table_type"] == "mv"
 
 
 # ==================== Schema Structure Tests ====================
 
 
-def test_get_schema(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_schema(connector: SnowflakeConnector, database_name: str, schema_name: str):
     """Test getting table schema."""
-    if config.database and config.schema_name:
-        tables = connector.get_tables(database_name=config.database, schema_name=config.schema_name)
+    tables = connector.get_tables(database_name=database_name, schema_name=schema_name)
 
-        if len(tables) > 0:
-            table_name = tables[0]
-            schema = connector.get_schema(
-                database_name=config.database,
-                schema_name=config.schema_name,
-                table_name=table_name,
-            )
+    if len(tables) > 0:
+        table_name = tables[0]
+        schema = connector.get_schema(
+            database_name=database_name,
+            schema_name=schema_name,
+            table_name=table_name,
+        )
 
-            assert isinstance(schema, list)
-            if len(schema) > 0:
-                # Check column structure
-                for col in schema:
-                    if isinstance(col, dict) and "name" in col:
-                        assert "type" in col
-                        assert "nullable" in col
+        assert isinstance(schema, list)
+        if len(schema) > 0:
+            for col in schema:
+                if isinstance(col, dict) and "name" in col:
+                    assert "type" in col
+                    assert "nullable" in col
 
 
 # ==================== Sample Data Tests ====================
 
 
-def test_get_sample_rows(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_get_sample_rows(connector: SnowflakeConnector, database_name: str, schema_name: str):
     """Test getting sample rows."""
-    if config.database and config.schema_name:
-        sample_rows = connector.get_sample_rows(database_name=config.database, schema_name=config.schema_name, top_n=3)
+    sample_rows = connector.get_sample_rows(database_name=database_name, schema_name=schema_name, top_n=3)
 
-        if len(sample_rows) > 0:
-            item = sample_rows[0]
-            assert "database_name" in item
-            assert "table_name" in item
-            assert "schema_name" in item
-            assert "sample_rows" in item
+    if len(sample_rows) > 0:
+        item = sample_rows[0]
+        assert "database_name" in item
+        assert "table_name" in item
+        assert "schema_name" in item
+        assert "sample_rows" in item
 
 
 # ==================== SQL Execution Tests ====================
@@ -235,7 +228,7 @@ def test_get_sample_rows(connector: SnowflakeConnector, config: SnowflakeConfig)
 
 def test_execute_query_csv(connector: SnowflakeConnector):
     """Test executing query with CSV format."""
-    result = connector.execute_query("SELECT 1 as num", result_format="csv")
+    result = connector.execute_query('SELECT 1 AS "num"', result_format="csv")
     assert result.success
     assert not result.error
     assert "num" in result.sql_return
@@ -243,7 +236,7 @@ def test_execute_query_csv(connector: SnowflakeConnector):
 
 def test_execute_query_list(connector: SnowflakeConnector):
     """Test executing query with list format."""
-    result = connector.execute_query("SELECT 1 as num", result_format="list")
+    result = connector.execute_query('SELECT 1 AS "num"', result_format="list")
     assert result.success
     assert not result.error
     assert result.sql_return == [{"num": 1}]
@@ -251,7 +244,7 @@ def test_execute_query_list(connector: SnowflakeConnector):
 
 def test_execute_query_arrow(connector: SnowflakeConnector):
     """Test executing query with Arrow format."""
-    result = connector.execute_query("SELECT 1 as num", result_format="arrow")
+    result = connector.execute_query('SELECT 1 AS "num"', result_format="arrow")
     assert result.success
     assert not result.error
     assert result.sql_return is not None
@@ -259,7 +252,7 @@ def test_execute_query_arrow(connector: SnowflakeConnector):
 
 def test_execute_query_pandas(connector: SnowflakeConnector):
     """Test executing query with pandas format."""
-    result = connector.execute_query("SELECT 1 as num", result_format="pandas")
+    result = connector.execute_query('SELECT 1 AS "num"', result_format="pandas")
     assert result.success
     assert not result.error
     assert len(result.sql_return) == 1
@@ -272,12 +265,11 @@ def test_execute_show_databases(connector: SnowflakeConnector):
     assert isinstance(result.sql_return, list)
 
 
-def test_execute_show_schemas(connector: SnowflakeConnector, config: SnowflakeConfig):
+def test_execute_show_schemas(connector: SnowflakeConnector, database_name: str):
     """Test executing SHOW SCHEMAS."""
-    if config.database:
-        result = connector.execute_query(f'SHOW SCHEMAS IN DATABASE "{config.database}"', result_format="list")
-        assert result.success
-        assert isinstance(result.sql_return, list)
+    result = connector.execute_query(f'SHOW SCHEMAS IN DATABASE "{database_name}"', result_format="list")
+    assert result.success
+    assert isinstance(result.sql_return, list)
 
 
 # ==================== Error Handling Tests ====================
@@ -295,24 +287,3 @@ def test_execute_nonexistent_table(connector: SnowflakeConnector):
     result = connector.execute_query("SELECT * FROM nonexistent_table_xyz")
     assert not result.success
     assert result.error is not None
-
-
-# ==================== Utility Tests ====================
-
-
-def test_full_name_with_database_and_schema(connector: SnowflakeConnector):
-    """Test full_name with database and schema."""
-    full_name = connector.full_name(database_name="mydb", schema_name="myschema", table_name="mytable")
-    assert full_name == '"mydb"."myschema"."mytable"'
-
-
-def test_full_name_with_schema_only(connector: SnowflakeConnector):
-    """Test full_name with schema only."""
-    full_name = connector.full_name(schema_name="myschema", table_name="mytable")
-    assert full_name == '"myschema"."mytable"'
-
-
-def test_full_name_with_table_only(connector: SnowflakeConnector):
-    """Test full_name with table only."""
-    full_name = connector.full_name(table_name="mytable")
-    assert full_name == '"mytable"'

--- a/datus-snowflake/tests/test_key_pair_auth.py
+++ b/datus-snowflake/tests/test_key_pair_auth.py
@@ -14,17 +14,20 @@ import pytest
 
 from datus_snowflake import SnowflakeConfig, SnowflakeConnector
 
-pytestmark = pytest.mark.skipif(
-    not all(
-        [
-            os.getenv("SNOWFLAKE_ACCOUNT"),
-            os.getenv("SNOWFLAKE_USER"),
-            os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
-            os.getenv("SNOWFLAKE_WAREHOUSE"),
-        ]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            [
+                os.getenv("SNOWFLAKE_ACCOUNT"),
+                os.getenv("SNOWFLAKE_USER"),
+                os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+                os.getenv("SNOWFLAKE_WAREHOUSE"),
+            ]
+        ),
+        reason="Snowflake key pair credentials (SNOWFLAKE_PRIVATE_KEY_FILE) not provided",
     ),
-    reason="Snowflake key pair credentials (SNOWFLAKE_PRIVATE_KEY_FILE) not provided",
-)
+]
 
 
 def test_connection_with_key_pair():
@@ -41,7 +44,7 @@ def test_connection_with_key_pair():
     conn = SnowflakeConnector(cfg)
     try:
         assert conn.test_connection()["success"] is True
-        result = conn.execute_query("SELECT 1 as num", result_format="list")
+        result = conn.execute_query('SELECT 1 AS "num"', result_format="list")
         assert result.success
         assert result.sql_return == [{"num": 1}]
     finally:

--- a/datus-snowflake/tests/test_namespace.py
+++ b/datus-snowflake/tests/test_namespace.py
@@ -1,0 +1,116 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+
+import datus_snowflake
+from datus_db_core import ConnectorRegistry, MaterializedViewSupportMixin, SchemaNamespaceMixin, connector_registry
+from datus_db_core.sql_utils import metadata_identifier
+from datus_snowflake import SnowflakeConnector
+
+
+class RecordingConnection:
+    def __init__(self):
+        self.cursor_obj = RecordingCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+class RecordingCursor:
+    def __init__(self):
+        self.executed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql):
+        self.executed = True
+
+
+def test_register_declares_database_schema_without_catalog():
+    saved = ConnectorRegistry._capabilities.copy()
+    try:
+        datus_snowflake.register()
+        assert connector_registry.support_database("snowflake")
+        assert connector_registry.support_schema("snowflake")
+        assert not connector_registry.support_catalog("snowflake")
+    finally:
+        ConnectorRegistry._capabilities = saved
+
+
+def test_metadata_identifier_ignores_catalog_after_register():
+    saved = ConnectorRegistry._capabilities.copy()
+    try:
+        datus_snowflake.register()
+        assert (
+            metadata_identifier(
+                catalog_name="catalog",
+                database_name="database",
+                schema_name="schema",
+                table_name="table",
+                dialect="snowflake",
+            )
+            == "database.schema.table"
+        )
+    finally:
+        ConnectorRegistry._capabilities = saved
+
+
+def test_connector_implements_namespace_mixins():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+
+    assert isinstance(connector, SchemaNamespaceMixin)
+    assert isinstance(connector, MaterializedViewSupportMixin)
+
+
+def test_sample_data_is_not_treated_as_system_database():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    assert connector._sys_databases() == {"SNOWFLAKE"}
+
+
+def test_full_name_with_database_and_schema():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+
+    full_name = connector.full_name(database_name="mydb", schema_name="myschema", table_name="mytable")
+
+    assert full_name == '"mydb"."myschema"."mytable"'
+
+
+def test_full_name_with_schema_only():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+
+    full_name = connector.full_name(schema_name="myschema", table_name="mytable")
+
+    assert full_name == '"myschema"."mytable"'
+
+
+def test_full_name_with_table_only():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+
+    full_name = connector.full_name(table_name="mytable")
+
+    assert full_name == '"mytable"'
+
+
+def test_catalog_parameter_is_rejected():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+
+    with pytest.raises(ValueError, match="does not support a catalog namespace"):
+        connector.full_name(catalog_name="cat", database_name="db", schema_name="schema", table_name="table")
+
+
+def test_context_set_rejects_catalog_before_execution():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.dialect = "snowflake"
+    connector.connection = RecordingConnection()
+
+    result = connector.execute_content_set("USE CATALOG cat")
+
+    assert not result.success
+    assert "does not support a catalog namespace" in result.error
+    assert not connector.connection.cursor_obj.executed


### PR DESCRIPTION
## Summary
- remove Snowflake catalog capability registration so namespace handling stays database/schema based
- reject catalog arguments before executing Snowflake context or metadata operations
- split live Snowflake tests into integration tests and add deterministic unit coverage for auth kwargs, namespace support, and catalog rejection

## Validation
- ci/run-unit-tests.sh datus-snowflake
- pytest datus-snowflake/tests -m integration using local agent-1 Snowflake config
- ruff check touched Snowflake files
- ruff format --check touched Snowflake files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snowflake connector now enforces catalog namespace rejection across all metadata operations, DDL execution, and data sampling.
  * Updated system database filtering for improved accuracy and consistency.
  * Enhanced catalog parameter validation to prevent unsupported operations with clear error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->