### PR TITLE
[Enhancement] Support Snowflake private key secrets

### DIFF
--- a/datus-snowflake/README.md
+++ b/datus-snowflake/README.md
@@ -50,8 +50,30 @@ print(result)  # {'success': True, 'message': 'Connection successful', 'database
 Snowflake accounts with MFA enabled reject plain password logins from non-interactive
 clients. Use RSA key pair authentication (`SNOWFLAKE_JWT`) instead — it bypasses MFA
 and is Snowflake's recommended path for programmatic access. Register the public key
-on your Snowflake user once (`ALTER USER <u> SET RSA_PUBLIC_KEY = '<base64>'`), then
-point the connector at the matching private key file:
+on your Snowflake user once (`ALTER USER <u> SET RSA_PUBLIC_KEY = '<base64>'`).
+
+For hosted/SaaS deployments, store the private key as an encrypted secret field and
+pass it as `private_key`; this avoids writing private keys to local files:
+
+```python
+from datus_snowflake import SnowflakeConnector
+
+connector = SnowflakeConnector(
+    {
+        "account": "myaccount",
+        "username": "myuser",
+        "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----",
+        # Only needed if the private key is encrypted:
+        "private_key_file_pwd": "key-passphrase",
+        "warehouse": "my_warehouse",
+        "database": "my_database",
+        "schema": "my_schema",
+    }
+)
+```
+
+For local or CI setups where a key file is already available, point the connector at
+the matching private key file:
 
 ```python
 from datus_snowflake import SnowflakeConnector
@@ -70,8 +92,9 @@ connector = SnowflakeConnector(
 )
 ```
 
-Exactly one of `password` or `private_key_file` must be provided; passing both (or
-neither) raises a `ValueError`.
+`private_key` takes precedence over `private_key_file` and `password` when
+provided. Without `private_key`, exactly one of `password` or `private_key_file`
+must be provided; passing both (or neither) raises a `ValueError`.
 
 ### Execute Queries
 
@@ -229,7 +252,23 @@ database:
 ```
 
 ```yaml
-# config.yaml — key pair authentication (MFA-friendly)
+# config.yaml — key pair authentication with an in-memory/DB-backed PEM secret
+database:
+  type: snowflake
+  account: myaccount
+  username: myuser
+  private_key: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+    -----END PRIVATE KEY-----
+  # private_key_file_pwd: key-passphrase   # only for encrypted keys
+  warehouse: my_warehouse
+  database: my_database
+  schema: my_schema
+```
+
+```yaml
+# config.yaml — key pair authentication with a local file
 database:
   type: snowflake
   account: myaccount

--- a/datus-snowflake/datus_snowflake/config.py
+++ b/datus-snowflake/datus_snowflake/config.py
@@ -23,6 +23,14 @@ class SnowflakeConfig(BaseModel):
         default=None,
         description="Path to PEM-encoded RSA private key for key pair authentication (SNOWFLAKE_JWT)",
     )
