### PR TITLE
[Tool] Release datus adapters for PR #75 (qualified listing names)

### DIFF
--- a/datus-clickhouse/pyproject.toml
+++ b/datus-clickhouse/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-clickhouse"
-version = "0.1.2"
+version = "0.1.3"
 description = "ClickHouse database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-clickzetta/pyproject.toml
+++ b/datus-clickzetta/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-clickzetta"
-version = "0.1.4"
+version = "0.1.5"
 description = "ClickZetta database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-greenplum/pyproject.toml
+++ b/datus-greenplum/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-greenplum"
-version = "0.1.3"
+version = "0.1.4"
 description = "Greenplum database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "datus-db-core>=0.1.4",
     "datus-sqlalchemy>=0.1.7",
-    "datus-postgresql>=0.1.6",
+    "datus-postgresql>=0.1.7",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",
 ]

--- a/datus-hive/pyproject.toml
+++ b/datus-hive/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-hive"
-version = "0.1.2"
+version = "0.1.3"
 description = "Hive database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-mysql/pyproject.toml
+++ b/datus-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-mysql"
-version = "0.1.7"
+version = "0.1.8"
 description = "MySQL database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-postgresql/pyproject.toml
+++ b/datus-postgresql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-postgresql"
-version = "0.1.6"
+version = "0.1.7"
 description = "PostgreSQL database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-redshift/pyproject.toml
+++ b/datus-redshift/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datus-redshift"
-version = "0.1.3"
+version = "0.1.4"
 description = "Amazon Redshift adapter for Datus Agent"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-snowflake/pyproject.toml
+++ b/datus-snowflake/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datus-snowflake"
-version = "0.1.6"
+version = "0.1.7"
 description = "Snowflake adapter for Datus Agent"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/datus-spark/pyproject.toml
+++ b/datus-spark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-spark"
-version = "0.1.2"
+version = "0.1.3"
 description = "Spark SQL database adapter for Datus"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}

--- a/datus-starrocks/pyproject.toml
+++ b/datus-starrocks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-starrocks"
-version = "0.1.6"
+version = "0.1.7"
 description = "StarRocks database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "datus-db-core>=0.1.3",
-    "datus-mysql>=0.1.7",
+    "datus-mysql>=0.1.8",
     "pydantic>=2.0.0",
 ]
 

--- a/datus-trino/pyproject.toml
+++ b/datus-trino/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datus-trino"
-version = "0.1.2"
+version = "0.1.3"
 description = "Trino database adapter for Datus"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

PR #75 changed the connector code of 10 adapters to return qualified `[db.][schema.]table` listing names. This bumps each so the behavior ships to PyPI, plus `greenplum` to enforce the updated `datus-postgresql` lower bound.

## Solution

Version bumps + dependent lower-bound updates, generated via `ci/prepare_package_release.py --update-dependent-bounds`:

| package | bump | dependent bound |
|---|---|---|
| clickhouse | 0.1.2 → 0.1.3 | |
| clickzetta | 0.1.4 → 0.1.5 | |
| hive | 0.1.2 → 0.1.3 | |
| mysql | 0.1.7 → 0.1.8 | starrocks → >=0.1.8 |
| postgresql | 0.1.6 → 0.1.7 | greenplum → >=0.1.7 |
| redshift | 0.1.3 → 0.1.4 | |
| snowflake | 0.1.6 → 0.1.7 | |
| spark | 0.1.2 → 0.1.3 | |
| starrocks | 0.1.6 → 0.1.7 | |
| trino | 0.1.2 → 0.1.3 | |
| greenplum | 0.1.3 → 0.1.4 | |

`datus-sqlalchemy` was already released as 0.1.7 (PR #76).

## Test Cases

- `pyproject.toml` only; no code changes.
- After merge, each package is published via the `publish-package-release` workflow (per-package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions across multiple connectors.
  * Updated minimum supported dependency versions for a few packages to keep releases aligned.
  * No user-facing features or behavior changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->