### PR TITLE
[BugFix] Declare pyarrow dependency for datus-redshift

### DIFF
--- a/datus-redshift/pyproject.toml
+++ b/datus-redshift/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "datus-db-core>=0.1.3",
     "redshift_connector>=2.0.0",
     "pydantic>=2.0.0",
+    "pyarrow>=14.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Why

`datus_redshift/connector.py` does a top-level `import pyarrow as pa`, but `pyarrow` was missing from the package dependencies. In an isolated install (the `publish-package-release` validation environment) this fails with `ModuleNotFoundError: No module named 'pyarrow'`, which blocked publishing redshift 0.1.4 (the other 10 adapters from PR #75 published fine).

## Solution

Add `pyarrow>=14.0.0` to `datus-redshift` dependencies, matching the bound used by the other adapters that import pyarrow (snowflake, sqlalchemy, clickzetta). Version stays 0.1.4 (never published — the prior run failed before tagging).

## Test Cases

- `pyproject.toml` only.
- Re-run `publish-package-release` for datus-redshift 0.1.4 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)