### PR TITLE
[Enhancement] Run impacted adapter tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,29 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Resolve changed test base
+        id: changed-base
+        shell: bash
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request)
+              echo "ref=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+              ;;
+            merge_group)
+              echo "ref=${{ github.event.merge_group.base_sha }}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ref=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
       - name: Run unit tests
-        run: ci/run-unit-tests.sh
+        run: |
+          if [ -n "${{ steps.changed-base.outputs.ref }}" ]; then
+            ci/run-unit-tests.sh --changed "${{ steps.changed-base.outputs.ref }}"
+          else
+            ci/run-unit-tests.sh
+          fi
 
   integration-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
@@ -59,8 +80,26 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Run full integration tests
-        run: ci/run-integration-tests.sh
+      - name: Resolve changed test base
+        id: changed-base
+        shell: bash
+        run: |
+          case "${{ github.event_name }}" in
+            merge_group)
+              echo "ref=${{ github.event.merge_group.base_sha }}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ref=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Run impacted integration tests
+        run: |
+          if [ -n "${{ steps.changed-base.outputs.ref }}" ]; then
+            ci/run-integration-tests.sh --changed "${{ steps.changed-base.outputs.ref }}"
+          else
+            ci/run-integration-tests.sh
+          fi
 
       - name: Stop integration services
         if: always()

--- a/ci/required-checks.md
+++ b/ci/required-checks.md
@@ -15,8 +15,9 @@ and job names stable, or update the ruleset and this document in the same change
 - `Adapter CI / unit-tests`
 
 PR checks must stay deterministic and avoid Docker service startup. They protect
-formatting, title hygiene, unit correctness, package import paths, and cheap
-adapter contracts.
+formatting, title hygiene, impacted unit correctness, package import paths, and
+cheap adapter contracts. Shared repository changes, such as workflow, CI, core,
+or SQLAlchemy changes, expand to all unit targets.
 
 ## Merge Queue Required Checks
 
@@ -24,8 +25,9 @@ adapter contracts.
 - `Adapter CI / integration-tests`
 
 `Adapter CI / integration-tests` is intentionally limited to `merge_group` and
-manual dispatch. It starts Docker-backed database services and validates real
-adapter behavior before code reaches `main`.
+manual dispatch. In merge queue runs it starts only impacted Docker-backed
+database services; shared workflow, CI, core, or SQLAlchemy changes expand to
+all integration targets. Manual dispatch keeps the full integration sweep.
 
 ## Bypass Policy
 

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -22,11 +22,12 @@ PACKAGE_SPECS=(
 
 usage() {
   cat <<'USAGE'
-Usage: ci/run-unit-tests.sh [--list] [--dry-run] [package ...]
+Usage: ci/run-unit-tests.sh [--list] [--dry-run] [--changed base-ref] [package ...]
 
 Runs deterministic unit tests for DB adapter workspace packages.
 
 Options:
+  --changed REF    Select impacted package targets from git diff REF...HEAD.
   --list      List configured package targets.
   --dry-run   Print selected package targets without running pytest.
   -h, --help  Show this help.
@@ -51,10 +52,23 @@ list_packages() {
 }
 
 requested_packages=()
+selected_packages=()
+changed_mode=0
+changed_base=""
 dry_run=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --changed)
+      if [ "$#" -lt 2 ]; then
+        echo "--changed requires a base ref" >&2
+        usage >&2
+        exit 2
+      fi
+      changed_mode=1
+      changed_base="$2"
+      shift 2
+      ;;
     --list)
       list_packages
       exit 0
@@ -86,14 +100,64 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+all_packages() {
+  local spec
+  for spec in "${PACKAGE_SPECS[@]}"; do
+    echo "${spec%%:*}"
+  done
+}
+
+packages_from_changed_files() {
+  local base_ref="$1"
+  local changed_files=""
+  changed_files="$(
+    {
+      git diff --name-only "${base_ref}...HEAD"
+      git diff --name-only --cached
+      git diff --name-only
+      git ls-files --others --exclude-standard
+    } | awk 'NF && !seen[$0]++'
+  )"
+
+  if [ -z "$changed_files" ]; then
+    return 0
+  fi
+
+  if echo "$changed_files" | grep -Eq '^(pyproject\.toml|uv\.lock|ci/|\.github/workflows/|datus-db-core/|datus-sqlalchemy/)'; then
+    all_packages
+    return 0
+  fi
+
+  local spec package
+  for spec in "${PACKAGE_SPECS[@]}"; do
+    package="${spec%%:*}"
+    if echo "$changed_files" | grep -Eq "^${package}/"; then
+      echo "$package"
+    fi
+  done
+}
+
+if [ "$changed_mode" -eq 1 ]; then
+  while IFS= read -r package; do
+    [ -n "$package" ] && selected_packages+=("$package")
+  done < <(packages_from_changed_files "$changed_base" | awk '!seen[$0]++')
+else
+  selected_packages=("${requested_packages[@]}")
+fi
+
+if [ "${#selected_packages[@]}" -eq 0 ] && [ "$changed_mode" -eq 1 ]; then
+  echo "No package changes detected; skipping unit tests."
+  exit 0
+fi
+
 should_run_package() {
   local package="$1"
-  if [ "${#requested_packages[@]}" -eq 0 ]; then
+  if [ "${#selected_packages[@]}" -eq 0 ]; then
     return 0
   fi
 
   local requested
-  for requested in "${requested_packages[@]}"; do
+  for requested in "${selected_packages[@]}"; do
     if [ "$requested" = "$package" ]; then
       return 0
     fi


### PR DESCRIPTION
## Summary
- Add `--changed <base-ref>` support to `ci/run-unit-tests.sh` so PR and merge queue unit checks can run only impacted package targets.
- Resolve pull request and merge queue base SHAs in `Adapter CI` and pass them to impacted unit/integration test selection.
- Keep manual workflow dispatch as a full sweep, and keep shared workflow/CI/core/SQLAlchemy changes expanding to all test targets.

## Validation
- `bash -n ci/run-unit-tests.sh ci/run-integration-tests.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'yaml_ok'"`
- `git diff --check -- .github/workflows/test.yml ci/run-unit-tests.sh ci/required-checks.md`
- `ci/run-unit-tests.sh datus-snowflake --dry-run`
- `ci/run-unit-tests.sh --changed upstream/main --dry-run`
- `ci/run-integration-tests.sh --changed upstream/main --dry-run`
