### PR TITLE
[BugFix] Declare pandas dependency for datus-redshift

### DIFF
--- a/datus-redshift/pyproject.toml
+++ b/datus-redshift/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "redshift_connector>=2.0.0",
     "pydantic>=2.0.0",
     "pyarrow>=14.0.0",
+    "pandas>=2.1.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Why

After adding pyarrow (#78), `publish-package-release` for redshift 0.1.4 still failed: `ModuleNotFoundError: No module named 'pandas'`. `datus_redshift/connector.py` imports pandas (`from pandas import DataFrame`) at module top level but never declared it.

## Solution

Add `pandas>=2.1.4` (matching datus-sqlalchemy). pyarrow + pandas were the only undeclared top-level third-party imports in the package; with both declared the isolated install now resolves. Version stays 0.1.4 (still unpublished).

## Test Cases

- `pyproject.toml` only.
- Re-run `publish-package-release` for datus-redshift 0.1.4 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)