+    private_key: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "PEM-encoded RSA private key for key pair authentication (SNOWFLAKE_JWT); "
+            "takes precedence over private_key_file and password"
+        ),
+        json_schema_extra={"input_type": "password"},
+    )
     private_key_file_pwd: Optional[SecretStr] = Field(
         default=None,
         description="Passphrase for the encrypted private key file (omit for unencrypted keys)",
@@ -34,13 +42,21 @@ class SnowflakeConfig(BaseModel):
     role: Optional[str] = Field(default=None, description="Snowflake role to use")
     timeout_seconds: int = Field(default=30, description="Connection timeout in seconds")
 
+    @staticmethod
+    def _has_secret(value: Optional[SecretStr]) -> bool:
+        return value is not None and bool(value.get_secret_value())
+
     @model_validator(mode="after")
-    def _require_exactly_one_credential(self) -> "SnowflakeConfig":
-        has_password = bool(self.password)
+    def _require_supported_credential(self) -> "SnowflakeConfig":
+        has_private_key = self._has_secret(self.private_key)
+        if has_private_key:
+            return self
+
+        has_password = self._has_secret(self.password)
         has_key = bool(self.private_key_file)
         if has_password == has_key:
             raise ValueError(
-                "SnowflakeConfig requires exactly one of `password` or `private_key_file` "
-                "(use key pair authentication for MFA-enforced accounts)"
+                "SnowflakeConfig requires `private_key`, or exactly one of `password` "
+                "or `private_key_file` (private_key takes precedence when provided)"
             )
         return self

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Union, ove
 
 import pyarrow as pa
 import pyarrow.compute as pc
+from cryptography.hazmat.primitives import serialization
 from pandas import DataFrame
 from snowflake.connector import Connect, SnowflakeConnection
 from snowflake.connector.errors import (
@@ -41,6 +42,26 @@ from datus_db_core import (
 from .config import SnowflakeConfig
 
 logger = get_logger(__name__)
+
+
+def _private_key_to_der(private_key: str, private_key_file_pwd: Optional[str] = None) -> bytes:
+    """Convert a PEM private key string into DER bytes accepted by Snowflake."""
+    normalized_pem = private_key.strip()
+    if "\\n" in normalized_pem and "\n" not in normalized_pem:
+        normalized_pem = normalized_pem.replace("\\n", "\n")
+
+    passphrase = private_key_file_pwd.encode() if private_key_file_pwd else None
+    try:
+        private_key = serialization.load_pem_private_key(normalized_pem.encode(), password=passphrase)
+    except TypeError:
+        if passphrase is None:
+            raise
+        private_key = serialization.load_pem_private_key(normalized_pem.encode(), password=None)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
 
 
 def _handle_snowflake_exception(e: Exception, sql: str = "") -> DatusDbException:
@@ -132,7 +153,16 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         }
         if config.role:
             connect_kwargs["role"] = config.role
-        if config.private_key_file:
+        if config.private_key and config.private_key.get_secret_value():
+            connect_kwargs["authenticator"] = "SNOWFLAKE_JWT"
+            private_key_file_pwd = (
+                config.private_key_file_pwd.get_secret_value() if config.private_key_file_pwd else None
+            )
+            connect_kwargs["private_key"] = _private_key_to_der(
+                config.private_key.get_secret_value(),
+                private_key_file_pwd,
+            )
+        elif config.private_key_file:
             connect_kwargs["authenticator"] = "SNOWFLAKE_JWT"
             connect_kwargs["private_key_file"] = config.private_key_file
             if config.private_key_file_pwd:

--- a/datus-snowflake/pyproject.toml
+++ b/datus-snowflake/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     {name = "DatusAI", email = "support@datus.ai"}
 ]
 dependencies = [
+    "cryptography>=41.0.0",
     "datus-db-core>=0.1.3",
     "snowflake-connector-python>=3.6.0",
     "pandas>=2.1.2,<2.2.0",

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -7,8 +7,30 @@
 from unittest.mock import patch
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from datus_snowflake import SnowflakeConfig, SnowflakeConnector
+
+
+def _private_key_material(encryption_password: bytes | None = None) -> tuple[str, bytes]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    encryption_algorithm = (
+        serialization.NoEncryption()
+        if encryption_password is None
+        else serialization.BestAvailableEncryption(encryption_password)
+    )
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption_algorithm,
+    ).decode()
+    der = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem, der
 
 
 def test_config_requires_password_or_key():
@@ -43,11 +65,40 @@ def test_config_accepts_key_pair_only(tmp_path):
     assert cfg.password is None
 
 
+def test_config_accepts_private_key_only():
+    cfg = SnowflakeConfig(account="a", username="u", warehouse="w", private_key="pem")
+    assert cfg.private_key.get_secret_value() == "pem"
+    assert cfg.private_key_file is None
+    assert cfg.password is None
+
+
+def test_config_private_key_can_override_other_credentials(tmp_path):
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+
+    cfg = SnowflakeConfig(
+        account="a",
+        username="u",
+        warehouse="w",
+        password="p",
+        private_key_file=str(key_file),
+        private_key="pem",
+    )
+
+    assert cfg.private_key.get_secret_value() == "pem"
+    assert cfg.private_key_file == str(key_file)
+    assert cfg.password.get_secret_value() == "p"
+
+
 def test_config_masks_secret_repr():
     """Secrets must not leak through repr/str of the config object."""
     cfg = SnowflakeConfig(account="a", username="u", warehouse="w", password="topsecret")
     assert "topsecret" not in repr(cfg)
     assert "topsecret" not in str(cfg)
+
+    cfg_pem = SnowflakeConfig(account="a", username="u", warehouse="w", private_key="pemsecret")
+    assert "pemsecret" not in repr(cfg_pem)
+    assert "pemsecret" not in str(cfg_pem)
 
 
 def test_config_coerces_numeric_credentials(tmp_path):
@@ -111,3 +162,51 @@ def test_connector_uses_key_pair_auth_kwargs(tmp_path):
     assert kwargs["private_key_file_pwd"] == "secret"
     assert kwargs["role"] == "ANALYST"
     assert "password" not in kwargs
+
+
+def test_connector_uses_private_key_auth_kwargs(tmp_path):
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("dummy")
+    pem, der = _private_key_material()
+
+    cfg = SnowflakeConfig(
+        account="a",
+        username="u",
+        warehouse="w",
+        password="ignored-password",
+        private_key_file=str(key_file),
+        private_key=pem.replace("\n", "\\n"),
+        private_key_file_pwd="unused-file-passphrase",
+        role="ANALYST",
+    )
+
+    with patch("datus_snowflake.connector.Connect") as connect:
+        SnowflakeConnector(cfg)
+
+    kwargs = connect.call_args.kwargs
+    assert kwargs["authenticator"] == "SNOWFLAKE_JWT"
+    assert kwargs["private_key"] == der
+    assert kwargs["role"] == "ANALYST"
+    assert "password" not in kwargs
+    assert "private_key_file" not in kwargs
+    assert "private_key_file_pwd" not in kwargs
+
+
+def test_connector_uses_encrypted_private_key_auth_kwargs():
+    pem, der = _private_key_material(b"secret")
+    cfg = SnowflakeConfig(
+        account="a",
+        username="u",
+        warehouse="w",
+        private_key=pem,
+        private_key_file_pwd="secret",
+    )
+
+    with patch("datus_snowflake.connector.Connect") as connect:
+        SnowflakeConnector(cfg)
+
+    kwargs = connect.call_args.kwargs
+    assert kwargs["authenticator"] == "SNOWFLAKE_JWT"
+    assert kwargs["private_key"] == der
+    assert "password" not in kwargs
+    assert "private_key_file" not in kwargs


### PR DESCRIPTION
## Summary
- Add a Snowflake `private_key` config field for SaaS/DB-backed PEM private keys.
- Prefer `private_key` over `private_key_file` and `password`, converting PEM text to DER bytes for the official Snowflake connector `private_key` parameter.
- Keep `private_key_file_pwd` for encrypted private keys and document both in-memory and file-based key pair auth.

## Validation
- `uv run --package datus-snowflake --with pytest pytest datus-snowflake/tests -m "not integration" -q`
- pre-commit ruff format / ruff hooks during commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for inline PEM-based private keys for Snowflake key-pair authentication with optional encryption passphrase support

* **Documentation**
  * Updated Snowflake authentication configuration examples and guidance
  * Clarified credential validation rules and precedence: `private_key` takes precedence over `private_key_file` and `password`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->