### PR TITLE
[Enhancement] Qualify table names in connector listings

### DIFF
--- a/datus-clickhouse/datus_clickhouse/connector.py
+++ b/datus-clickhouse/datus_clickhouse/connector.py
@@ -247,9 +247,27 @@ class ClickHouseConnector(SQLAlchemyConnector, MigrationTargetMixin):
         return result
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
-        return [meta["table_name"] for meta in self._get_metadata("table", catalog_name, database_name)]
+        return [
+            self._qualify_name(meta, database_name, schema_name)
+            for meta in self._get_metadata("table", catalog_name, database_name)
+        ]
 
     @override
     def get_tables_with_ddl(

--- a/datus-clickhouse/tests/integration/test_tpch.py
+++ b/datus-clickhouse/tests/integration/test_tpch.py
@@ -13,12 +13,13 @@ from datus_clickhouse import ClickHouseConnector
 def test_tpch_get_tables(tpch_setup: ClickHouseConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables()
+    db = tpch_setup.database_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-clickzetta/datus_clickzetta/connector.py
+++ b/datus-clickzetta/datus_clickzetta/connector.py
@@ -661,6 +661,21 @@ class ClickZettaConnector:
         except DatusDbException:
             return [self.schema_name] if self.schema_name else []
 
+    @staticmethod
+    def _qualify(name, real_db, real_schema, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the connector resolved that coordinate.
+        """
+        parts = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(name)
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         workspace = database_name or self.database_name
         schema = self._normalized_schema(schema_name)
@@ -675,7 +690,11 @@ class ClickZettaConnector:
         if df.empty:
             return []
         valid_types = {"MANAGED_TABLE", "EXTERNAL_TABLE", "BASE TABLE", "TABLE"}
-        return [row.table_name for row in df.itertuples() if str(row.table_type).upper() in valid_types]
+        return [
+            self._qualify(row.table_name, workspace, schema, database_name, schema_name)
+            for row in df.itertuples()
+            if str(row.table_type).upper() in valid_types
+        ]
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         workspace = database_name or self.database_name
@@ -692,7 +711,11 @@ class ClickZettaConnector:
             if df.empty:
                 return []
             view_types = {"VIEW", "DYNAMIC_TABLE"}
-            return [row.table_name for row in df.itertuples() if str(row.table_type).upper() in view_types]
+            return [
+                self._qualify(row.table_name, workspace, schema, database_name, schema_name)
+                for row in df.itertuples()
+                if str(row.table_type).upper() in view_types
+            ]
         except DatusDbException:
             return []
 
@@ -712,7 +735,11 @@ class ClickZettaConnector:
             df = self._run_query(sql)
             if df.empty:
                 return []
-            return [row.table_name for row in df.itertuples() if str(row.table_type).upper() == "MATERIALIZED_VIEW"]
+            return [
+                self._qualify(row.table_name, workspace, schema, database_name, schema_name)
+                for row in df.itertuples()
+                if str(row.table_type).upper() == "MATERIALIZED_VIEW"
+            ]
         except DatusDbException:
             return []
 

--- a/datus-clickzetta/tests/integration/test_tpch.py
+++ b/datus-clickzetta/tests/integration/test_tpch.py
@@ -12,12 +12,14 @@ import pytest
 def test_tpch_get_tables(tpch_setup):
     """Test that TPC-H tables exist."""
     tables = tpch_setup.get_tables()
+    ws = tpch_setup.database_name
+    schema = tpch_setup.schema_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{ws}.{schema}.tpch_region".lower(),
+        f"{ws}.{schema}.tpch_nation".lower(),
+        f"{ws}.{schema}.tpch_customer".lower(),
+        f"{ws}.{schema}.tpch_orders".lower(),
+        f"{ws}.{schema}.tpch_supplier".lower(),
     }
     table_set = {t.lower() for t in tables}
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-greenplum/tests/integration/test_tpch.py
+++ b/datus-greenplum/tests/integration/test_tpch.py
@@ -13,12 +13,13 @@ from datus_greenplum import GreenplumConnector
 def test_tpch_get_tables(tpch_setup: GreenplumConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables(schema_name="public")
+    db = tpch_setup.database_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-hive/datus_hive/connector.py
+++ b/datus-hive/datus_hive/connector.py
@@ -123,21 +123,38 @@ class HiveConnector(SQLAlchemyConnector):
         return {"information_schema", "sys"}
 
     @override
+    @staticmethod
+    def _qualify(name, real_db, real_schema, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the connector resolved that coordinate.
+        """
+        parts = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(name)
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of tables."""
         self.connect()
+        arg_db = database_name
         database_name = database_name or self.database_name
         if database_name:
             sql = f"SHOW TABLES IN {self.quote_identifier(database_name)}"
         else:
             sql = "SHOW TABLES"
         result = self._execute_pandas(sql)
-        return self._extract_table_names(result)
+        return [self._qualify(name, database_name, "", arg_db, "") for name in self._extract_table_names(result)]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of views."""
         self.connect()
+        arg_db = database_name
         database_name = database_name or self.database_name
         if database_name:
             sql = f"SHOW VIEWS IN {self.quote_identifier(database_name)}"
@@ -148,7 +165,7 @@ class HiveConnector(SQLAlchemyConnector):
         except Exception as exc:
             logger.warning("Failed to get Hive views: %s", exc)
             return []
-        return self._extract_table_names(result)
+        return [self._qualify(name, database_name, "", arg_db, "") for name in self._extract_table_names(result)]
 
     @override
     def get_schema(

--- a/datus-hive/tests/integration/test_tpch.py
+++ b/datus-hive/tests/integration/test_tpch.py
@@ -13,12 +13,13 @@ from datus_hive import HiveConnector
 def test_tpch_get_tables(tpch_setup: HiveConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables()
+    db = tpch_setup.database_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-mysql/datus_mysql/connector.py
+++ b/datus-mysql/datus_mysql/connector.py
@@ -236,9 +236,27 @@ class MySQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
         return result
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
-        return [meta["table_name"] for meta in self._get_metadata("table", catalog_name, database_name)]
+        return [
+            self._qualify_name(meta, database_name, schema_name)
+            for meta in self._get_metadata("table", catalog_name, database_name)
+        ]
 
     @override
     def get_tables_with_ddl(

--- a/datus-mysql/tests/integration/test_tpch.py
+++ b/datus-mysql/tests/integration/test_tpch.py
@@ -13,12 +13,13 @@ from datus_mysql import MySQLConnector
 def test_tpch_get_tables(tpch_setup: MySQLConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables()
+    db = tpch_setup.database_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-postgresql/datus_postgresql/connector.py
+++ b/datus-postgresql/datus_postgresql/connector.py
@@ -337,21 +337,45 @@ class PostgreSQLConnector(SQLAlchemyConnector, MigrationTargetMixin):
         return result
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
-        return [meta["table_name"] for meta in self._get_metadata("table", catalog_name, database_name, schema_name)]
+        return [
+            self._qualify_name(meta, database_name, schema_name)
+            for meta in self._get_metadata("table", catalog_name, database_name, schema_name)
+        ]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of view names."""
-        return [meta["table_name"] for meta in self._get_metadata("view", catalog_name, database_name, schema_name)]
+        return [
+            self._qualify_name(meta, database_name, schema_name)
+            for meta in self._get_metadata("view", catalog_name, database_name, schema_name)
+        ]
 
     @override
     def get_materialized_views(
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
     ) -> List[str]:
         """Get list of materialized view names."""
-        return [meta["table_name"] for meta in self._get_metadata("mv", catalog_name, database_name, schema_name)]
+        return [
+            self._qualify_name(meta, database_name, schema_name)
+            for meta in self._get_metadata("mv", catalog_name, database_name, schema_name)
+        ]
 
     @override
     def get_tables_with_ddl(

--- a/datus-postgresql/tests/integration/test_tpch.py
+++ b/datus-postgresql/tests/integration/test_tpch.py
@@ -128,17 +128,21 @@ class TestTpchMetadata:
     """Validate metadata retrieval for TPC-H tables."""
 
     def test_get_tables_includes_tpch(self, tpch_setup):
-        """get_tables() should return TPC-H tables."""
+        """get_tables() should return TPC-H tables qualified with the database name.
+
+        Only ``schema_name`` is passed, so the listing prefixes the unscoped database
+        level, yielding ``<database>.<table>``.
+        """
         tables = tpch_setup.get_tables(schema_name="public")
-        tpch_tables = {t for t in tables if t.startswith("tpch_")}
+        db = tpch_setup.database_name
         expected = {
-            "tpch_region",
-            "tpch_nation",
-            "tpch_supplier",
-            "tpch_customer",
-            "tpch_orders",
+            f"{db}.tpch_region",
+            f"{db}.tpch_nation",
+            f"{db}.tpch_supplier",
+            f"{db}.tpch_customer",
+            f"{db}.tpch_orders",
         }
-        assert expected.issubset(tpch_tables)
+        assert expected.issubset(set(tables))
 
     def test_get_schema_columns(self, tpch_setup):
         """get_schema() should return correct columns for tpch_region."""

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -833,6 +833,21 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             raise _handle_redshift_exception(e, sql)
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """
         Get list of table names.
@@ -851,7 +866,7 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             schema_name=schema_name,
             table_type="table",
         )
-        return [item["table_name"] for item in tables]
+        return [self._qualify_name(item, database_name, schema_name) for item in tables]
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """
@@ -871,7 +886,7 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             schema_name=schema_name,
             table_type="view",
         )
-        return [view["table_name"] for view in views]
+        return [self._qualify_name(view, database_name, schema_name) for view in views]
 
     def get_materialized_views(
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
@@ -893,7 +908,7 @@ class RedshiftConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedView
             schema_name=schema_name,
             table_type="mv",
         )
-        return [mv["table_name"] for mv in mvs]
+        return [self._qualify_name(mv, database_name, schema_name) for mv in mvs]
 
     def _get_tables_per_schema(
         self,

--- a/datus-redshift/tests/integration/test_tpch.py
+++ b/datus-redshift/tests/integration/test_tpch.py
@@ -25,12 +25,14 @@ S = TPCH_SCHEMA
 def test_tpch_get_tables(tpch_setup: RedshiftConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables()
+    db = tpch_setup.database_name
+    schema = tpch_setup.schema_name
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.{schema}.tpch_region",
+        f"{db}.{schema}.tpch_nation",
+        f"{db}.{schema}.tpch_customer",
+        f"{db}.{schema}.tpch_orders",
+        f"{db}.{schema}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -554,6 +554,21 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
                 raise _handle_snowflake_exception(e, sql) from e
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
         self._reject_catalog(catalog_name)
@@ -563,7 +578,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             schema_name=schema_name,
             table_type="table",
         )
-        return [item["table_name"] for item in tables]
+        return [self._qualify_name(item, database_name, schema_name) for item in tables]
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of view names."""
@@ -574,7 +589,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             schema_name=schema_name,
             table_type="view",
         )
-        return [view["table_name"] for view in views]
+        return [self._qualify_name(view, database_name, schema_name) for view in views]
 
     def get_materialized_views(
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
@@ -587,7 +602,7 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             schema_name=schema_name,
             table_type="mv",
         )
-        return [mv["table_name"] for mv in mvs]
+        return [self._qualify_name(mv, database_name, schema_name) for mv in mvs]
 
     def _get_tables_per_db(
         self,

--- a/datus-spark/datus_spark/connector.py
+++ b/datus-spark/datus_spark/connector.py
@@ -109,6 +109,21 @@ class SparkConnector(SQLAlchemyConnector):
         return []
 
     @override
+    @staticmethod
+    def _qualify(name, real_db, real_schema, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the connector resolved that coordinate.
+        """
+        parts = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(name)
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
         db = database_name or self.database_name
@@ -121,7 +136,7 @@ class SparkConnector(SQLAlchemyConnector):
             name_col = result.columns[1]
         else:
             name_col = result.columns[0]
-        return result[name_col].tolist()
+        return [self._qualify(name, db, "", database_name, "") for name in result[name_col].tolist()]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
@@ -135,7 +150,7 @@ class SparkConnector(SQLAlchemyConnector):
                 name_col = result.columns[1]
             else:
                 name_col = result.columns[0]
-            return result[name_col].tolist()
+            return [self._qualify(name, db, "", database_name, "") for name in result[name_col].tolist()]
         except Exception as e:
             logger.warning(f"Failed to get views: {e}")
             return []

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -560,18 +560,41 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
         except Exception as e:
             raise self._handle_exception(e, operation="inspector creation") from e
 
+    @staticmethod
+    def _qualify(name, real_db, real_schema, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the connector resolved that coordinate.
+        """
+        parts = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(name)
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of tables."""
         sqlalchemy_schema = self._sqlalchemy_schema(catalog_name, database_name, schema_name)
         inspector = self._inspector()
-        return inspector.get_table_names(schema=sqlalchemy_schema)
+        real_schema = sqlalchemy_schema or getattr(inspector, "default_schema_name", "") or ""
+        return [
+            self._qualify(name, "", real_schema, "", sqlalchemy_schema)
+            for name in inspector.get_table_names(schema=sqlalchemy_schema)
+        ]
 
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of views."""
         sqlalchemy_schema = self._sqlalchemy_schema(catalog_name, database_name, schema_name)
         inspector = self._inspector()
         try:
-            return inspector.get_view_names(schema=sqlalchemy_schema)
+            real_schema = sqlalchemy_schema or getattr(inspector, "default_schema_name", "") or ""
+            return [
+                self._qualify(name, "", real_schema, "", sqlalchemy_schema)
+                for name in inspector.get_view_names(schema=sqlalchemy_schema)
+            ]
         except Exception as e:
             raise DatusDbException(
                 ErrorCode.DB_FAILED,
@@ -629,7 +652,11 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
         inspector = self._inspector()
         try:
             if hasattr(inspector, "get_materialized_view_names"):
-                return inspector.get_materialized_view_names(schema=schema_name if schema_name else None)
+                real_schema = schema_name or getattr(inspector, "default_schema_name", "") or ""
+                return [
+                    self._qualify(name, "", real_schema, "", schema_name)
+                    for name in inspector.get_materialized_view_names(schema=schema_name if schema_name else None)
+                ]
             return []
         except Exception as e:
             logger.debug(f"Materialized views not supported: {str(e)}")

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -652,10 +652,11 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
         inspector = self._inspector()
         try:
             if hasattr(inspector, "get_materialized_view_names"):
-                real_schema = schema_name or getattr(inspector, "default_schema_name", "") or ""
+                sqlalchemy_schema = self._sqlalchemy_schema(catalog_name, database_name, schema_name)
+                real_schema = sqlalchemy_schema or getattr(inspector, "default_schema_name", "") or ""
                 return [
-                    self._qualify(name, "", real_schema, "", schema_name)
-                    for name in inspector.get_materialized_view_names(schema=schema_name if schema_name else None)
+                    self._qualify(name, "", real_schema, "", sqlalchemy_schema)
+                    for name in inspector.get_materialized_view_names(schema=sqlalchemy_schema)
                 ]
             return []
         except Exception as e:

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -689,7 +689,11 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
                         logger.debug(f"Materialized views not supported: {e}")
 
             logger.info(f"Getting sample data from {len(tables)} tables, limit {top_n}")
-            for table_name in tables:
+            for listed_name in tables:
+                # get_tables/get_views/get_materialized_views now return qualified
+                # ``[db.][schema.]table`` names; strip back to the bare table so
+                # full_name()/identifier() don't double-qualify the coordinates.
+                table_name = listed_name.split(".")[-1]
                 full_name = self.full_name(catalog_name, database_name, schema_name, table_name)
                 query = f"SELECT * FROM {full_name} LIMIT {top_n}"
                 result = self._execute_pandas(query)

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -266,17 +266,32 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         return result
 
     @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
         result = self._get_metadata(table_type="table", catalog_name=catalog_name, database_name=database_name)
-        return [table["table_name"] for table in result]
+        return [self._qualify_name(table, database_name, schema_name) for table in result]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of view names."""
         try:
             result = self._get_metadata(table_type="view", catalog_name=catalog_name, database_name=database_name)
-            return [view["table_name"] for view in result]
+            return [self._qualify_name(view, database_name, schema_name) for view in result]
         except Exception as e:
             logger.warning(f"Failed to get views: {e}")
             return []
@@ -287,7 +302,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         """Get list of materialized view names."""
         try:
             result = self._get_metadata(table_type="mv", catalog_name=catalog_name, database_name=database_name)
-            return [mv["table_name"] for mv in result]
+            return [self._qualify_name(mv, database_name, schema_name) for mv in result]
         except Exception as e:
             logger.warning(f"Failed to get materialized views: {e}")
             return []

--- a/datus-starrocks/tests/integration/test_tpch.py
+++ b/datus-starrocks/tests/integration/test_tpch.py
@@ -13,12 +13,13 @@ from datus_starrocks import StarRocksConnector
 def test_tpch_get_tables(tpch_setup: StarRocksConnector):
     """Test that TPC-H tables exist in the database."""
     tables = tpch_setup.get_tables()
+    db = tpch_setup.starrocks_config.database
     expected = {
-        "tpch_region",
-        "tpch_nation",
-        "tpch_customer",
-        "tpch_orders",
-        "tpch_supplier",
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
     }
     table_set = set(tables)
     assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -155,6 +155,21 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
         return schemas
 
     @override
+    @staticmethod
+    def _qualify(name, real_db, real_schema, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the connector resolved that coordinate.
+        """
+        parts = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(name)
+        return ".".join(parts)
+
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get list of table names."""
         catalog = catalog_name or self.catalog_name
@@ -162,7 +177,10 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
         result = self._execute_pandas(f'SHOW TABLES FROM "{catalog}"."{schema}"')
         if result.empty:
             return []
-        return result.iloc[:, 0].tolist()
+        return [
+            self._qualify(name, catalog, schema, catalog_name, schema_name or database_name)
+            for name in result.iloc[:, 0].tolist()
+        ]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
@@ -176,7 +194,10 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
             )
             if result.empty:
                 return []
-            return result.iloc[:, 0].tolist()
+            return [
+                self._qualify(name, catalog, schema, catalog_name, schema_name or database_name)
+                for name in result.iloc[:, 0].tolist()
+            ]
         except Exception as e:
             logger.warning(f"Failed to get views: {e}")
             return []


### PR DESCRIPTION
## Why

`list_tables` in datus-agent needs each table entry to be addressable on its own. When a caller lists tables without fully scoping the namespace (e.g. no schema, or neither db nor schema), the bare table name the connectors returned was ambiguous — the model could not tell which db/schema a table lived in, and could not form a valid qualified reference for a follow-up query.

## Solution

Change `get_tables` / `get_views` / `get_materialized_views` to return a qualified name formatted as `[db.][schema.]table`, prefixing **only** the namespace levels the caller left blank:

- caller passed neither db nor schema → `db.schema.table`
- caller passed db but not schema → `schema.table`
- caller passed both → `table` (bare)

Key decisions / tradeoffs:

- **Query scope is unchanged.** We do not enumerate extra namespaces or issue N+1 queries. Each connector only assembles the db/schema coordinates it already resolved for the rows it was going to return.
- The qualify decision keys off the caller's **original** arguments, not the connector-defaulted values, so a level filled in from connector defaults is still surfaced in the name.
- A small `_qualify_name` / `_qualify` helper is added per connector. For dict-metadata connectors it reads `database_name`/`schema_name` off the row; for string-list connectors it uses the db/schema resolved at the call site.

Per-connector namespace mapping:

| Connector | Levels |
|---|---|
| snowflake, redshift, postgresql | db + schema |
| clickhouse, mysql, starrocks | db only (`db.table`) |
| clickzetta | workspace (db) + schema |
| hive, spark | db only |
| trino | catalog → db slot, schema → schema slot |
| sqlalchemy | single schema namespace; uses `inspector.default_schema_name` when the caller passed nothing |
| greenplum | inherits the postgresql implementation |

## Test Cases

Manually verified end-to-end against a live Snowflake datasource via datus-agent's `list_tables`: with no args → `DB.SCHEMA.TABLE`, with db only → `SCHEMA.TABLE`, with db+schema → `TABLE`. Existing adapter integration tests should be updated to assert on the qualified form; that follow-up is tracked alongside the datus-agent PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table, view, and materialized view names are now returned in a fully qualified format when available, making results easier to identify across databases and schemas.
  * Support was expanded across multiple connectors so returned object names now include the appropriate database, schema, catalog, or workspace context when needed.

* **Tests**
  * Updated integration coverage to expect qualified TPC-H object names across the affected connectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->