### PR TITLE
[Enhancement] Improve Trino Iceberg migration hints

### DIFF
--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -432,17 +432,47 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
                 "supported": True,
                 "dialect_family": "trino-iceberg",
                 "requires": [],
-                "forbids": ["DUPLICATE KEY (StarRocks)", "ENGINE = ... (ClickHouse/MySQL)"],
+                "forbids": [
+                    "DUPLICATE KEY (StarRocks)",
+                    "ENGINE = ... (ClickHouse/MySQL)",
+                    "checkpoint_interval (Delta Lake-only; Iceberg uses snapshot_id checkpoints)",
+                ],
                 "type_hints": {
                     "partitioning": "Use WITH (partitioning = ARRAY['month(ds)', 'bucket(id, 4)'])",
-                    "format": "Default format is PARQUET; ORC also supported",
+                    "sorted_by": "Use WITH (sorted_by = ARRAY['col']) to sort data written to each file",
+                    "format": "Use WITH (format = 'PARQUET'|'ORC'|'AVRO'); default is PARQUET",
                     "location": "Optional WITH (location = 's3://...') for custom table location",
+                    "snapshot_checkpoint": (
+                        "Persist the last processed Iceberg snapshot_id externally; do not add "
+                        "checkpoint_interval to Iceberg CREATE TABLE DDL"
+                    ),
+                    "change_reads": (
+                        "Use TABLE(system.table_changes(... start_snapshot_id => N, "
+                        "end_snapshot_id => M)) to read per-snapshot changes"
+                    ),
+                },
+                "checkpointing": {
+                    "mode": "iceberg_snapshot",
+                    "checkpoint_key": "snapshot_id",
+                    "latest_checkpoint_sql": (
+                        'SELECT snapshot_id FROM catalog.schema."table$snapshots" ORDER BY committed_at DESC LIMIT 1'
+                    ),
+                    "changes_since_checkpoint_sql": (
+                        "SELECT * FROM TABLE(system.table_changes("
+                        "schema_name => '<schema>', table_name => '<table>', "
+                        "start_snapshot_id => <last_snapshot_id>, "
+                        "end_snapshot_id => <current_snapshot_id>))"
+                    ),
+                    "note": (
+                        "Trino Iceberg exposes snapshots as checkpoints; checkpoint_interval is a "
+                        "Delta Lake table property, not an Iceberg table property."
+                    ),
                 },
                 "example_ddl": (
                     "CREATE TABLE catalog.schema.t (\n"
                     "  id BIGINT,\n"
                     "  ds DATE\n"
-                    ") WITH (partitioning = ARRAY['month(ds)'])"
+                    ") WITH (format = 'PARQUET', partitioning = ARRAY['month(ds)'])"
                 ),
             }
         if catalog_type == "delta":
@@ -500,9 +530,10 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
             return layout
         if catalog_type == "iceberg":
             partition_cols = [c["name"] for c in columns if c["name"].lower() in ("ds", "dt", "partition_date")]
+            layout = {"format": "PARQUET"}
             if partition_cols:
-                return {"partitioning": [f"month({partition_cols[0]})"]}
-            return {}
+                layout["partitioning"] = [f"month({partition_cols[0]})"]
+            return layout
         return {}
 
     def validate_ddl(self, ddl: str) -> List[str]:
@@ -517,6 +548,23 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
             )
         if "ENGINE =" in upper or "ENGINE=" in upper:
             errors.append("ENGINE clause is MySQL/ClickHouse syntax; Trino uses WITH (...) table properties")
+
+        if "CHECKPOINT_INTERVAL" in upper or "PARTITIONED_BY" in upper:
+            try:
+                catalog_type = self._detect_catalog_type()
+            except Exception:
+                catalog_type = "unknown"
+
+            if catalog_type == "iceberg":
+                if "CHECKPOINT_INTERVAL" in upper:
+                    errors.append(
+                        "checkpoint_interval is a Delta Lake table property; Trino Iceberg uses snapshot_id values "
+                        'from the "$snapshots" metadata table as checkpoints'
+                    )
+                if "PARTITIONED_BY" in upper:
+                    errors.append(
+                        "Iceberg catalogs use WITH (partitioning = ARRAY[...]); partitioned_by is not supported"
+                    )
         return errors
 
     def map_source_type(self, source_dialect: str, source_type: str) -> Optional[str]:

