### PR TITLE
[Enhancement] Add connector current SQL context

### DIFF
--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -67,6 +67,19 @@ class BaseSqlConnector(ABC):
     def schema_name(self, value: str):
         self._schema_var.set(value)
 
+    def get_current_context(self) -> Dict[str, str]:
+        """Return the connector's effective SQL context.
+
+        The returned names are SQL-addressing coordinates, not Datus datasource
+        routing keys. Dialect-specific connectors may override this method to
+        normalize aliases or fill dialect defaults.
+        """
+        return {
+            "catalog_name": self.catalog_name or "",
+            "database_name": self.database_name or "",
+            "schema_name": self.schema_name or "",
+        }
+
     def close(self):
         pass
 

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -150,6 +150,16 @@ class TestBaseSqlConnectorInit:
         assert connector.database_name == ""
         assert connector.schema_name == ""
 
+    def test_get_current_context_returns_sql_coordinates(self):
+        connector = ConcreteConnector()
+        connector.switch_context(catalog_name="cat", database_name="db", schema_name="sch")
+
+        assert connector.get_current_context() == {
+            "catalog_name": "cat",
+            "database_name": "db",
+            "schema_name": "sch",
+        }
+
     def test_init_with_config(self):
         config = ConnectionConfig(timeout_seconds=60)
         connector = ConcreteConnector(config=config, dialect="mysql")

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -125,6 +125,15 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         return catalog
 
     @override
+    def get_current_context(self) -> Dict[str, str]:
+        """Return StarRocks SQL coordinates with the effective catalog resolved."""
+        return {
+            "catalog_name": self._resolve_catalog(),
+            "database_name": self.database_name or "",
+            "schema_name": "",
+        }
+
+    @override
     def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         """Apply catalog and/or database context to a connection."""
         if catalog_name:

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -126,6 +126,45 @@ def test_resolve_catalog_with_def():
         assert result == "default_catalog"
 
 
+def test_get_current_context_resolves_default_catalog():
+    """Test current context exposes effective SQL coordinates."""
+    config = StarRocksConfig(username="test_user", database="ac_manage")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = StarRocksConnector(config)
+
+        assert connector.get_current_context() == {
+            "catalog_name": "default_catalog",
+            "database_name": "ac_manage",
+            "schema_name": "",
+        }
+
+
+def test_get_current_context_normalizes_def_catalog():
+    """Test current context normalizes StarRocks catalog aliases."""
+    config = StarRocksConfig(username="test_user", catalog="def", database="ac_manage")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = StarRocksConnector(config)
+        connector.catalog_name = "def"
+
+        assert connector.get_current_context()["catalog_name"] == "default_catalog"
+
+
+def test_get_current_context_keeps_custom_catalog():
+    """Test current context keeps configured non-default catalogs."""
+    config = StarRocksConfig(username="test_user", catalog="external_catalog", database="analytics")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = StarRocksConnector(config)
+
+        assert connector.get_current_context() == {
+            "catalog_name": "external_catalog",
+            "database_name": "analytics",
+            "schema_name": "",
+        }
+
+
 def test_resolve_catalog_preserves_custom():
     """Test _resolve_catalog preserves custom catalog."""
     config = StarRocksConfig(username="test_user")


### PR DESCRIPTION
Summary:
- Add BaseSqlConnector.get_current_context() for effective SQL coordinates.
- Implement StarRocks current context with resolved catalog and database.
- Add unit coverage for base and StarRocks connector behavior.

Validation:
- uv run --project datus-db-core pytest datus-db-core/tests/unit/test_base.py -q
- uv run --project datus-starrocks pytest datus-starrocks/tests/unit/test_connector_unit.py -q
- uv run --project datus-db-core ruff check datus-db-core/datus_db_core/base.py datus-db-core/tests/unit/test_base.py
- uv run --project datus-starrocks ruff check datus-starrocks/datus_starrocks/connector.py datus-starrocks/tests/unit/test_connector_unit.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve the current SQL context coordinates, including catalog, database, and schema information
  * StarRocks connector now implements specialized catalog name resolution with proper normalization for default values

* **Tests**
  * Added comprehensive unit tests validating SQL context retrieval functionality
  * Included StarRocks-specific test scenarios covering default catalog resolution and custom catalog preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->