--- a/datus-trino/tests/unit/test_migration_mixin.py
+++ b/datus-trino/tests/unit/test_migration_mixin.py
@@ -64,6 +64,29 @@ class TestDescribeMigrationCapabilitiesIceberg:
         )
         assert "partition" in haystack.lower()
 
+    def test_describes_snapshot_checkpointing(self, iceberg_connector):
+        result = iceberg_connector.describe_migration_capabilities()
+
+        checkpointing = result["checkpointing"]
+        assert checkpointing["mode"] == "iceberg_snapshot"
+        assert checkpointing["checkpoint_key"] == "snapshot_id"
+        assert "$snapshots" in checkpointing["latest_checkpoint_sql"]
+        assert "table_changes" in checkpointing["changes_since_checkpoint_sql"]
+
+    def test_does_not_recommend_delta_checkpoint_interval(self, iceberg_connector):
+        result = iceberg_connector.describe_migration_capabilities()
+        text = " ".join(
+            [
+                " ".join(result.get("type_hints", {}).values()),
+                result.get("example_ddl", ""),
+                str(result.get("checkpointing", {})),
+            ]
+        )
+
+        assert "checkpoint_interval" in " ".join(result["forbids"])
+        assert "checkpoint_interval" not in result["example_ddl"]
+        assert "checkpoint_interval" in text
+
 
 class TestDescribeMigrationCapabilitiesGeneric:
     @pytest.fixture
@@ -110,6 +133,35 @@ class TestValidateDdl:
         errors = connector.validate_ddl(ddl)
         assert any("ENGINE" in e.upper() or "CLICKHOUSE" in e.upper() for e in errors)
 
+    def test_accepts_iceberg_snapshot_ddl(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        ddl = """CREATE TABLE catalog.schema.t (
+          id BIGINT,
+          ds DATE
+        ) WITH (format = 'PARQUET', partitioning = ARRAY['month(ds)'])"""
+
+        assert connector.validate_ddl(ddl) == []
+
+    def test_rejects_delta_checkpoint_interval_for_iceberg(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        ddl = """CREATE TABLE catalog.schema.t (
+          id BIGINT,
+          ds DATE
+        ) WITH (format = 'PARQUET', checkpoint_interval = 5)"""
+
+        errors = connector.validate_ddl(ddl)
+        assert any("checkpoint_interval" in e for e in errors)
+
+    def test_rejects_partitioned_by_for_iceberg(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        ddl = """CREATE TABLE catalog.schema.t (
+          id BIGINT,
+          ds DATE
+        ) WITH (partitioned_by = ARRAY['ds'])"""
+
+        errors = connector.validate_ddl(ddl)
+        assert any("partitioning" in e for e in errors)
+
 
 class TestSuggestTableLayoutHive:
     def test_hive_returns_partitioned_by(self, connector, monkeypatch):
@@ -124,14 +176,22 @@ class TestSuggestTableLayoutHive:
 
 
 class TestSuggestTableLayoutIceberg:
-    def test_iceberg_returns_partitioning(self, connector, monkeypatch):
+    def test_iceberg_returns_format_and_partitioning(self, connector, monkeypatch):
+        monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
+        columns = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "ds", "type": "DATE", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout == {"format": "PARQUET", "partitioning": ["month(ds)"]}
+
+    def test_iceberg_returns_format_without_partitioning(self, connector, monkeypatch):
         monkeypatch.setattr(connector, "_detect_catalog_type", lambda: "iceberg")
         columns = [
             {"name": "id", "type": "BIGINT", "nullable": False},
         ]
         layout = connector.suggest_table_layout(columns)
-        # Iceberg hints: include partitioning
-        assert "partitioning" in layout or layout == {}
+        assert layout == {"format": "PARQUET"}
 
 
 class TestSuggestTableLayoutGeneric:


### PR DESCRIPTION

## Summary
- Describe Iceberg snapshot checkpointing in Trino migration capabilities.
- Avoid recommending Delta checkpoint_interval for Iceberg DDL and add validation errors for invalid Iceberg properties.
- Include default PARQUET format in Iceberg table layout suggestions.

## Validation
- uv run --package datus-trino pytest datus-trino/tests/unit/test_migration_mixin.py -q
- uv run --package datus-trino ruff check datus-trino/datus_trino/connector.py datus-trino/tests/unit/test_migration_mixin.py
- uv run --package datus-trino ruff format --check datus-trino/datus_trino/connector.py datus-trino/tests/unit/test_migration_mixin.py
