### PR TITLE
[Feature] Add Apache Doris adapter

### DIFF
--- a/.github/workflows/package-release-readiness.yml
+++ b/.github/workflows/package-release-readiness.yml
@@ -13,6 +13,7 @@ on:
           - datus-mysql
           - datus-postgresql
           - datus-starrocks
+          - datus-doris
           - datus-snowflake
           - datus-clickzetta
           - datus-clickhouse

--- a/.github/workflows/prepare-package-release-pr.yml
+++ b/.github/workflows/prepare-package-release-pr.yml
@@ -13,6 +13,7 @@ on:
           - datus-mysql
           - datus-postgresql
           - datus-starrocks
+          - datus-doris
           - datus-snowflake
           - datus-clickzetta
           - datus-clickhouse

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -13,6 +13,7 @@ on:
           - datus-mysql
           - datus-postgresql
           - datus-starrocks
+          - datus-doris
           - datus-snowflake
           - datus-clickzetta
           - datus-clickhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Plugin Adapters (Independent packages, install as needed)
 ├── datus-sqlalchemy (SQLAlchemy base layer)
 │   ├── datus-mysql
 │   ├── datus-starrocks
+│   └── datus-doris
 │
 └── Native SDK Adapters
     ├── datus-snowflake
@@ -72,7 +73,23 @@ pip install datus-starrocks
 
 ---
 
-### 4. datus-snowflake
+### 4. datus-doris
+Apache Doris database adapter (MySQL protocol compatible).
+
+**Installation**:
+```bash
+pip install datus-doris
+```
+
+**Features**:
+- Inherits MySQL query and connection functionality
+- Multi-Catalog support with the built-in `internal` catalog
+- Asynchronous materialized view metadata and DDL support
+- Doris-specific migration and table-layout guidance
+
+---
+
+### 5. datus-snowflake
 Snowflake database adapter (native SDK).
 
 **Installation**:
@@ -89,7 +106,7 @@ pip install datus-snowflake
 
 ---
 
-### 5. datus-clickzetta
+### 6. datus-clickzetta
 ClickZetta Lakehouse database adapter (native SDK).
 
 **Installation**:
@@ -125,6 +142,7 @@ uv sync
 pip install -e datus-sqlalchemy
 pip install -e datus-mysql
 pip install -e datus-starrocks
+pip install -e datus-doris
 pip install -e datus-snowflake
 ```
 

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -552,14 +552,36 @@ PY
 
 adapters_from_changed_files() {
   local base_ref="$1"
+  local base_changed_files=""
+  local staged_files=""
+  local unstaged_files=""
+  local untracked_files=""
   local changed_files=""
+
+  if ! base_changed_files="$(git diff --name-only "${base_ref}...HEAD")"; then
+    echo "Unable to determine changed adapters from base ref '$base_ref'." >&2
+    return 1
+  fi
+  if ! staged_files="$(git diff --name-only --cached)"; then
+    echo "Unable to determine staged adapter changes." >&2
+    return 1
+  fi
+  if ! unstaged_files="$(git diff --name-only)"; then
+    echo "Unable to determine unstaged adapter changes." >&2
+    return 1
+  fi
+  if ! untracked_files="$(git ls-files --others --exclude-standard)"; then
+    echo "Unable to determine untracked adapter changes." >&2
+    return 1
+  fi
+
   changed_files="$(
-    {
-      git diff --name-only "${base_ref}...HEAD"
-      git diff --name-only --cached
-      git diff --name-only
-      git ls-files --others --exclude-standard
-    } | awk 'NF && !seen[$0]++'
+    printf '%s\n' \
+      "$base_changed_files" \
+      "$staged_files" \
+      "$unstaged_files" \
+      "$untracked_files" |
+      awk 'NF && !seen[$0]++'
   )"
 
   if [ -z "$changed_files" ]; then
@@ -581,9 +603,13 @@ adapters_from_changed_files() {
 
 selected_adapters=()
 if [ "$changed_mode" -eq 1 ]; then
+  changed_adapters=""
+  if ! changed_adapters="$(adapters_from_changed_files "$changed_base")"; then
+    exit 1
+  fi
   while IFS= read -r adapter; do
     [ -n "$adapter" ] && selected_adapters+=("$adapter")
-  done < <(adapters_from_changed_files "$changed_base" | awk '!seen[$0]++')
+  done < <(printf '%s\n' "$changed_adapters" | awk '!seen[$0]++')
 else
   if [ "${#requested_adapters[@]}" -gt 0 ]; then
     selected_adapters=("${requested_adapters[@]}")

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-ALL_ADAPTERS=(postgresql mysql clickhouse starrocks trino greenplum hive spark)
+ALL_ADAPTERS=(postgresql mysql clickhouse starrocks doris trino greenplum hive spark)
 DOCKER_COMPOSE=()
 STARTED_ADAPTERS=()
 
@@ -147,6 +147,7 @@ adapter_services() {
     mysql) echo "mysql:300" ;;
     clickhouse) echo "clickhouse:300" ;;
     starrocks) echo "starrocks:600" ;;
+    doris) echo "doris-fe:600 doris-be:600 hive-metastore:600" ;;
     trino) echo "trino:300" ;;
     greenplum) echo "greenplum:600" ;;
     hive) echo "hive-metastore:600 hive-server:900" ;;
@@ -204,6 +205,17 @@ export_adapter_env() {
       export STARROCKS_CATALOG="default_catalog"
       export STARROCKS_DATABASE="test"
       ;;
+    doris)
+      export DORIS_QUERY_HOST_PORT="${DORIS_QUERY_HOST_PORT:-49030}"
+      export DORIS_HTTP_HOST_PORT="${DORIS_HTTP_HOST_PORT:-48030}"
+      export DORIS_HOST="127.0.0.1"
+      export DORIS_PORT="$DORIS_QUERY_HOST_PORT"
+      export DORIS_USER="root"
+      export DORIS_PASSWORD=""
+      export DORIS_CATALOG="internal"
+      export DORIS_DATABASE="test"
+      export HIVE_METASTORE_URI="thrift://hive-metastore:9083"
+      ;;
     trino)
       export TRINO_HOST_PORT="${TRINO_HOST_PORT:-28080}"
       export TRINO_HOST="127.0.0.1"
@@ -252,6 +264,7 @@ adapter_env_summary() {
     mysql) echo "env: MYSQL_HOST=$MYSQL_HOST MYSQL_PORT=$MYSQL_PORT MYSQL_DATABASE=$MYSQL_DATABASE" ;;
     clickhouse) echo "env: CLICKHOUSE_HOST=$CLICKHOUSE_HOST CLICKHOUSE_PORT=$CLICKHOUSE_PORT CLICKHOUSE_DATABASE=$CLICKHOUSE_DATABASE" ;;
     starrocks) echo "env: STARROCKS_HOST=$STARROCKS_HOST STARROCKS_PORT=$STARROCKS_PORT STARROCKS_CATALOG=$STARROCKS_CATALOG STARROCKS_DATABASE=$STARROCKS_DATABASE" ;;
+    doris) echo "env: DORIS_HOST=$DORIS_HOST DORIS_PORT=$DORIS_PORT DORIS_CATALOG=$DORIS_CATALOG DORIS_DATABASE=$DORIS_DATABASE" ;;
     trino) echo "env: TRINO_HOST=$TRINO_HOST TRINO_PORT=$TRINO_PORT TRINO_CATALOG=$TRINO_CATALOG TRINO_SCHEMA=$TRINO_SCHEMA" ;;
     greenplum) echo "env: GREENPLUM_HOST=$GREENPLUM_HOST GREENPLUM_PORT=$GREENPLUM_PORT GREENPLUM_DATABASE=$GREENPLUM_DATABASE GREENPLUM_SCHEMA=$GREENPLUM_SCHEMA" ;;
     hive) echo "env: HIVE_HOST=$HIVE_HOST HIVE_PORT=$HIVE_PORT HIVE_DATABASE=$HIVE_DATABASE" ;;
@@ -384,6 +397,9 @@ wait_for_adapter_client_readiness() {
       ;;
     starrocks)
       uv run --package datus-starrocks python datus-starrocks/scripts/wait_for_starrocks.py --timeout "${STARROCKS_READY_TIMEOUT:-300}"
+      ;;
+    doris)
+      uv run --package datus-doris python datus-doris/scripts/wait_for_doris.py --timeout "${DORIS_READY_TIMEOUT:-600}"
       ;;
     trino)
       wait_for_python_connector_readiness "trino" "datus-trino"
@@ -569,7 +585,9 @@ if [ "$changed_mode" -eq 1 ]; then
     [ -n "$adapter" ] && selected_adapters+=("$adapter")
   done < <(adapters_from_changed_files "$changed_base" | awk '!seen[$0]++')
 else
-  selected_adapters=("${requested_adapters[@]}")
+  if [ "${#requested_adapters[@]}" -gt 0 ]; then
+    selected_adapters=("${requested_adapters[@]}")
+  fi
 fi
 
 if [ "${#selected_adapters[@]}" -eq 0 ] && [ "$changed_mode" -eq 1 ]; then

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 ALL_ADAPTERS=(postgresql mysql clickhouse starrocks doris trino greenplum hive spark)
 DOCKER_COMPOSE=()
 STARTED_ADAPTERS=()
+CURRENT_ADAPTER=""
 
 usage() {
   cat <<'USAGE'
@@ -293,6 +294,61 @@ cleanup_started() {
   for adapter in "${STARTED_ADAPTERS[@]}"; do
     compose_down "$adapter"
   done
+}
+
+dump_adapter_diagnostics() {
+  local adapter="$1"
+  local compose_file
+  local spec
+  local service_name
+  local container_id
+
+  compose_file="$(adapter_compose "$adapter")"
+  echo ""
+  echo "=== Failure diagnostics: $adapter ===" >&2
+  docker_compose -f "$compose_file" ps -a >&2 || true
+
+  for spec in $(adapter_services "$adapter"); do
+    service_name="${spec%%:*}"
+    container_id="$(docker_compose -f "$compose_file" ps -a -q "$service_name" 2>/dev/null || true)"
+    if [ -z "$container_id" ]; then
+      echo "No container found for service '$service_name'." >&2
+      continue
+    fi
+
+    printf "service=%s " "$service_name" >&2
+    docker inspect --format \
+      'container={{.Name}} status={{.State.Status}} exit_code={{.State.ExitCode}} oom_killed={{.State.OOMKilled}} error={{.State.Error}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+      "$container_id" >&2 || true
+
+    echo "--- Logs: $service_name ---" >&2
+    docker_compose -f "$compose_file" logs --no-color --tail=300 "$service_name" >&2 || true
+  done
+
+  echo "--- Runner memory ---" >&2
+  if command -v free >/dev/null 2>&1; then
+    free -h >&2 || true
+  elif command -v vm_stat >/dev/null 2>&1; then
+    vm_stat >&2 || true
+  else
+    echo "No supported memory-reporting command found." >&2
+  fi
+
+  echo "--- Docker disk usage ---" >&2
+  docker system df >&2 || true
+  echo "--- Runner filesystem ---" >&2
+  df -h "$ROOT_DIR" >&2 || true
+}
+
+cleanup_on_exit() {
+  local exit_status=$?
+  trap - EXIT
+
+  if [ "$exit_status" -ne 0 ] && [ -n "$CURRENT_ADAPTER" ]; then
+    dump_adapter_diagnostics "$CURRENT_ADAPTER"
+  fi
+  cleanup_started
+  exit "$exit_status"
 }
 
 cleanup_only=0
@@ -647,9 +703,10 @@ if [ "$dry_run" -eq 1 ]; then
 fi
 
 preflight
-trap cleanup_started EXIT
+trap cleanup_on_exit EXIT
 
 for adapter in "${selected_adapters[@]}"; do
+  CURRENT_ADAPTER="$adapter"
   compose_file="$(adapter_compose "$adapter")"
   test_path="$(adapter_test_path "$adapter")"
   package="$(adapter_package "$adapter")"
@@ -680,4 +737,5 @@ for adapter in "${selected_adapters[@]}"; do
   uv run --package "$package" --with pytest --with pandas --with pyarrow pytest "$test_path" -m integration --tb=short --verbose
 
   compose_down "$adapter"
+  CURRENT_ADAPTER=""
 done

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -11,6 +11,7 @@ PACKAGE_SPECS=(
   "datus-postgresql:datus-postgresql/tests/unit"
   "datus-clickhouse:datus-clickhouse/tests/unit"
   "datus-starrocks:datus-starrocks/tests/unit"
+  "datus-doris:datus-doris/tests/unit"
   "datus-trino:datus-trino/tests/unit"
   "datus-greenplum:datus-greenplum/tests/unit"
   "datus-hive:datus-hive/tests/unit"
@@ -142,7 +143,9 @@ if [ "$changed_mode" -eq 1 ]; then
     [ -n "$package" ] && selected_packages+=("$package")
   done < <(packages_from_changed_files "$changed_base" | awk '!seen[$0]++')
 else
-  selected_packages=("${requested_packages[@]}")
+  if [ "${#requested_packages[@]}" -gt 0 ]; then
+    selected_packages=("${requested_packages[@]}")
+  fi
 fi
 
 if [ "${#selected_packages[@]}" -eq 0 ] && [ "$changed_mode" -eq 1 ]; then

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -110,14 +110,36 @@ all_packages() {
 
 packages_from_changed_files() {
   local base_ref="$1"
+  local base_changed_files=""
+  local staged_files=""
+  local unstaged_files=""
+  local untracked_files=""
   local changed_files=""
+
+  if ! base_changed_files="$(git diff --name-only "${base_ref}...HEAD")"; then
+    echo "Unable to determine changed packages from base ref '$base_ref'." >&2
+    return 1
+  fi
+  if ! staged_files="$(git diff --name-only --cached)"; then
+    echo "Unable to determine staged package changes." >&2
+    return 1
+  fi
+  if ! unstaged_files="$(git diff --name-only)"; then
+    echo "Unable to determine unstaged package changes." >&2
+    return 1
+  fi
+  if ! untracked_files="$(git ls-files --others --exclude-standard)"; then
+    echo "Unable to determine untracked package changes." >&2
+    return 1
+  fi
+
   changed_files="$(
-    {
-      git diff --name-only "${base_ref}...HEAD"
-      git diff --name-only --cached
-      git diff --name-only
-      git ls-files --others --exclude-standard
-    } | awk 'NF && !seen[$0]++'
+    printf '%s\n' \
+      "$base_changed_files" \
+      "$staged_files" \
+      "$unstaged_files" \
+      "$untracked_files" |
+      awk 'NF && !seen[$0]++'
   )"
 
   if [ -z "$changed_files" ]; then
@@ -139,9 +161,13 @@ packages_from_changed_files() {
 }
 
 if [ "$changed_mode" -eq 1 ]; then
+  changed_packages=""
+  if ! changed_packages="$(packages_from_changed_files "$changed_base")"; then
+    exit 1
+  fi
   while IFS= read -r package; do
     [ -n "$package" ] && selected_packages+=("$package")
-  done < <(packages_from_changed_files "$changed_base" | awk '!seen[$0]++')
+  done < <(printf '%s\n' "$changed_packages" | awk '!seen[$0]++')
 else
   if [ "${#requested_packages[@]}" -gt 0 ]; then
     selected_packages=("${requested_packages[@]}")

--- a/datus-db-core/datus_db_core/sql_utils.py
+++ b/datus-db-core/datus_db_core/sql_utils.py
@@ -92,42 +92,24 @@ def strip_sql_comments(sql: str) -> str:
     result = []
     i = 0
     length = len(sql)
-    in_single_quote = False
-    in_double_quote = False
+    quote_char: Optional[str] = None
 
     while i < length:
         ch = sql[i]
 
-        if in_single_quote:
+        if quote_char is not None:
             result.append(ch)
-            if ch == "'" and not _is_escaped(sql, i):
-                if i + 1 < length and sql[i + 1] == "'":
+            if ch == quote_char and not _is_escaped(sql, i):
+                if i + 1 < length and sql[i + 1] == quote_char:
                     result.append(sql[i + 1])
                     i += 2
                     continue
-                in_single_quote = False
+                quote_char = None
             i += 1
             continue
 
-        if in_double_quote:
-            result.append(ch)
-            if ch == '"' and not _is_escaped(sql, i):
-                if i + 1 < length and sql[i + 1] == '"':
-                    result.append(sql[i + 1])
-                    i += 2
-                    continue
-                in_double_quote = False
-            i += 1
-            continue
-
-        if ch == "'":
-            in_single_quote = True
-            result.append(ch)
-            i += 1
-            continue
-
-        if ch == '"':
-            in_double_quote = True
+        if ch in ("'", '"', "`"):
+            quote_char = ch
             result.append(ch)
             i += 1
             continue
@@ -160,6 +142,37 @@ def strip_sql_comments(sql: str) -> str:
             continue
 
         result.append(ch)
+        i += 1
+
+    return "".join(result)
+
+
+def mask_sql_quoted_regions(sql: str) -> str:
+    """Replace SQL string literals and quoted identifiers with whitespace."""
+    result = []
+    i = 0
+    length = len(sql)
+    quote_char: Optional[str] = None
+
+    while i < length:
+        ch = sql[i]
+
+        if quote_char is None:
+            if ch in ("'", '"', "`"):
+                quote_char = ch
+                result.append(" ")
+            else:
+                result.append(ch)
+            i += 1
+            continue
+
+        result.append("\n" if ch == "\n" else " ")
+        if ch == quote_char and not _is_escaped(sql, i):
+            if i + 1 < length and sql[i + 1] == quote_char:
+                result.append(" ")
+                i += 2
+                continue
+            quote_char = None
         i += 1
 
     return "".join(result)

--- a/datus-db-core/datus_db_core/sql_utils.py
+++ b/datus-db-core/datus_db_core/sql_utils.py
@@ -305,6 +305,7 @@ _KEYWORD_SQL_TYPE_MAP: Dict[str, SQLType] = {
     "PRAGMA": SQLType.METADATA_SHOW,
     "EXPLAIN": SQLType.EXPLAIN,
     "USE": SQLType.CONTENT_SET,
+    "SWITCH": SQLType.CONTENT_SET,
     "SET": SQLType.CONTENT_SET,
     "CALL": SQLType.CONTENT_SET,
     "EXEC": SQLType.CONTENT_SET,
@@ -432,7 +433,7 @@ def parse_sql_type(sql: str, dialect: str) -> SQLType:
     return inferred if inferred else SQLType.UNKNOWN
 
 
-_CONTEXT_CMD_RE = re.compile(r"^\s*(use|set)\b", flags=re.IGNORECASE)
+_CONTEXT_CMD_RE = re.compile(r"^\s*(use|set|switch)\b", flags=re.IGNORECASE)
 
 
 def _identifier_name(value: Any) -> str:
@@ -494,6 +495,18 @@ def parse_context_switch(sql: str, dialect: str) -> Optional[Dict[str, Any]]:
         "raw": statement,
     }
 
+    if command == "SWITCH":
+        switch_match = re.match(r"^\s*SWITCH\s+(.+)$", statement, flags=re.IGNORECASE)
+        if not switch_match:
+            return None
+        remainder = switch_match.group(1).rstrip(";").strip()
+        if not remainder:
+            return None
+        parts = _parse_identifier_sequence(remainder, normalized_dialect)
+        result["catalog_name"] = parts["identifier"] or parts["database"] or parts["catalog"]
+        result["target"] = "catalog"
+        return result
+
     if command == "USE":
         expression = sqlglot.parse_one(statement, dialect=normalized_dialect, error_level=sqlglot.ErrorLevel.IGNORE)
         if not isinstance(expression, expressions.Use):
@@ -544,7 +557,7 @@ def parse_context_switch(sql: str, dialect: str) -> Optional[Dict[str, Any]]:
             result["target"] = "database"
             return result
 
-        if normalized_dialect == "starrocks":
+        if normalized_dialect in ("starrocks", "doris"):
             if catalog or (database and not catalog):
                 result["catalog_name"] = catalog or database
                 result["database_name"] = identifier

--- a/datus-db-core/tests/unit/test_sql_utils.py
+++ b/datus-db-core/tests/unit/test_sql_utils.py
@@ -10,6 +10,7 @@ from datus_db_core.constants import SQLType
 from datus_db_core.registry import ConnectorRegistry
 from datus_db_core.sql_utils import (
     _first_statement,
+    mask_sql_quoted_regions,
     metadata_identifier,
     parse_context_switch,
     parse_dialect,
@@ -22,12 +23,18 @@ from datus_db_core.sql_utils import (
 @pytest.fixture(autouse=True)
 def restore_registry_metadata():
     saved_connectors = ConnectorRegistry._connectors.copy()
+    saved_factories = ConnectorRegistry._factories.copy()
     saved_metadata = ConnectorRegistry._metadata.copy()
     saved_capabilities = ConnectorRegistry._capabilities.copy()
+    saved_uri_builders = ConnectorRegistry._uri_builders.copy()
+    saved_context_resolvers = ConnectorRegistry._context_resolvers.copy()
     yield
     ConnectorRegistry._connectors = saved_connectors
+    ConnectorRegistry._factories = saved_factories
     ConnectorRegistry._metadata = saved_metadata
     ConnectorRegistry._capabilities = saved_capabilities
+    ConnectorRegistry._uri_builders = saved_uri_builders
+    ConnectorRegistry._context_resolvers = saved_context_resolvers
 
 
 class TestParseReadDialect:
@@ -95,6 +102,25 @@ class TestStripSqlComments:
         result = strip_sql_comments(sql)
         assert "multiline" not in result
         assert "1" in result
+
+    def test_comment_markers_inside_backtick_identifier(self):
+        sql = "SELECT `dash--name`, `block/*name*/` -- real comment\nFROM t"
+        result = strip_sql_comments(sql)
+        assert "`dash--name`" in result
+        assert "`block/*name*/`" in result
+        assert "real comment" not in result
+        assert "FROM t" in result
+
+
+class TestMaskSqlQuotedRegions:
+    def test_masks_literals_and_quoted_identifiers(self):
+        sql = "CREATE TABLE `FULLTEXT` (note VARCHAR DEFAULT 'CHECK(id)') DUPLICATE KEY(id)"
+        masked = mask_sql_quoted_regions(sql)
+
+        assert len(masked) == len(sql)
+        assert "FULLTEXT" not in masked
+        assert "CHECK" not in masked
+        assert "DUPLICATE KEY" in masked
 
 
 class TestFirstStatement:

--- a/datus-db-core/tests/unit/test_sql_utils.py
+++ b/datus-db-core/tests/unit/test_sql_utils.py
@@ -186,6 +186,9 @@ class TestParseSqlType:
         assert parse_sql_type("SET search_path TO my_schema", "postgres") == SQLType.CONTENT_SET
         assert parse_sql_type("SET catalog my_cat", "starrocks") == SQLType.CONTENT_SET
 
+    def test_switch_catalog_doris(self):
+        assert parse_sql_type("SWITCH internal", "doris") == SQLType.CONTENT_SET
+
     def test_with_cte_select(self):
         assert parse_sql_type("WITH cte AS (SELECT 1) SELECT * FROM cte", "snowflake") == SQLType.SELECT
 
@@ -332,6 +335,26 @@ class TestParseContextSwitch:
         assert result is not None
         assert result["database_name"] == "my_db"
         assert result["target"] == "database"
+
+    def test_use_doris_database(self):
+        result = parse_context_switch("USE my_db", "doris")
+        assert result is not None
+        assert result["database_name"] == "my_db"
+        assert result["target"] == "database"
+
+    def test_use_doris_catalog_database(self):
+        result = parse_context_switch("USE external_catalog.analytics", "doris")
+        assert result is not None
+        assert result["catalog_name"] == "external_catalog"
+        assert result["database_name"] == "analytics"
+        assert result["target"] == "database"
+
+    def test_switch_doris_catalog(self):
+        result = parse_context_switch("SWITCH `external-catalog`;", "doris")
+        assert result is not None
+        assert result["command"] == "SWITCH"
+        assert result["catalog_name"] == "external-catalog"
+        assert result["target"] == "catalog"
 
     def test_raw_preserved(self):
         result = parse_context_switch("USE my_db", "mysql")

--- a/datus-doris/README.md
+++ b/datus-doris/README.md
@@ -119,6 +119,8 @@ queries, and list/CSV/Pandas/Arrow output.
 | `DORIS_PASSWORD` | empty | Password |
 | `DORIS_CATALOG` | `internal` | Initial catalog |
 | `DORIS_DATABASE` | `test` | Test database |
+| `DORIS_FE_JAVA_XMS` | `1024m` | Initial FE JVM heap for the Docker test environment |
+| `DORIS_FE_JAVA_XMX` | `2048m` | Maximum FE JVM heap for the Docker test environment |
 | `HIVE_METASTORE_URI` | `thrift://hive-metastore:9083` | Hive catalog metastore URI |
 
 ## License

--- a/datus-doris/README.md
+++ b/datus-doris/README.md
@@ -1,0 +1,126 @@
+# datus-doris
+
+Apache Doris database adapter for Datus.
+
+## Features
+
+- MySQL-protocol connection and SQL execution
+- Multi-catalog discovery and context switching
+- Catalog-aware table, view, schema, and sample-row metadata
+- Asynchronous materialized-view discovery and DDL retrieval
+- Three-part identifiers: `catalog.database.table`
+- Doris migration capability, table-layout, and type-mapping guidance
+- List, CSV, Pandas, and Arrow result formats inherited from `datus-mysql`
+
+## Installation
+
+```bash
+pip install datus-doris
+```
+
+The package installs `datus-db-core` and `datus-mysql` as dependencies and
+registers the `doris` adapter through the `datus.adapters` entry-point group.
+
+## Configuration
+
+```yaml
+database:
+  type: doris
+  host: localhost
+  port: 9030
+  username: root
+  password: ""
+  catalog: internal
+  database: analytics
+```
+
+The built-in catalog is `internal`. External catalogs, including Hive Metastore
+catalogs, can be selected through the same connector API.
+
+## Python API
+
+```python
+from datus_doris import DorisConfig, DorisConnector
+
+config = DorisConfig(
+    host="localhost",
+    port=9030,
+    username="root",
+    password="",
+    catalog="internal",
+    database="analytics",
+)
+
+with DorisConnector(config) as connector:
+    catalogs = connector.get_catalogs()
+    tables = connector.get_tables(database_name="analytics")
+    views = connector.get_views(database_name="analytics")
+    materialized_views = connector.get_materialized_views_with_ddl(
+        database_name="analytics"
+    )
+    result = connector.execute_query("SELECT 1")
+```
+
+Catalog context can be switched explicitly:
+
+```python
+connector.switch_catalog("hive_catalog")
+databases = connector.get_databases()
+connector.switch_catalog("internal")
+```
+
+Fully qualified identifiers are rendered as Doris three-part names:
+
+```python
+connector.full_name(
+    catalog_name="internal",
+    database_name="analytics",
+    table_name="events",
+)
+# `internal`.`analytics`.`events`
+```
+
+## Development and testing
+
+Unit tests do not require a database:
+
+```bash
+ci/run-unit-tests.sh datus-doris
+```
+
+The repository integration runner starts Apache Doris FE/BE 4.0.7 and Hive
+Metastore 4.0.1, waits for an alive backend and a successful OLAP DDL probe,
+runs the complete integration suite, and removes the test services afterward:
+
+```bash
+ci/run-integration-tests.sh doris
+```
+
+To run the package-local workflow manually:
+
+```bash
+cd datus-doris
+docker compose up -d --wait
+./scripts/test.sh integration
+docker compose down -v
+```
+
+The integration suite covers catalog operations, Hive external catalogs,
+tables, views, asynchronous materialized views, DDL/DML, sample rows, TPC-H
+queries, and list/CSV/Pandas/Arrow output.
+
+### Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DORIS_HOST` | `localhost` | FE query host |
+| `DORIS_PORT` | `9030` | MySQL protocol port |
+| `DORIS_USER` | `root` | Username |
+| `DORIS_PASSWORD` | empty | Password |
+| `DORIS_CATALOG` | `internal` | Initial catalog |
+| `DORIS_DATABASE` | `test` | Test database |
+| `HIVE_METASTORE_URI` | `thrift://hive-metastore:9083` | Hive catalog metastore URI |
+
+## License
+
+Apache License 2.0

--- a/datus-doris/datus_doris/__init__.py
+++ b/datus-doris/datus_doris/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from .config import DorisConfig
+from .connector import DorisConnector
+
+__version__ = "0.1.0"
+__all__ = ["DorisConnector", "DorisConfig", "register"]
+
+
+def register():
+    """Register Doris connector with Datus registry."""
+    from datus_db_core import connector_registry
+
+    connector_registry.register(
+        "doris",
+        DorisConnector,
+        config_class=DorisConfig,
+        capabilities={"catalog", "database"},
+    )

--- a/datus-doris/datus_doris/config.py
+++ b/datus-doris/datus_doris/config.py
@@ -1,0 +1,27 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DorisConfig(BaseModel):
+    """Doris-specific configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    host: str = Field(default="127.0.0.1", description="Doris server host")
+    port: int = Field(default=9030, description="Doris server port")
+    username: str = Field(..., description="Doris username")
+    password: str = Field(
+        default="",
+        description="Doris password",
+        json_schema_extra={"input_type": "password"},
+    )
+    catalog: str = Field(default="internal", description="Default catalog name")
+    database: Optional[str] = Field(default=None, description="Default database name")
+    charset: str = Field(default="utf8mb4", description="Character set to use")
+    autocommit: bool = Field(default=True, description="Enable autocommit mode")
+    timeout_seconds: int = Field(default=30, description="Connection timeout in seconds")

--- a/datus-doris/datus_doris/connector.py
+++ b/datus-doris/datus_doris/connector.py
@@ -99,8 +99,10 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
             timeout_seconds=config.timeout_seconds,
         )
         super().__init__(mysql_config)
-        self._deferred_database = config.database if needs_catalog_switch else ""
         self._default_catalog = self.default_catalog() if config.catalog in ("", None, "def") else config.catalog
+        # Keep the configured database in connector context even when it must
+        # be omitted from the initial MySQL connection URL. _conn() consumes
+        # this value after switching to the configured external catalog.
         self._default_database = config.database or ""
 
         # Override dialect to Doris
@@ -296,7 +298,7 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
 
         # Build WHERE clause
         if database_name:
-            safe_db = database_name.replace("'", "''")
+            safe_db = database_name.replace("\\", "\\\\").replace("'", "''")
             where = f"TABLE_SCHEMA = '{safe_db}'"
         else:
             where = list_to_in_str("TABLE_SCHEMA NOT IN", list(self._sys_databases()))
@@ -473,8 +475,8 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
             return []
         current_catalog = self._resolve_catalog(catalog_name)
         database_name = database_name or self.database_name
-        safe_db = database_name.replace("'", "''")
-        safe_table = table_name.replace("'", "''")
+        safe_db = database_name.replace("\\", "\\\\").replace("'", "''")
+        safe_table = table_name.replace("\\", "\\\\").replace("'", "''")
         rows = self._execute_pandas(
             f"""
             SELECT
@@ -558,7 +560,9 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
         return quoted_table
 
     @override
-    def _sqlalchemy_schema(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> str:
+    def _sqlalchemy_schema(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> Optional[str]:
         """Get schema name for SQLAlchemy Inspector with catalog support."""
         database_name = database_name or self.database_name
 
@@ -682,6 +686,7 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
     # ==================== MigrationTargetMixin ====================
 
     def describe_migration_capabilities(self) -> Dict[str, Any]:
+        """Describe Doris-specific DDL and type-mapping requirements."""
         return {
             "supported": True,
             "dialect_family": "mysql-like",
@@ -711,6 +716,7 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
         }
 
     def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Suggest Doris duplicate-key and distribution columns."""
         if not columns:
             return {"duplicate_key": [], "distributed_by": [], "buckets": 10}
 
@@ -754,31 +760,36 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
         return [name for score, name in scored[:max_keys] if score > 0] or [columns[0]["name"]]
 
     def validate_ddl(self, ddl: str) -> List[str]:
+        """Return Doris compatibility errors for a proposed table DDL."""
         errors: List[str] = []
-        upper = ddl.upper()
+        from datus_db_core.sql_utils import strip_sql_comments
 
-        has_duplicate_key = "DUPLICATE KEY" in upper and "ON DUPLICATE KEY" not in upper
-        if not (has_duplicate_key or any(k in upper for k in ("UNIQUE KEY", "AGGREGATE KEY"))):
+        upper = strip_sql_comments(ddl).upper()
+        has_duplicate_key = bool(re.search(r"\bDUPLICATE\s+KEY\b", upper)) and not re.search(
+            r"\bON\s+DUPLICATE\s+KEY\b", upper
+        )
+        if not (has_duplicate_key or re.search(r"\bUNIQUE\s+KEY\b", upper) or re.search(r"\bAGGREGATE\s+KEY\b", upper)):
             errors.append("Doris DDL must define one of: DUPLICATE KEY / UNIQUE KEY / AGGREGATE KEY")
 
-        if "DISTRIBUTED BY" not in upper:
+        if not re.search(r"\bDISTRIBUTED\s+BY\b", upper):
             errors.append("Doris DDL must include a DISTRIBUTED BY clause")
 
-        if "AUTO_INCREMENT" in upper and "UNIQUE KEY" not in upper:
+        if re.search(r"\bAUTO_INCREMENT\b", upper) and not re.search(r"\bUNIQUE\s+KEY\b", upper):
             errors.append("Doris AUTO_INCREMENT columns require a UNIQUE KEY table")
 
-        if "FOREIGN KEY" in upper:
+        if re.search(r"\bFOREIGN\s+KEY\b", upper):
             errors.append("Doris does not support FOREIGN KEY")
 
-        if "FULLTEXT" in upper:
+        if re.search(r"\bFULLTEXT\b", upper):
             errors.append("Doris does not support FULLTEXT indexes")
 
-        if "CHECK" in upper:
+        if re.search(r"\bCHECK\s*\(", upper):
             errors.append("Doris does not support CHECK constraints")
 
         return errors
 
     def map_source_type(self, source_dialect: str, source_type: str) -> str | None:
+        """Map a source type when Doris requires a dialect-specific override."""
         base = source_type.strip().upper()
         # Strip params for matching
         import re as _re

--- a/datus-doris/datus_doris/connector.py
+++ b/datus-doris/datus_doris/connector.py
@@ -762,9 +762,9 @@ class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSuppor
     def validate_ddl(self, ddl: str) -> List[str]:
         """Return Doris compatibility errors for a proposed table DDL."""
         errors: List[str] = []
-        from datus_db_core.sql_utils import strip_sql_comments
+        from datus_db_core.sql_utils import mask_sql_quoted_regions, strip_sql_comments
 
-        upper = strip_sql_comments(ddl).upper()
+        upper = mask_sql_quoted_regions(strip_sql_comments(ddl)).upper()
         has_duplicate_key = bool(re.search(r"\bDUPLICATE\s+KEY\b", upper)) and not re.search(
             r"\bON\s+DUPLICATE\s+KEY\b", upper
         )

--- a/datus-doris/datus_doris/connector.py
+++ b/datus-doris/datus_doris/connector.py
@@ -1,0 +1,797 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import re
+from contextlib import contextmanager
+from typing import Any, Dict, List, Literal, Optional, Set, Union, override
+
+from sqlalchemy import text
+
+from datus_db_core import (
+    TABLE_TYPE,
+    CatalogSupportMixin,
+    ExecuteSQLResult,
+    MaterializedViewSupportMixin,
+    MigrationTargetMixin,
+    get_logger,
+    list_to_in_str,
+    parse_context_switch,
+)
+from datus_mysql import MySQLConnector
+
+from .config import DorisConfig
+
+logger = get_logger(__name__)
+
+_INTEGER_TYPES = frozenset({"INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "INT2", "INT4", "INT8", "LARGEINT"})
+_SWITCH_RE = re.compile(r"^\s*SWITCH\s+(.+?)\s*;?\s*$", flags=re.IGNORECASE | re.DOTALL)
+
+
+def _parse_doris_context_switch(sql: str) -> Optional[Dict[str, Any]]:
+    """Parse Doris context commands, including with older datus-db-core releases."""
+    switch_match = _SWITCH_RE.match(sql)
+    if switch_match:
+        target = switch_match.group(1).rstrip(";").strip()
+        parsed_target = parse_context_switch(f"USE {target}", dialect="starrocks")
+        if not parsed_target:
+            return None
+        catalog_name = parsed_target.get("database_name") or parsed_target.get("catalog_name")
+        return {
+            "command": "SWITCH",
+            "target": "catalog",
+            "catalog_name": catalog_name,
+            "database_name": "",
+            "schema_name": "",
+        }
+
+    if re.match(r"^\s*USE\b", sql, flags=re.IGNORECASE):
+        # Doris and StarRocks share USE [catalog.]database semantics. Parsing
+        # through the older dialect name keeps this adapter compatible with
+        # datus-db-core versions released before the Doris dialect was added.
+        return parse_context_switch(sql, dialect="starrocks")
+
+    return parse_context_switch(sql, dialect="doris")
+
+
+class DorisConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSupportMixin, MigrationTargetMixin):
+    """
+    Doris database connector.
+
+    Doris uses MySQL protocol but adds multi-catalog support and materialized views.
+    Metadata queries use catalog-qualified information_schema (e.g.
+    `catalog.information_schema.TABLES`) so they are stateless and thread-safe,
+    without requiring session context switching.
+    """
+
+    def __init__(self, config: Union[DorisConfig, dict]):
+        """
+        Initialize Doris connector.
+
+        Args:
+            config: DorisConfig object or dict with configuration
+        """
+        # Handle config object or dict
+        if isinstance(config, dict):
+            config = DorisConfig(**config)
+        elif not isinstance(config, DorisConfig):
+            raise TypeError(f"config must be DorisConfig or dict, got {type(config)}")
+
+        self.doris_config = config
+
+        # Pass MySQL config to parent connector
+        from datus_mysql import MySQLConfig
+
+        # When using a non-default catalog, don't put database in the connection
+        # string — it would fail because the database doesn't exist under
+        # internal.  We switch catalog and USE database in connect().
+        needs_catalog_switch = config.catalog and config.catalog not in ("internal", "def")
+        mysql_database = "" if needs_catalog_switch else (config.database or "")
+
+        mysql_config = MySQLConfig(
+            host=config.host,
+            port=config.port,
+            username=config.username,
+            password=config.password,
+            database=mysql_database,
+            charset=config.charset,
+            autocommit=config.autocommit,
+            timeout_seconds=config.timeout_seconds,
+        )
+        super().__init__(mysql_config)
+        self._deferred_database = config.database if needs_catalog_switch else ""
+        self._default_catalog = self.default_catalog() if config.catalog in ("", None, "def") else config.catalog
+        self._default_database = config.database or ""
+
+        # Override dialect to Doris
+        self.dialect = "doris"
+
+    # ==================== Context Manager Support ====================
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit with cleanup."""
+        self.close()
+        return False  # Don't suppress exceptions
+
+    @override
+    def execute(
+        self,
+        input_params: Any,
+        result_format: Optional[Literal["csv", "arrow", "pandas", "list"]] = None,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> ExecuteSQLResult:
+        """Route Doris SWITCH commands even with older core SQL classifiers."""
+        sql_query = (
+            input_params.get("sql_query")
+            if isinstance(input_params, dict)
+            else getattr(input_params, "sql_query", None)
+        )
+        if isinstance(sql_query, str) and _SWITCH_RE.match(sql_query):
+            self.validate_input(input_params)
+            return self.execute_content_set(sql_query.strip())
+        return super().execute(
+            input_params=input_params,
+            result_format=result_format,
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+        )
+
+    # ==================== Catalog Management (CatalogSupportMixin) ====================
+
+    @override
+    def default_catalog(self) -> str:
+        """Doris default catalog."""
+        return "internal"
+
+    @override
+    def get_catalogs(self) -> List[str]:
+        """Get list of catalogs."""
+        result = self._execute_pandas("SHOW CATALOGS")
+        if result.empty:
+            return []
+        catalog_column = "CatalogName" if "CatalogName" in result.columns else "Catalog"
+        return result[catalog_column].tolist()
+
+    @override
+    def switch_catalog(self, catalog_name: str) -> None:
+        """Switch to a different catalog.
+
+        Clears database_name because the old database may not exist
+        in the new catalog.
+
+        Args:
+            catalog_name: Name of the catalog to switch to
+        """
+        self.switch_context(catalog_name=catalog_name)
+        self.database_name = ""
+
+    def _resolve_catalog(self, catalog_name: str = "") -> str:
+        """Resolve the effective catalog name, falling back to configured or default."""
+        catalog = catalog_name or self.catalog_name
+        if not catalog or catalog == "def":
+            return self.default_catalog()
+        return catalog
+
+    @override
+    def get_current_context(self) -> Dict[str, str]:
+        """Return Doris SQL coordinates with the effective catalog resolved."""
+        return {
+            "catalog_name": self._resolve_catalog(),
+            "database_name": self.database_name or "",
+            "schema_name": "",
+        }
+
+    @override
+    def do_switch_context(self, conn, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Apply catalog and/or database context to a connection."""
+        if catalog_name:
+            conn.execute(text(f"SWITCH {self.quote_identifier(catalog_name)}"))
+            conn.commit()
+            logger.debug(f"Switched catalog to: {catalog_name}")
+        if database_name:
+            conn.execute(text(f"USE {self.quote_identifier(database_name)}"))
+            conn.commit()
+            logger.debug(f"Switched database to: {database_name}")
+
+    @contextmanager
+    @override
+    def _conn(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        """Checkout a connection with catalog-aware context.
+
+        When a per-call ``catalog_name`` override targets a catalog different
+        from the stored thread-local catalog and no ``database_name`` is
+        passed explicitly, the stored ``self.database_name`` is NOT carried
+        over: it belongs to the old catalog and may not exist in the new
+        one, which would fail ``USE <db>`` after ``SWITCH <new>``.
+
+        The per-call ``catalog_name`` is normalized via ``_resolve_catalog``
+        (e.g. the ``"def"`` alias → ``internal``) before both the
+        divergence check and the downstream ``SWITCH``, so aliases are
+        compared and applied consistently.
+        """
+        resolved_catalog = self._resolve_catalog(catalog_name) if catalog_name else ""
+        if resolved_catalog and not database_name and resolved_catalog != self.catalog_name:
+            effective_database = ""
+            effective_schema = schema_name or self.schema_name
+            engine = self._ensure_engine()
+            conn = engine.connect()
+            try:
+                self.do_switch_context(
+                    conn,
+                    catalog_name=resolved_catalog,
+                    database_name=effective_database,
+                    schema_name=effective_schema,
+                )
+                yield conn
+            except Exception:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+        else:
+            with super()._conn(
+                catalog_name=resolved_catalog or catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+            ) as conn:
+                yield conn
+
+    @override
+    def execute_content_set(self, sql: str) -> ExecuteSQLResult:
+        """Execute USE/SWITCH, clearing stored database on catalog changes.
+
+        Mirrors ``switch_catalog()``: when the catalog changes, the stored
+        ``database_name`` no longer refers to a valid database under the
+        new catalog, so it is cleared to avoid a stale ``USE`` on the next
+        checkout.
+        """
+        result = super().execute_content_set(sql)
+        if result.success:
+            context = _parse_doris_context_switch(sql)
+            if context:
+                if catalog := context.get("catalog_name"):
+                    self.catalog_name = catalog
+                if database := context.get("database_name"):
+                    self.database_name = database
+                if context.get("target") == "catalog" and context.get("catalog_name"):
+                    self.database_name = ""
+        return result
+
+    # ==================== Metadata Retrieval (Stateless, Catalog-Qualified) ====================
+
+    def _get_metadata(
+        self,
+        table_type: str = "table",
+        catalog_name: str = "",
+        database_name: str = "",
+    ) -> List[Dict[str, str]]:
+        """
+        Get metadata for tables/views using catalog-qualified information_schema.
+
+        Uses `catalog.information_schema.TABLES` syntax so no session-level
+        catalog switch is needed.
+        This makes metadata queries stateless and thread-safe.
+        """
+        self.connect()
+        current_catalog = self._resolve_catalog(catalog_name)
+        database_name = database_name or self.database_name
+
+        if table_type == "mv":
+            return self._get_materialized_view_metadata(current_catalog, database_name)
+
+        from datus_mysql.connector import _get_metadata_config
+
+        metadata_config = _get_metadata_config(table_type)
+
+        # Build WHERE clause
+        if database_name:
+            safe_db = database_name.replace("'", "''")
+            where = f"TABLE_SCHEMA = '{safe_db}'"
+        else:
+            where = list_to_in_str("TABLE_SCHEMA NOT IN", list(self._sys_databases()))
+
+        type_filter = list_to_in_str("AND TABLE_TYPE IN", metadata_config.table_types)
+
+        # Use catalog-qualified information_schema without changing session context.
+        query = (
+            f"SELECT TABLE_SCHEMA, TABLE_NAME "
+            f"FROM {self.quote_identifier(current_catalog)}.information_schema.{metadata_config.info_table} "
+            f"WHERE {where} {type_filter}"
+        )
+
+        query_result = self._execute_pandas(query)
+
+        result = []
+        for i in range(len(query_result)):
+            db_name = query_result["TABLE_SCHEMA"][i]
+            tb_name = query_result["TABLE_NAME"][i]
+            result.append(
+                {
+                    "identifier": self.identifier(
+                        catalog_name=current_catalog, database_name=db_name, table_name=tb_name
+                    ),
+                    "catalog_name": current_catalog,
+                    "schema_name": "",
+                    "database_name": db_name,
+                    "table_name": tb_name,
+                    "table_type": table_type,
+                }
+            )
+        if table_type == "table" and current_catalog == self.default_catalog():
+            materialized_views = {
+                (mv["database_name"], mv["table_name"])
+                for mv in self._get_materialized_view_metadata(current_catalog, database_name)
+            }
+            result = [meta for meta in result if (meta["database_name"], meta["table_name"]) not in materialized_views]
+        return result
+
+    def _get_materialized_view_metadata(self, catalog_name: str, database_name: str = "") -> List[Dict[str, str]]:
+        """Return independently queryable Doris asynchronous materialized views."""
+        if catalog_name != self.default_catalog():
+            return []
+
+        databases = [database_name] if database_name else self.get_databases(catalog_name=catalog_name)
+        result: List[Dict[str, str]] = []
+        for db_name in databases:
+            safe_db = db_name.replace("\\", "\\\\").replace('"', '\\"')
+            rows = self._execute_pandas(f'SELECT Name, QuerySql FROM mv_infos("database"="{safe_db}")')
+            for i in range(len(rows)):
+                table_name = str(rows["Name"][i])
+                result.append(
+                    {
+                        "identifier": self.identifier(
+                            catalog_name=catalog_name,
+                            database_name=db_name,
+                            table_name=table_name,
+                        ),
+                        "catalog_name": catalog_name,
+                        "schema_name": "",
+                        "database_name": db_name,
+                        "table_name": table_name,
+                        "table_type": "mv",
+                        "query_sql": str(rows["QuerySql"][i]),
+                    }
+                )
+        return result
+
+    @override
+    @staticmethod
+    def _qualify_name(meta, arg_db, arg_schema):
+        """Prefix the table with the db/schema levels the caller left blank.
+
+        Yields ``[db.][schema.]table`` so an unscoped listing stays addressable; a level is
+        prepended only when the caller passed it empty and the row carries that coordinate.
+        """
+        parts = []
+        if not arg_db and meta.get("database_name"):
+            parts.append(meta["database_name"])
+        if not arg_schema and meta.get("schema_name"):
+            parts.append(meta["schema_name"])
+        parts.append(meta["table_name"])
+        return ".".join(parts)
+
+    def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
+        """Get list of table names."""
+        result = self._get_metadata(table_type="table", catalog_name=catalog_name, database_name=database_name)
+        return [self._qualify_name(table, database_name, schema_name) for table in result]
+
+    @override
+    def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
+        """Get list of view names."""
+        try:
+            result = self._get_metadata(table_type="view", catalog_name=catalog_name, database_name=database_name)
+            return [self._qualify_name(view, database_name, schema_name) for view in result]
+        except Exception as e:
+            logger.warning(f"Failed to get views: {e}")
+            return []
+
+    def get_materialized_views(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[str]:
+        """Get list of materialized view names."""
+        try:
+            result = self._get_metadata(table_type="mv", catalog_name=catalog_name, database_name=database_name)
+            return [self._qualify_name(mv, database_name, schema_name) for mv in result]
+        except Exception as e:
+            logger.warning(f"Failed to get materialized views: {e}")
+            return []
+
+    def get_materialized_views_with_ddl(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[Dict[str, str]]:
+        """Get asynchronous materialized views with their Doris DDL definitions."""
+        current_catalog = self._resolve_catalog(catalog_name)
+        database_name = database_name or self.database_name
+        result = []
+        for meta in self._get_materialized_view_metadata(current_catalog, database_name):
+            full_name = self.full_name(
+                catalog_name=meta["catalog_name"],
+                database_name=meta["database_name"],
+                table_name=meta["table_name"],
+            )
+            try:
+                definition = self._show_create(full_name, "MATERIALIZED VIEW")
+            except Exception as e:
+                logger.warning(f"Could not get DDL for {full_name}: {e}")
+                definition = meta["query_sql"]
+            meta["definition"] = definition
+            meta.pop("query_sql", None)
+            result.append(meta)
+        return result
+
+    @override
+    def _get_objects_with_ddl(
+        self,
+        table_type: TABLE_TYPE = "table",
+        tables: Optional[List[str]] = None,
+        catalog_name: str = "",
+        database_name: str = "",
+    ) -> List[Dict[str, str]]:
+        """Get catalog-aware Doris table or view metadata with DDL."""
+        from datus_mysql.connector import _get_metadata_config
+
+        requested = set(tables or [])
+        metadata_config = _get_metadata_config(table_type)
+        result = []
+        for meta in self._get_metadata(table_type, catalog_name, database_name):
+            full_name = self.full_name(
+                catalog_name=meta["catalog_name"],
+                database_name=meta["database_name"],
+                table_name=meta["table_name"],
+            )
+            if requested and meta["table_name"] not in requested and full_name not in requested:
+                continue
+            try:
+                meta["definition"] = self._show_create(full_name, metadata_config.show_create_table)
+            except Exception as e:
+                logger.warning(f"Could not get DDL for {full_name}: {e}")
+                meta["definition"] = f"-- DDL not available for {meta['table_name']}"
+            result.append(meta)
+        return result
+
+    @override
+    def get_schema(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Get Doris column metadata from the requested catalog."""
+        if not table_name:
+            return []
+        current_catalog = self._resolve_catalog(catalog_name)
+        database_name = database_name or self.database_name
+        safe_db = database_name.replace("'", "''")
+        safe_table = table_name.replace("'", "''")
+        rows = self._execute_pandas(
+            f"""
+            SELECT
+                COLUMN_NAME AS Field,
+                COLUMN_TYPE AS Type,
+                IS_NULLABLE AS `Null`,
+                COLUMN_KEY AS `Key`,
+                COLUMN_DEFAULT AS `Default`,
+                COLUMN_COMMENT AS Comment
+            FROM {self.quote_identifier(current_catalog)}.information_schema.columns
+            WHERE TABLE_SCHEMA = '{safe_db}'
+              AND TABLE_NAME = '{safe_table}'
+            ORDER BY ORDINAL_POSITION
+            """
+        )
+        return [
+            {
+                "cid": i,
+                "name": rows["Field"][i],
+                "type": rows["Type"][i],
+                "nullable": rows["Null"][i] == "YES",
+                "default_value": rows["Default"][i],
+                "pk": rows["Key"][i] == "PRI",
+                "comment": rows["Comment"][i],
+            }
+            for i in range(len(rows))
+        ]
+
+    # ==================== Database Management ====================
+
+    def _sys_databases(self) -> Set[str]:
+        """System databases to filter out (Doris-specific)."""
+        # Include MySQL system databases plus Doris-specific ones
+        mysql_sys = super()._sys_databases()
+        doris_sys = {"__internal_schema"}
+        return mysql_sys | doris_sys
+
+    @override
+    def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
+        """Get list of databases using catalog-qualified SHOW DATABASES."""
+        current_catalog = self._resolve_catalog(catalog_name)
+        result = self._execute_pandas(f"SHOW DATABASES FROM {self.quote_identifier(current_catalog)}")
+        if result.empty:
+            return []
+        databases = result.iloc[:, 0].tolist()
+        if not include_sys:
+            sys_dbs = self._sys_databases()
+            databases = [db for db in databases if db not in sys_dbs]
+        return databases
+
+    # ==================== Full Name Construction ====================
+
+    @override
+    def full_name(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+    ) -> str:
+        """
+        Build fully-qualified table name with catalog support.
+
+        Doris format: `catalog`.`database`.`table`
+        """
+        catalog_name = self._resolve_catalog(catalog_name)
+        quoted_table = self.quote_identifier(table_name)
+
+        if catalog_name:
+            if database_name:
+                return ".".join(
+                    (
+                        self.quote_identifier(catalog_name),
+                        self.quote_identifier(database_name),
+                        quoted_table,
+                    )
+                )
+            return quoted_table
+        if database_name:
+            return f"{self.quote_identifier(database_name)}.{quoted_table}"
+        return quoted_table
+
+    @override
+    def _sqlalchemy_schema(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> str:
+        """Get schema name for SQLAlchemy Inspector with catalog support."""
+        database_name = database_name or self.database_name
+
+        catalog_name = catalog_name or self.catalog_name or self.default_catalog()
+        if database_name:
+            return f"{catalog_name}.{database_name}"
+        return None
+
+    @override
+    def get_sample_rows(
+        self,
+        tables: Optional[List[str]] = None,
+        top_n: int = 5,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_type: TABLE_TYPE = "table",
+    ) -> List[Dict[str, Any]]:
+        """Get sample rows without losing the requested Doris catalog."""
+        if table_type == "full":
+            return super().get_sample_rows(
+                tables=tables,
+                top_n=top_n,
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_type=table_type,
+            )
+
+        current_catalog = self._resolve_catalog(catalog_name)
+        database_name = database_name or self.database_name
+        requested = set(tables or [])
+        result = []
+        for meta in self._get_metadata(table_type, current_catalog, database_name):
+            qualified_name = self._qualify_name(meta, database_name, schema_name)
+            full_name = self.full_name(
+                catalog_name=meta["catalog_name"],
+                database_name=meta["database_name"],
+                table_name=meta["table_name"],
+            )
+            if (
+                requested
+                and meta["table_name"] not in requested
+                and qualified_name not in requested
+                and full_name not in requested
+            ):
+                continue
+            rows = self._execute_pandas(f"SELECT * FROM {full_name} LIMIT {top_n}")
+            if rows.empty:
+                continue
+            result.append({**meta, "sample_rows": rows.to_csv(index=False)})
+        return result
+
+    # ==================== Connection Cleanup ====================
+
+    @override
+    def close(self):
+        """
+        Close engine with special handling for PyMySQL cleanup errors.
+
+        Doris may trigger PyMySQL struct.pack errors during cleanup,
+        which we safely ignore.
+        """
+        try:
+            super().close()
+        except Exception as e:
+            error_str = str(e)
+
+            # Check for known PyMySQL cleanup errors
+            pymysql_errors = [
+                "struct.error",
+                "struct.pack",
+                "COMMAND.COM_QUIT",
+                "required argument is not an integer",
+            ]
+
+            if any(err in error_str for err in pymysql_errors):
+                logger.debug(f"Ignoring PyMySQL cleanup error: {e}")
+                if hasattr(self, "engine"):
+                    try:
+                        if self.engine:
+                            self.engine.dispose()
+                    except Exception:
+                        pass
+                    finally:
+                        self.engine = None
+                self._owns_engine = False
+            else:
+                logger.error(f"Unexpected close error: {e}")
+                raise
+
+    # ==================== Utility Methods ====================
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert connector to serializable dictionary."""
+        return {
+            "db_type": "doris",
+            "host": self.host,
+            "port": self.port,
+            "user": self.username,
+            "catalog": self.catalog_name,
+            "database": self.database_name,
+        }
+
+    def get_type(self) -> str:
+        """Return the database type."""
+        return "doris"
+
+    @override
+    def test_connection(self) -> bool:
+        """Test the database connection with proper cleanup."""
+        try:
+            return super().test_connection()
+        finally:
+            # Ensure connection is closed after test
+            try:
+                self.close()
+            except Exception as e:
+                logger.debug(f"Ignoring cleanup error during test: {e}")
+
+    # ==================== MigrationTargetMixin ====================
+
+    def describe_migration_capabilities(self) -> Dict[str, Any]:
+        return {
+            "supported": True,
+            "dialect_family": "mysql-like",
+            "requires": [
+                "One of DUPLICATE KEY / UNIQUE KEY / AGGREGATE KEY",
+                "DISTRIBUTED BY HASH(cols) BUCKETS N",
+            ],
+            "forbids": ["FOREIGN KEY", "FULLTEXT INDEX", "CHECK"],
+            "type_hints": {
+                "unbounded VARCHAR": "VARCHAR(65533)",
+                "TEXT": "STRING",
+                "TIMESTAMP": "DATETIME",
+                "TIMESTAMPTZ": "DATETIME",
+                "TIME": "VARCHAR(20) (Doris has no native TIME)",
+                "UUID": "VARCHAR(36)",
+                "HUGEINT": "LARGEINT",
+            },
+            "example_ddl": (
+                "CREATE TABLE db.t (\n"
+                "  id BIGINT NOT NULL,\n"
+                "  name VARCHAR(255)\n"
+                ") ENGINE=OLAP\n"
+                "DUPLICATE KEY(id)\n"
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n"
+                'PROPERTIES ("replication_num" = "1")'
+            ),
+        }
+
+    def suggest_table_layout(self, columns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not columns:
+            return {"duplicate_key": [], "distributed_by": [], "buckets": 10}
+
+        keys = self._score_keys(columns, max_keys=3)
+        return {"duplicate_key": keys, "distributed_by": keys, "buckets": 10}
+
+    @staticmethod
+    def _score_keys(columns: List[Dict[str, Any]], max_keys: int = 3) -> List[str]:
+        """Select key columns using priority rules.
+
+        Priority:
+          1. Columns with 'id' or '_id' suffix (+100)
+          2. INT/BIGINT type columns (+50)
+          3. Non-nullable columns preferred (+10)
+          4. Fallback to first column
+        """
+        import re as _re
+
+        scored = []
+        for col in columns:
+            name = col["name"]
+            col_type = str(col.get("type", "")).upper()
+            base_type = _re.sub(r"\(.*\)", "", col_type).strip()
+            nullable = col.get("nullable", True)
+
+            score = 0
+            if name.lower() == "id" or name.lower().endswith("_id"):
+                score += 100
+            if base_type in _INTEGER_TYPES:
+                score += 50
+            if not nullable:
+                score += 10
+
+            scored.append((score, name))
+
+        scored.sort(key=lambda x: (-x[0], x[1]))
+
+        if scored[0][0] == 0:
+            return [columns[0]["name"]]
+
+        return [name for score, name in scored[:max_keys] if score > 0] or [columns[0]["name"]]
+
+    def validate_ddl(self, ddl: str) -> List[str]:
+        errors: List[str] = []
+        upper = ddl.upper()
+
+        has_duplicate_key = "DUPLICATE KEY" in upper and "ON DUPLICATE KEY" not in upper
+        if not (has_duplicate_key or any(k in upper for k in ("UNIQUE KEY", "AGGREGATE KEY"))):
+            errors.append("Doris DDL must define one of: DUPLICATE KEY / UNIQUE KEY / AGGREGATE KEY")
+
+        if "DISTRIBUTED BY" not in upper:
+            errors.append("Doris DDL must include a DISTRIBUTED BY clause")
+
+        if "AUTO_INCREMENT" in upper and "UNIQUE KEY" not in upper:
+            errors.append("Doris AUTO_INCREMENT columns require a UNIQUE KEY table")
+
+        if "FOREIGN KEY" in upper:
+            errors.append("Doris does not support FOREIGN KEY")
+
+        if "FULLTEXT" in upper:
+            errors.append("Doris does not support FULLTEXT indexes")
+
+        if "CHECK" in upper:
+            errors.append("Doris does not support CHECK constraints")
+
+        return errors
+
+    def map_source_type(self, source_dialect: str, source_type: str) -> str | None:
+        base = source_type.strip().upper()
+        # Strip params for matching
+        import re as _re
+
+        base_noparam = _re.sub(r"\(.*\)", "", base).strip()
+        # Deterministic overrides for well-known pairings
+        overrides = {
+            "HUGEINT": "LARGEINT",
+            "TIMESTAMP": "DATETIME",
+            "TIMESTAMPTZ": "DATETIME",
+            "TIMESTAMP WITH TIME ZONE": "DATETIME",
+            "TEXT": "STRING",
+            "TIME": "VARCHAR(20)",
+            "UUID": "VARCHAR(36)",
+        }
+        return overrides.get(base_noparam)

--- a/datus-doris/datus_doris/tpch_data.py
+++ b/datus-doris/datus_doris/tpch_data.py
@@ -6,8 +6,10 @@
 
 from datus_db_core.testing.tpch import ROW_COUNTS, TPCH_TABLES, build_tpch_inserts
 
-TPCH_DDL = [
-    """
+_TPCH_DDL_ITEMS = [
+    (
+        "tpch_region",
+        """
     CREATE TABLE IF NOT EXISTS `tpch_region` (
         `regionkey` INT NOT NULL,
         `name` VARCHAR(25) NOT NULL,
@@ -17,7 +19,10 @@ TPCH_DDL = [
     DISTRIBUTED BY HASH(`regionkey`) BUCKETS 1
     PROPERTIES ("replication_num" = "1")
     """,
-    """
+    ),
+    (
+        "tpch_nation",
+        """
     CREATE TABLE IF NOT EXISTS `tpch_nation` (
         `nationkey` INT NOT NULL,
         `name` VARCHAR(25) NOT NULL,
@@ -28,7 +33,10 @@ TPCH_DDL = [
     DISTRIBUTED BY HASH(`nationkey`) BUCKETS 1
     PROPERTIES ("replication_num" = "1")
     """,
-    """
+    ),
+    (
+        "tpch_customer",
+        """
     CREATE TABLE IF NOT EXISTS `tpch_customer` (
         `custkey` INT NOT NULL,
         `name` VARCHAR(25) NOT NULL,
@@ -40,7 +48,10 @@ TPCH_DDL = [
     DISTRIBUTED BY HASH(`custkey`) BUCKETS 1
     PROPERTIES ("replication_num" = "1")
     """,
-    """
+    ),
+    (
+        "tpch_orders",
+        """
     CREATE TABLE IF NOT EXISTS `tpch_orders` (
         `orderkey` INT NOT NULL,
         `custkey` INT NOT NULL,
@@ -52,7 +63,10 @@ TPCH_DDL = [
     DISTRIBUTED BY HASH(`orderkey`) BUCKETS 1
     PROPERTIES ("replication_num" = "1")
     """,
-    """
+    ),
+    (
+        "tpch_supplier",
+        """
     CREATE TABLE IF NOT EXISTS `tpch_supplier` (
         `suppkey` INT NOT NULL,
         `name` VARCHAR(25) NOT NULL,
@@ -63,8 +77,13 @@ TPCH_DDL = [
     DISTRIBUTED BY HASH(`suppkey`) BUCKETS 1
     PROPERTIES ("replication_num" = "1")
     """,
+    ),
 ]
 
+if [table for table, _ in _TPCH_DDL_ITEMS] != TPCH_TABLES:
+    raise ValueError("Doris TPC-H DDL order must match the shared TPCH_TABLES order")
+
+TPCH_DDL = [ddl for _, ddl in _TPCH_DDL_ITEMS]
 TPCH_DATA = build_tpch_inserts(lambda t: f"`{t}`")
 
 __all__ = ["TPCH_DDL", "TPCH_DATA", "TPCH_TABLES", "ROW_COUNTS"]

--- a/datus-doris/datus_doris/tpch_data.py
+++ b/datus-doris/datus_doris/tpch_data.py
@@ -1,0 +1,70 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Doris-dialect TPC-H test data definitions."""
+
+from datus_db_core.testing.tpch import ROW_COUNTS, TPCH_TABLES, build_tpch_inserts
+
+TPCH_DDL = [
+    """
+    CREATE TABLE IF NOT EXISTS `tpch_region` (
+        `regionkey` INT NOT NULL,
+        `name` VARCHAR(25) NOT NULL,
+        `comment` VARCHAR(152)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`regionkey`)
+    DISTRIBUTED BY HASH(`regionkey`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS `tpch_nation` (
+        `nationkey` INT NOT NULL,
+        `name` VARCHAR(25) NOT NULL,
+        `regionkey` INT NOT NULL,
+        `comment` VARCHAR(152)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`nationkey`)
+    DISTRIBUTED BY HASH(`nationkey`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS `tpch_customer` (
+        `custkey` INT NOT NULL,
+        `name` VARCHAR(25) NOT NULL,
+        `nationkey` INT NOT NULL,
+        `acctbal` DECIMAL(15,2) NOT NULL,
+        `mktsegment` VARCHAR(10) NOT NULL
+    ) ENGINE=OLAP
+    UNIQUE KEY (`custkey`)
+    DISTRIBUTED BY HASH(`custkey`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS `tpch_orders` (
+        `orderkey` INT NOT NULL,
+        `custkey` INT NOT NULL,
+        `orderstatus` VARCHAR(1) NOT NULL,
+        `totalprice` DECIMAL(15,2) NOT NULL,
+        `orderdate` DATE NOT NULL
+    ) ENGINE=OLAP
+    UNIQUE KEY (`orderkey`)
+    DISTRIBUTED BY HASH(`orderkey`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS `tpch_supplier` (
+        `suppkey` INT NOT NULL,
+        `name` VARCHAR(25) NOT NULL,
+        `nationkey` INT NOT NULL,
+        `acctbal` DECIMAL(15,2) NOT NULL
+    ) ENGINE=OLAP
+    UNIQUE KEY (`suppkey`)
+    DISTRIBUTED BY HASH(`suppkey`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")
+    """,
+]
+
+TPCH_DATA = build_tpch_inserts(lambda t: f"`{t}`")
+
+__all__ = ["TPCH_DDL", "TPCH_DATA", "TPCH_TABLES", "ROW_COUNTS"]

--- a/datus-doris/docker-compose.yml
+++ b/datus-doris/docker-compose.yml
@@ -1,0 +1,74 @@
+services:
+  doris-fe:
+    image: apache/doris:fe-4.0.7
+    environment:
+      FE_SERVERS: "fe1:10.77.80.2:9010"
+      FE_ID: "1"
+      TZ: Asia/Shanghai
+    ports:
+      - "${DORIS_QUERY_HOST_PORT:-9030}:9030"
+      - "${DORIS_HTTP_HOST_PORT:-8030}:8030"
+    healthcheck:
+      test: ["CMD-SHELL", "mysql -h127.0.0.1 -P9030 -uroot -e 'SHOW FRONTENDS' >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    volumes:
+      - doris_fe_data:/opt/apache-doris/fe/doris-meta
+    networks:
+      doris-test:
+        ipv4_address: 10.77.80.2
+
+  doris-be:
+    image: apache/doris:be-4.0.7
+    environment:
+      FE_SERVERS: "fe1:10.77.80.2:9010"
+      BE_ADDR: "10.77.80.3:9050"
+      TZ: Asia/Shanghai
+    depends_on:
+      doris-fe:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysql -h10.77.80.2 -P9030 -uroot -N -e 'SHOW BACKENDS' 2>/dev/null | grep -w 10.77.80.3 | grep -w true >/dev/null",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    volumes:
+      - doris_be_data:/opt/apache-doris/be/storage
+    networks:
+      doris-test:
+        ipv4_address: 10.77.80.3
+
+  hive-metastore:
+    image: apache/hive:4.0.1
+    environment:
+      SERVICE_NAME: metastore
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '(echo > /dev/tcp/localhost/9083) 2>/dev/null || exit 1'"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+    volumes:
+      - hive_warehouse:/opt/hive/data/warehouse
+    networks:
+      doris-test:
+        ipv4_address: 10.77.80.4
+
+networks:
+  doris-test:
+    name: datus-doris-test-network
+    ipam:
+      config:
+        - subnet: 10.77.80.0/24
+
+volumes:
+  doris_fe_data:
+  doris_be_data:
+  hive_warehouse:

--- a/datus-doris/docker-compose.yml
+++ b/datus-doris/docker-compose.yml
@@ -16,8 +16,14 @@ services:
           -e "s/-Xmx[0-9]+[mMgG]/-Xmx$${DORIS_FE_JAVA_XMX}/" \
           -e "s/-Xms[0-9]+[mMgG]/-Xms$${DORIS_FE_JAVA_XMS}/" \
           /opt/apache-doris/fe/conf/fe.conf
+        if ! grep -q -- "-XX:-UseContainerSupport" /opt/apache-doris/fe/conf/fe.conf; then
+          sed -i -E \
+            's/^([[:space:]]*JAVA_OPTS_FOR_JDK_17=")/\1-XX:-UseContainerSupport /' \
+            /opt/apache-doris/fe/conf/fe.conf
+        fi
         grep -q -- "-Xmx$${DORIS_FE_JAVA_XMX}" /opt/apache-doris/fe/conf/fe.conf
         grep -q -- "-Xms$${DORIS_FE_JAVA_XMS}" /opt/apache-doris/fe/conf/fe.conf
+        grep -q -- "-XX:-UseContainerSupport" /opt/apache-doris/fe/conf/fe.conf
         exec bash /usr/local/bin/init_fe.sh
     ports:
       - "${DORIS_QUERY_HOST_PORT:-9030}:9030"

--- a/datus-doris/docker-compose.yml
+++ b/datus-doris/docker-compose.yml
@@ -4,7 +4,21 @@ services:
     environment:
       FE_SERVERS: "fe1:10.77.80.2:9010"
       FE_ID: "1"
+      DORIS_FE_JAVA_XMS: "${DORIS_FE_JAVA_XMS:-1024m}"
+      DORIS_FE_JAVA_XMX: "${DORIS_FE_JAVA_XMX:-2048m}"
       TZ: Asia/Shanghai
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        sed -i -E \
+          -e "s/-Xmx[0-9]+[mMgG]/-Xmx$${DORIS_FE_JAVA_XMX}/" \
+          -e "s/-Xms[0-9]+[mMgG]/-Xms$${DORIS_FE_JAVA_XMS}/" \
+          /opt/apache-doris/fe/conf/fe.conf
+        grep -q -- "-Xmx$${DORIS_FE_JAVA_XMX}" /opt/apache-doris/fe/conf/fe.conf
+        grep -q -- "-Xms$${DORIS_FE_JAVA_XMS}" /opt/apache-doris/fe/conf/fe.conf
+        exec bash /usr/local/bin/init_fe.sh
     ports:
       - "${DORIS_QUERY_HOST_PORT:-9030}:9030"
       - "${DORIS_HTTP_HOST_PORT:-8030}:8030"

--- a/datus-doris/pyproject.toml
+++ b/datus-doris/pyproject.toml
@@ -1,0 +1,75 @@
+[project]
+name = "datus-doris"
+version = "0.1.0"
+description = "Doris database adapter for Datus"
+readme = "README.md"
+requires-python = ">=3.12"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "DatusAI", email = "support@datus.ai"}
+]
+keywords = ["datus", "database", "doris", "adapter"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+]
+
+dependencies = [
+    "datus-db-core>=0.1.3",
+    "datus-mysql>=0.1.8",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/Datus-ai/datus-db-adapters"
+Repository = "https://github.com/Datus-ai/datus-db-adapters"
+Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
+
+[project.entry-points."datus.adapters"]
+doris = "datus_doris:register"
+
+[tool.uv.sources]
+datus-db-core = { workspace = true }
+datus-mysql = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["datus_doris"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+    "acceptance: marks tests as acceptance tests for CI/CD (core functionality validation)",
+]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+[tool.coverage.run]
+source = ["datus_doris"]
+omit = ["tests/*", "**/__init__.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]

--- a/datus-doris/pyproject.toml
+++ b/datus-doris/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
 dependencies = [
     "datus-db-core>=0.1.3",
     "datus-mysql>=0.1.8",
+    "datus-sqlalchemy>=0.1.7",
+    "pymysql>=1.1.1",
     "pydantic>=2.0.0",
 ]
 
@@ -40,6 +42,7 @@ doris = "datus_doris:register"
 [tool.uv.sources]
 datus-db-core = { workspace = true }
 datus-mysql = { workspace = true }
+datus-sqlalchemy = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/datus-doris/scripts/init_tpch_data.py
+++ b/datus-doris/scripts/init_tpch_data.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Initialize TPC-H sample data in Doris.
+
+Usage:
+    # Start Doris first:
+    cd datus-doris && docker compose up -d
+
+    # Then run this script:
+    uv run python scripts/init_tpch_data.py
+
+    # Drop existing tables first (clean re-init):
+    uv run python scripts/init_tpch_data.py --drop
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Suppress adapter registry warnings in workspace dev environment
+logging.getLogger("datus.tools.db_tools.registry").setLevel(logging.ERROR)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from wait_for_doris import DorisReadinessConfig, wait_for_doris_ready  # noqa: E402
+
+from datus_doris import DorisConfig, DorisConnector  # noqa: E402
+from datus_doris.tpch_data import ROW_COUNTS, TPCH_DATA, TPCH_DDL, TPCH_TABLES  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Initialize TPC-H sample data in Doris")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("DORIS_HOST", "localhost"),
+        help="Doris host (default: localhost)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("DORIS_PORT", "9030")),
+        help="Doris MySQL protocol port (default: 9030)",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.getenv("DORIS_USER", "root"),
+        help="Username (default: root)",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.getenv("DORIS_PASSWORD", ""),
+        help="Password (default: empty)",
+    )
+    parser.add_argument(
+        "--catalog",
+        default=os.getenv("DORIS_CATALOG", "internal"),
+        help="Catalog (default: internal)",
+    )
+    parser.add_argument(
+        "--database",
+        default=os.getenv("DORIS_DATABASE", "test"),
+        help="Database (default: test)",
+    )
+    parser.add_argument(
+        "--drop",
+        action="store_true",
+        help="Drop existing TPC-H tables before creating",
+    )
+    parser.add_argument(
+        "--wait-timeout",
+        type=int,
+        default=int(os.getenv("DORIS_READY_TIMEOUT", "300")),
+        help="Seconds to wait for Doris FE/BE readiness before loading data (default: 300)",
+    )
+    args = parser.parse_args()
+
+    print(f"Connecting to Doris at {args.host}:{args.port}...")
+    readiness_config = DorisReadinessConfig(
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        catalog=args.catalog,
+        database=args.database,
+    )
+    try:
+        detail = wait_for_doris_ready(readiness_config, timeout=args.wait_timeout, interval=5)
+        print(f"Doris readiness check passed: {detail}")
+    except TimeoutError as e:
+        print(f"Failed to connect to Doris: {e}")
+        print("  Start it with: cd datus-doris && docker compose up -d")
+        sys.exit(1)
+
+    config = DorisConfig(
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        catalog=args.catalog,
+        database=args.database,
+    )
+    conn = DorisConnector(config)
+
+    if not conn.test_connection():
+        print("Failed to connect to Doris. Is the server running?")
+        print("  Start it with: cd datus-doris && docker compose up -d")
+        sys.exit(1)
+
+    print("Connected successfully!")
+
+    try:
+        if args.drop:
+            print("\nDropping existing TPC-H tables...")
+            for table in TPCH_TABLES:
+                conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")  # noqa: S608
+                print(f"  Dropped {table}")
+
+        print("\nCreating TPC-H tables...")
+        for i, ddl in enumerate(TPCH_DDL):
+            conn.execute_ddl(ddl)
+            print(f"  Created {TPCH_TABLES[i]}")
+
+        print("\nInserting TPC-H data...")
+        for i, data in enumerate(TPCH_DATA):
+            conn.execute_insert(data)
+            print(f"  Inserted {ROW_COUNTS[i]} rows into {TPCH_TABLES[i]}")
+
+        # Verify
+        print("\nVerifying data...")
+        has_mismatch = False
+        for i, table in enumerate(TPCH_TABLES):
+            result = conn.execute(
+                {"sql_query": f"SELECT COUNT(*) AS cnt FROM `{table}`"},  # noqa: S608
+                result_format="list",
+            )
+            count = result.sql_return[0]["cnt"]
+            expected = ROW_COUNTS[i]
+            status = "OK" if count == expected else "MISMATCH"
+            if count != expected:
+                has_mismatch = True
+            print(f"  {table}: {count} rows [{status}]")
+
+        if has_mismatch:
+            print("\nVerification failed. Re-run with --drop for a clean re-init.")
+            sys.exit(2)
+    finally:
+        conn.close()
+
+    print("\nDone! TPC-H data is ready for use in Datus.")
+    print("\nExample queries:")
+    print("  SELECT * FROM `tpch_region`")
+    print("  SELECT n.name, r.name FROM `tpch_nation` n JOIN `tpch_region` r ON n.regionkey = r.regionkey")
+
+
+if __name__ == "__main__":
+    main()

--- a/datus-doris/scripts/init_tpch_data.py
+++ b/datus-doris/scripts/init_tpch_data.py
@@ -37,6 +37,7 @@ from datus_doris.tpch_data import ROW_COUNTS, TPCH_DATA, TPCH_DDL, TPCH_TABLES  
 
 
 def main():
+    """Initialize and verify the Doris TPC-H sample dataset."""
     parser = argparse.ArgumentParser(description="Initialize TPC-H sample data in Doris")
     parser.add_argument(
         "--host",

--- a/datus-doris/scripts/test.sh
+++ b/datus-doris/scripts/test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Test runner script for datus-doris
+# Usage: ./scripts/test.sh [unit|integration|acceptance|all]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PACKAGE_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Set test defaults without overriding caller-provided values.
+export DORIS_HOST="${DORIS_HOST:-localhost}"
+export DORIS_PORT="${DORIS_PORT:-9030}"
+export DORIS_USER="${DORIS_USER:-root}"
+export DORIS_PASSWORD="${DORIS_PASSWORD:-}"
+export DORIS_CATALOG="${DORIS_CATALOG:-internal}"
+export DORIS_DATABASE="${DORIS_DATABASE:-test}"
+
+wait_for_doris() {
+    uv run python scripts/wait_for_doris.py --timeout "${DORIS_READY_TIMEOUT:-300}"
+}
+
+# Function to run tests
+run_unit_tests() {
+    echo -e "${GREEN}Running unit tests (no database required)...${NC}"
+    uv run pytest tests/ -m "not integration" -v
+}
+
+run_integration_tests() {
+    echo -e "${GREEN}Running integration tests (requires Doris)...${NC}"
+    echo -e "${YELLOW}Using: ${DORIS_USER}@${DORIS_HOST}:${DORIS_PORT}/${DORIS_DATABASE}${NC}"
+    wait_for_doris
+    uv run pytest tests/integration -v
+}
+
+run_acceptance_tests() {
+    echo -e "${GREEN}Running acceptance tests...${NC}"
+    echo -e "${YELLOW}Unit tests:${NC}"
+    uv run pytest tests/ -m "acceptance and not integration" -v
+    echo -e "\n${YELLOW}Integration tests:${NC}"
+    wait_for_doris
+    uv run pytest tests/ -m "acceptance and integration" -v
+}
+
+run_all_tests() {
+    run_unit_tests
+    echo ""
+    run_integration_tests
+}
+
+# Parse command
+case "${1:-all}" in
+    unit)
+        run_unit_tests
+        ;;
+    integration)
+        run_integration_tests
+        ;;
+    acceptance)
+        run_acceptance_tests
+        ;;
+    all)
+        run_all_tests
+        ;;
+    *)
+        echo -e "${RED}Usage: $0 [unit|integration|acceptance|all]${NC}"
+        exit 1
+        ;;
+esac

--- a/datus-doris/scripts/wait_for_doris.py
+++ b/datus-doris/scripts/wait_for_doris.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 
 import pymysql
 
+DORIS_PRIVILEGE_ERROR_CODE = 5203
+
 
 @dataclass(frozen=True)
 class DorisReadinessConfig:
@@ -27,19 +29,23 @@ class DorisReadinessConfig:
 
 
 def quote_identifier(identifier: str) -> str:
+    """Quote a Doris identifier."""
     return "`" + identifier.replace("`", "``") + "`"
 
 
 def table_identifier(catalog: str, database: str, table: str) -> str:
+    """Build a qualified, quoted Doris table identifier."""
     parts = [part for part in (catalog, database, table) if part]
     return ".".join(quote_identifier(part) for part in parts)
 
 
 def is_alive(value: object) -> bool:
+    """Interpret Doris SHOW BACKENDS Alive values."""
     return str(value).strip().lower() in {"true", "1", "yes"}
 
 
 def positive_int(value: str) -> int:
+    """Parse a strictly positive integer argument."""
     parsed = int(value)
     if parsed <= 0:
         raise argparse.ArgumentTypeError("must be greater than 0")
@@ -47,6 +53,7 @@ def positive_int(value: str) -> int:
 
 
 def positive_float(value: str) -> float:
+    """Parse a strictly positive floating-point argument."""
     parsed = float(value)
     if parsed <= 0:
         raise argparse.ArgumentTypeError("must be greater than 0")
@@ -54,6 +61,7 @@ def positive_float(value: str) -> float:
 
 
 def check_doris_ready(config: DorisReadinessConfig) -> str:
+    """Verify connectivity, backend health, and OLAP DDL readiness."""
     backend_detail = "backend status not checked"
     probe_table = f"__datus_doris_readiness_probe_{os.getpid()}_{int(time.time() * 1000)}"
     conn = pymysql.connect(
@@ -77,7 +85,8 @@ def check_doris_ready(config: DorisReadinessConfig) -> str:
             try:
                 cursor.execute("SHOW BACKENDS")
             except pymysql.err.OperationalError as exc:
-                if not exc.args or exc.args[0] != 5203:
+                # Doris reports missing SYSTEM OPERATE/NODE privileges as 5203.
+                if not exc.args or exc.args[0] != DORIS_PRIVILEGE_ERROR_CODE:
                     raise
                 backend_detail = "backend status unavailable without SYSTEM OPERATE/NODE privilege"
             else:
@@ -96,25 +105,37 @@ def check_doris_ready(config: DorisReadinessConfig) -> str:
                     cursor.execute(f"SWITCH {quote_identifier(config.catalog)}")
                 cursor.execute(f"CREATE DATABASE IF NOT EXISTS {quote_identifier(config.database)}")
                 full_probe_table = table_identifier(config.catalog, config.database, probe_table)
-                cursor.execute(
-                    f"""
-                    CREATE TABLE {full_probe_table} (
-                        `id` INT
+                create_error: BaseException | None = None
+                try:
+                    cursor.execute(
+                        f"""
+                        CREATE TABLE {full_probe_table} (
+                            `id` INT
+                        )
+                        ENGINE=OLAP
+                        DUPLICATE KEY(`id`)
+                        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                        PROPERTIES ("replication_num" = "1")
+                        """
                     )
-                    ENGINE=OLAP
-                    DUPLICATE KEY(`id`)
-                    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-                    PROPERTIES ("replication_num" = "1")
-                    """
-                )
-                cursor.execute(f"DROP TABLE IF EXISTS {full_probe_table}")
-                return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+                    return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+                except BaseException as exc:
+                    create_error = exc
+                    raise
+                finally:
+                    try:
+                        cursor.execute(f"DROP TABLE IF EXISTS {full_probe_table}")
+                    except Exception as cleanup_error:
+                        if create_error is None:
+                            raise
+                        create_error.add_note(f"Probe-table cleanup also failed: {cleanup_error}")
             return f"{backend_detail}; no database DDL probe requested"
     finally:
         conn.close()
 
 
 def wait_for_doris_ready(config: DorisReadinessConfig, timeout: int, interval: float) -> str:
+    """Poll until Doris passes the readiness probe or timeout expires."""
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
 
@@ -132,6 +153,7 @@ def wait_for_doris_ready(config: DorisReadinessConfig, timeout: int, interval: f
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the readiness-check command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default=os.getenv("DORIS_HOST", "localhost"))
     parser.add_argument("--port", type=int, default=int(os.getenv("DORIS_PORT", "9030")))
@@ -149,6 +171,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    """Run the Doris readiness-check command."""
     args = build_parser().parse_args()
     config = DorisReadinessConfig(
         host=args.host,

--- a/datus-doris/scripts/wait_for_doris.py
+++ b/datus-doris/scripts/wait_for_doris.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Wait until Doris can run test DDL safely."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+
+import pymysql
+
+
+@dataclass(frozen=True)
+class DorisReadinessConfig:
+    host: str
+    port: int
+    username: str
+    password: str
+    catalog: str
+    database: str
+
+
+def quote_identifier(identifier: str) -> str:
+    return "`" + identifier.replace("`", "``") + "`"
+
+
+def table_identifier(catalog: str, database: str, table: str) -> str:
+    parts = [part for part in (catalog, database, table) if part]
+    return ".".join(quote_identifier(part) for part in parts)
+
+
+def is_alive(value: object) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def check_doris_ready(config: DorisReadinessConfig) -> str:
+    backend_detail = "backend status not checked"
+    probe_table = f"__datus_doris_readiness_probe_{os.getpid()}_{int(time.time() * 1000)}"
+    conn = pymysql.connect(
+        host=config.host,
+        port=config.port,
+        user=config.username,
+        password=config.password,
+        charset="utf8mb4",
+        autocommit=True,
+        connect_timeout=5,
+        read_timeout=5,
+        write_timeout=5,
+    )
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            row = cursor.fetchone()
+            if not row or row[0] != 1:
+                raise RuntimeError(f"unexpected SELECT 1 result: {row!r}")
+
+            try:
+                cursor.execute("SHOW BACKENDS")
+            except pymysql.err.OperationalError as exc:
+                if not exc.args or exc.args[0] != 5203:
+                    raise
+                backend_detail = "backend status unavailable without SYSTEM OPERATE/NODE privilege"
+            else:
+                rows = cursor.fetchall()
+                columns = [description[0] for description in cursor.description or []]
+                alive_index = next((index for index, column in enumerate(columns) if column.lower() == "alive"), None)
+                if alive_index is None:
+                    raise RuntimeError(f"SHOW BACKENDS did not return an Alive column: {columns!r}")
+                alive_rows = [row for row in rows if is_alive(row[alive_index])]
+                if not alive_rows:
+                    raise RuntimeError(f"SHOW BACKENDS has no alive backend: columns={columns!r} rows={rows!r}")
+                backend_detail = f"{len(alive_rows)} alive backend(s)"
+
+            if config.database:
+                if config.catalog:
+                    cursor.execute(f"SWITCH {quote_identifier(config.catalog)}")
+                cursor.execute(f"CREATE DATABASE IF NOT EXISTS {quote_identifier(config.database)}")
+                full_probe_table = table_identifier(config.catalog, config.database, probe_table)
+                cursor.execute(
+                    f"""
+                    CREATE TABLE {full_probe_table} (
+                        `id` INT
+                    )
+                    ENGINE=OLAP
+                    DUPLICATE KEY(`id`)
+                    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                    PROPERTIES ("replication_num" = "1")
+                    """
+                )
+                cursor.execute(f"DROP TABLE IF EXISTS {full_probe_table}")
+                return f"{backend_detail}; database {config.database!r} accepts OLAP DDL"
+            return f"{backend_detail}; no database DDL probe requested"
+    finally:
+        conn.close()
+
+
+def wait_for_doris_ready(config: DorisReadinessConfig, timeout: int, interval: float) -> str:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            return check_doris_ready(config)
+        except Exception as exc:  # noqa: BLE001 - readiness probes report the last failure.
+            last_error = exc
+            time.sleep(interval)
+
+    if last_error is None:
+        raise TimeoutError(f"timed out after {timeout}s waiting for Doris readiness")
+    message = f"timed out after {timeout}s waiting for Doris readiness; last error: {last_error}"
+    raise TimeoutError(message) from last_error
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("DORIS_HOST", "localhost"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("DORIS_PORT", "9030")))
+    parser.add_argument("--username", default=os.getenv("DORIS_USER", "root"))
+    parser.add_argument("--password", default=os.getenv("DORIS_PASSWORD", ""))
+    parser.add_argument("--catalog", default=os.getenv("DORIS_CATALOG", "internal"))
+    parser.add_argument("--database", default=os.getenv("DORIS_DATABASE", "test"))
+    parser.add_argument("--timeout", type=positive_int, default=positive_int(os.getenv("DORIS_READY_TIMEOUT", "300")))
+    parser.add_argument(
+        "--interval",
+        type=positive_float,
+        default=positive_float(os.getenv("DORIS_READY_INTERVAL", "5")),
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    config = DorisReadinessConfig(
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        catalog=args.catalog,
+        database=args.database,
+    )
+
+    print(f"Waiting for Doris at {config.host}:{config.port}/{config.catalog}/{config.database}...", flush=True)
+    try:
+        detail = wait_for_doris_ready(config, timeout=args.timeout, interval=args.interval)
+    except TimeoutError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Doris readiness check passed: {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/datus-doris/tests/conftest.py
+++ b/datus-doris/tests/conftest.py
@@ -1,0 +1,15 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+
+def pytest_configure(config):
+    """Configure custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "acceptance: marks tests as acceptance tests for CI/CD (core functionality validation)",
+    )

--- a/datus-doris/tests/integration/__init__.py
+++ b/datus-doris/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.

--- a/datus-doris/tests/integration/conftest.py
+++ b/datus-doris/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import time
+import uuid
 from typing import Generator
 
 import pytest
@@ -32,121 +33,99 @@ def _build_config(database: str | None = None) -> DorisConfig:
 
 
 def _require_success(result, operation: str) -> None:
-    if not result.success:
-        raise RuntimeError(f"{operation} failed: {result.error}")
+    assert result.success, f"{operation} failed: {result.error}"
 
 
 @pytest.fixture(scope="session")
-def hive_catalog_setup() -> Generator[str, None, None]:
-    """Session-scoped fixture: create a Hive external catalog in Doris for catalog tests."""
-    metastore_uri = os.getenv("HIVE_METASTORE_URI", "thrift://hive-metastore:9083")
-    doris_config = _build_config(database="information_schema")
-
-    conn = None
+def database_setup() -> Generator[DorisConfig, None, None]:
+    """Verify Doris and create the test database before running integration tests."""
+    test_config = _build_config()
+    init_conn = DorisConnector(_build_config(database="information_schema"))
     try:
-        conn = DorisConnector(doris_config)
-        if not conn.test_connection():
-            pytest.skip("Doris not available for Hive catalog setup")
-    except Exception as e:
-        pytest.skip(f"Doris not available: {e}")
-
-    try:
-        _require_success(conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`"), "drop Hive catalog")
-        _require_success(
-            conn.execute_ddl(
-                f"""
-            CREATE CATALOG `{HIVE_CATALOG_NAME}`
-            PROPERTIES (
-                "type" = "hms",
-                "hive.metastore.uris" = "{metastore_uri}"
+        assert init_conn.test_connection(), "Doris connection test failed"
+        if test_config.database:
+            _require_success(
+                init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{test_config.database}`"),
+                "create test database",
             )
-            """
-            ),
-            "create Hive catalog",
-        )
-        databases = conn.get_databases(catalog_name=HIVE_CATALOG_NAME, include_sys=True)
-        assert "default" in databases
-        yield HIVE_CATALOG_NAME
     finally:
-        if conn is not None:
-            try:
-                conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`")
-            except Exception:
-                logger.warning("Failed to drop Hive catalog during teardown", exc_info=True)
-            try:
-                conn.close()
-            except Exception:
-                pass
+        init_conn.close()
+
+    yield test_config
 
 
 @pytest.fixture
-def config() -> DorisConfig:
-    """Create Doris configuration from environment or defaults for integration tests."""
-    return _build_config()
+def config(database_setup: DorisConfig) -> DorisConfig:
+    return database_setup.model_copy()
 
 
 @pytest.fixture
 def connector(config: DorisConfig) -> Generator[DorisConnector, None, None]:
-    """Create and cleanup Doris connector for integration tests."""
-    conn = None
-    try:
-        # Ensure test database exists (connect without database first)
-        init_config = DorisConfig(
-            host=config.host,
-            port=config.port,
-            username=config.username,
-            password=config.password,
-            catalog=config.catalog,
-            database="information_schema",
-        )
-        init_conn = DorisConnector(init_config)
-        try:
-            if not init_conn.test_connection():
-                pytest.skip("Database connection test failed")
-            if config.database:
-                init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{config.database}`")
-        finally:
-            init_conn.close()
-
-        conn = DorisConnector(config)
-    except Exception as e:
-        pytest.skip(f"Database not available: {e}")
-
+    conn = DorisConnector(config)
     try:
         yield conn
     finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except Exception:
-                logger.warning("Failed to close connector during teardown", exc_info=True)
+        conn.close()
 
 
-@pytest.fixture(scope="session", autouse=True)
-def metadata_objects_setup() -> Generator[None, None, None]:
-    """Create deterministic table, view, and async materialized view fixtures."""
-    test_config = _build_config()
-    init_conn = None
-    conn = None
+@pytest.fixture(scope="session")
+def hive_catalog_setup(
+    database_setup: DorisConfig,
+) -> Generator[str, None, None]:
+    """Create a real Hive external catalog for Doris catalog tests."""
+    metastore_uri = os.getenv(
+        "HIVE_METASTORE_URI",
+        "thrift://hive-metastore:9083",
+    )
+    conn = DorisConnector(_build_config(database="information_schema"))
     try:
-        init_conn = DorisConnector(_build_config(database="information_schema"))
-        if not init_conn.test_connection():
-            pytest.skip("Database connection test failed")
         _require_success(
-            init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{test_config.database}`"),
-            "create test database",
+            conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`"),
+            "drop Hive catalog",
         )
-        conn = DorisConnector(test_config)
-    except Exception as e:
-        pytest.skip(f"Database not available: {e}")
+        _require_success(
+            conn.execute_ddl(
+                f"""
+                CREATE CATALOG `{HIVE_CATALOG_NAME}`
+                PROPERTIES (
+                    "type" = "hms",
+                    "hive.metastore.uris" = "{metastore_uri}"
+                )
+                """
+            ),
+            "create Hive catalog",
+        )
+        assert "default" in conn.get_databases(
+            catalog_name=HIVE_CATALOG_NAME,
+            include_sys=True,
+        )
+        yield HIVE_CATALOG_NAME
     finally:
-        if init_conn is not None:
-            init_conn.close()
+        try:
+            conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`")
+        finally:
+            conn.close()
 
+
+@pytest.fixture(scope="session")
+def metadata_objects_setup(
+    database_setup: DorisConfig,
+) -> Generator[None, None, None]:
+    """Create deterministic table, view, and async materialized-view fixtures."""
+    conn = DorisConnector(database_setup)
     try:
-        _require_success(conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`"), "drop metadata MV")
-        _require_success(conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`"), "drop metadata view")
-        _require_success(conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`"), "drop metadata table")
+        _require_success(
+            conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`"),
+            "drop metadata MV",
+        )
+        _require_success(
+            conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`"),
+            "drop metadata view",
+        )
+        _require_success(
+            conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`"),
+            "drop metadata table",
+        )
         _require_success(
             conn.execute_ddl(
                 f"""
@@ -185,7 +164,7 @@ def metadata_objects_setup() -> Generator[None, None, None]:
 
         deadline = time.monotonic() + 90
         while time.monotonic() < deadline:
-            if METADATA_MV in conn.get_materialized_views(database_name=test_config.database or "test"):
+            if METADATA_MV in conn.get_materialized_views(database_name=database_setup.database or "test"):
                 break
             time.sleep(2)
         else:
@@ -193,69 +172,71 @@ def metadata_objects_setup() -> Generator[None, None, None]:
 
         yield
     finally:
-        if conn is not None:
-            try:
-                conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`")
-                conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`")
-                conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`")
-            finally:
-                conn.close()
+        try:
+            conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`")
+            conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`")
+            conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`")
+        finally:
+            conn.close()
+
+
+@pytest.fixture
+def unique_key_table(
+    connector: DorisConnector,
+    config: DorisConfig,
+) -> Generator[str, None, None]:
+    """Create an isolated UNIQUE KEY table for one DML test."""
+    table_name = f"datus_dml_{uuid.uuid4().hex[:8]}"
+    connector.switch_context(database_name=config.database)
+    _require_success(
+        connector.execute_ddl(
+            f"""
+            CREATE TABLE `{table_name}` (
+                `id` BIGINT NOT NULL,
+                `name` VARCHAR(64)
+            ) ENGINE=OLAP
+            UNIQUE KEY (`id`)
+            DISTRIBUTED BY HASH(`id`) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "enable_unique_key_merge_on_write" = "true"
+            )
+            """
+        ),
+        "create DML test table",
+    )
+    try:
+        yield table_name
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS `{table_name}`")
 
 
 @pytest.fixture(scope="session")
-def tpch_setup() -> Generator[DorisConnector, None, None]:
-    """Session-scoped fixture: create TPC-H tables, insert data, yield connector, cleanup."""
-    tpch_config = _build_config()
-
-    conn = None
-    # Only skip on connection failures; DDL/DML errors should propagate and fail
-    # the suite so they are not silently hidden.
+def tpch_setup(
+    database_setup: DorisConfig,
+) -> Generator[DorisConnector, None, None]:
+    """Create deterministic TPC-H tables and rows for query-contract tests."""
+    conn = DorisConnector(database_setup)
     try:
-        # Ensure test database exists
-        init_config = DorisConfig(
-            host=tpch_config.host,
-            port=tpch_config.port,
-            username=tpch_config.username,
-            password=tpch_config.password,
-            catalog=tpch_config.catalog,
-            database="information_schema",
-        )
-        init_conn = DorisConnector(init_config)
-        try:
-            if not init_conn.test_connection():
-                pytest.skip("Database connection test failed")
-            if tpch_config.database:
-                init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{tpch_config.database}`")
-        finally:
-            init_conn.close()
-
-        conn = DorisConnector(tpch_config)
-    except Exception as e:
-        pytest.skip(f"Database not available: {e}")
-
-    try:
-        # Drop tables first for deterministic setup.
-        # Errors here are real failures and must not be swallowed.
         for table in TPCH_TABLES:
-            conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
-
-        # Create tables
-        for ddl in TPCH_DDL:
-            conn.execute_ddl(ddl)
-
-        # Insert data
-        for data in TPCH_DATA:
-            conn.execute_insert(data)
+            _require_success(
+                conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`"),
+                f"drop TPC-H table {table}",
+            )
+        for index, ddl in enumerate(TPCH_DDL):
+            _require_success(conn.execute_ddl(ddl), f"create TPC-H table {index}")
+        for index, data in enumerate(TPCH_DATA):
+            _require_success(conn.execute_insert(data), f"insert TPC-H rows {index}")
 
         yield conn
     finally:
-        if conn is not None:
-            try:
-                for table in TPCH_TABLES:
-                    conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
-            except Exception:
-                logger.warning("Failed to drop TPC-H tables during teardown", exc_info=True)
-            try:
-                conn.close()
-            except Exception:
-                logger.warning("Failed to close connection during teardown", exc_info=True)
+        try:
+            for table in TPCH_TABLES:
+                conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
+        except Exception:
+            logger.warning(
+                "Failed to drop TPC-H tables during teardown",
+                exc_info=True,
+            )
+        finally:
+            conn.close()

--- a/datus-doris/tests/integration/conftest.py
+++ b/datus-doris/tests/integration/conftest.py
@@ -1,0 +1,261 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import logging
+import os
+import time
+from typing import Generator
+
+import pytest
+
+from datus_doris import DorisConfig, DorisConnector
+from datus_doris.tpch_data import TPCH_DATA, TPCH_DDL, TPCH_TABLES
+
+logger = logging.getLogger(__name__)
+
+HIVE_CATALOG_NAME = "hive_test_catalog"
+METADATA_TABLE = "datus_metadata_table"
+METADATA_VIEW = "datus_metadata_view"
+METADATA_MV = "datus_metadata_mv"
+
+
+def _build_config(database: str | None = None) -> DorisConfig:
+    return DorisConfig(
+        host=os.getenv("DORIS_HOST", "localhost"),
+        port=int(os.getenv("DORIS_PORT", "9030")),
+        username=os.getenv("DORIS_USER", "root"),
+        password=os.getenv("DORIS_PASSWORD", ""),
+        catalog=os.getenv("DORIS_CATALOG", "internal"),
+        database=database if database is not None else os.getenv("DORIS_DATABASE", "test"),
+    )
+
+
+def _require_success(result, operation: str) -> None:
+    if not result.success:
+        raise RuntimeError(f"{operation} failed: {result.error}")
+
+
+@pytest.fixture(scope="session")
+def hive_catalog_setup() -> Generator[str, None, None]:
+    """Session-scoped fixture: create a Hive external catalog in Doris for catalog tests."""
+    metastore_uri = os.getenv("HIVE_METASTORE_URI", "thrift://hive-metastore:9083")
+    doris_config = _build_config(database="information_schema")
+
+    conn = None
+    try:
+        conn = DorisConnector(doris_config)
+        if not conn.test_connection():
+            pytest.skip("Doris not available for Hive catalog setup")
+    except Exception as e:
+        pytest.skip(f"Doris not available: {e}")
+
+    try:
+        _require_success(conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`"), "drop Hive catalog")
+        _require_success(
+            conn.execute_ddl(
+                f"""
+            CREATE CATALOG `{HIVE_CATALOG_NAME}`
+            PROPERTIES (
+                "type" = "hms",
+                "hive.metastore.uris" = "{metastore_uri}"
+            )
+            """
+            ),
+            "create Hive catalog",
+        )
+        databases = conn.get_databases(catalog_name=HIVE_CATALOG_NAME, include_sys=True)
+        assert "default" in databases
+        yield HIVE_CATALOG_NAME
+    finally:
+        if conn is not None:
+            try:
+                conn.execute_ddl(f"DROP CATALOG IF EXISTS `{HIVE_CATALOG_NAME}`")
+            except Exception:
+                logger.warning("Failed to drop Hive catalog during teardown", exc_info=True)
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@pytest.fixture
+def config() -> DorisConfig:
+    """Create Doris configuration from environment or defaults for integration tests."""
+    return _build_config()
+
+
+@pytest.fixture
+def connector(config: DorisConfig) -> Generator[DorisConnector, None, None]:
+    """Create and cleanup Doris connector for integration tests."""
+    conn = None
+    try:
+        # Ensure test database exists (connect without database first)
+        init_config = DorisConfig(
+            host=config.host,
+            port=config.port,
+            username=config.username,
+            password=config.password,
+            catalog=config.catalog,
+            database="information_schema",
+        )
+        init_conn = DorisConnector(init_config)
+        try:
+            if not init_conn.test_connection():
+                pytest.skip("Database connection test failed")
+            if config.database:
+                init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{config.database}`")
+        finally:
+            init_conn.close()
+
+        conn = DorisConnector(config)
+    except Exception as e:
+        pytest.skip(f"Database not available: {e}")
+
+    try:
+        yield conn
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                logger.warning("Failed to close connector during teardown", exc_info=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def metadata_objects_setup() -> Generator[None, None, None]:
+    """Create deterministic table, view, and async materialized view fixtures."""
+    test_config = _build_config()
+    init_conn = None
+    conn = None
+    try:
+        init_conn = DorisConnector(_build_config(database="information_schema"))
+        if not init_conn.test_connection():
+            pytest.skip("Database connection test failed")
+        _require_success(
+            init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{test_config.database}`"),
+            "create test database",
+        )
+        conn = DorisConnector(test_config)
+    except Exception as e:
+        pytest.skip(f"Database not available: {e}")
+    finally:
+        if init_conn is not None:
+            init_conn.close()
+
+    try:
+        _require_success(conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`"), "drop metadata MV")
+        _require_success(conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`"), "drop metadata view")
+        _require_success(conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`"), "drop metadata table")
+        _require_success(
+            conn.execute_ddl(
+                f"""
+                CREATE TABLE `{METADATA_TABLE}` (
+                    `id` BIGINT NOT NULL,
+                    `value` INT
+                ) ENGINE=OLAP
+                DUPLICATE KEY (`id`)
+                DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                PROPERTIES ("replication_num" = "1")
+                """
+            ),
+            "create metadata table",
+        )
+        _require_success(
+            conn.execute_insert(f"INSERT INTO `{METADATA_TABLE}` VALUES (1, 10), (2, 20)"),
+            "insert metadata rows",
+        )
+        _require_success(
+            conn.execute_ddl(f"CREATE VIEW `{METADATA_VIEW}` AS SELECT id, value FROM `{METADATA_TABLE}`"),
+            "create metadata view",
+        )
+        _require_success(
+            conn.execute_ddl(
+                f"""
+                CREATE MATERIALIZED VIEW `{METADATA_MV}`
+                BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
+                DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                PROPERTIES ("replication_num" = "1")
+                AS SELECT id, SUM(value) AS total_value
+                FROM `{METADATA_TABLE}` GROUP BY id
+                """
+            ),
+            "create metadata materialized view",
+        )
+
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            if METADATA_MV in conn.get_materialized_views(database_name=test_config.database or "test"):
+                break
+            time.sleep(2)
+        else:
+            raise AssertionError("Doris async materialized view did not become visible within 90 seconds")
+
+        yield
+    finally:
+        if conn is not None:
+            try:
+                conn.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{METADATA_MV}`")
+                conn.execute_ddl(f"DROP VIEW IF EXISTS `{METADATA_VIEW}`")
+                conn.execute_ddl(f"DROP TABLE IF EXISTS `{METADATA_TABLE}`")
+            finally:
+                conn.close()
+
+
+@pytest.fixture(scope="session")
+def tpch_setup() -> Generator[DorisConnector, None, None]:
+    """Session-scoped fixture: create TPC-H tables, insert data, yield connector, cleanup."""
+    tpch_config = _build_config()
+
+    conn = None
+    # Only skip on connection failures; DDL/DML errors should propagate and fail
+    # the suite so they are not silently hidden.
+    try:
+        # Ensure test database exists
+        init_config = DorisConfig(
+            host=tpch_config.host,
+            port=tpch_config.port,
+            username=tpch_config.username,
+            password=tpch_config.password,
+            catalog=tpch_config.catalog,
+            database="information_schema",
+        )
+        init_conn = DorisConnector(init_config)
+        try:
+            if not init_conn.test_connection():
+                pytest.skip("Database connection test failed")
+            if tpch_config.database:
+                init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{tpch_config.database}`")
+        finally:
+            init_conn.close()
+
+        conn = DorisConnector(tpch_config)
+    except Exception as e:
+        pytest.skip(f"Database not available: {e}")
+
+    try:
+        # Drop tables first for deterministic setup.
+        # Errors here are real failures and must not be swallowed.
+        for table in TPCH_TABLES:
+            conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
+
+        # Create tables
+        for ddl in TPCH_DDL:
+            conn.execute_ddl(ddl)
+
+        # Insert data
+        for data in TPCH_DATA:
+            conn.execute_insert(data)
+
+        yield conn
+    finally:
+        if conn is not None:
+            try:
+                for table in TPCH_TABLES:
+                    conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
+            except Exception:
+                logger.warning("Failed to drop TPC-H tables during teardown", exc_info=True)
+            try:
+                conn.close()
+            except Exception:
+                logger.warning("Failed to close connection during teardown", exc_info=True)

--- a/datus-doris/tests/integration/test_catalog_operations.py
+++ b/datus-doris/tests/integration/test_catalog_operations.py
@@ -50,13 +50,16 @@ def test_switch_external_catalog_and_restore(
     connector: DorisConnector,
     hive_catalog_setup: str,
 ):
-    original_catalog = connector.catalog_name
+    original_context = connector.get_current_context()
     try:
         connector.switch_catalog(hive_catalog_setup)
         assert connector.catalog_name == hive_catalog_setup
         assert connector.database_name == ""
         assert "default" in connector.get_databases(include_sys=True)
     finally:
-        connector.switch_catalog(original_catalog)
+        connector.switch_context(
+            catalog_name=original_context["catalog_name"],
+            database_name=original_context["database_name"],
+        )
 
-    assert connector.catalog_name == original_catalog
+    assert connector.get_current_context() == original_context

--- a/datus-doris/tests/integration/test_catalog_operations.py
+++ b/datus-doris/tests/integration/test_catalog_operations.py
@@ -1,0 +1,113 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+
+from datus_doris import DorisConnector
+
+# ==================== Catalog Tests (CatalogSupportMixin) ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_catalogs(connector: DorisConnector):
+    """Test getting list of catalogs."""
+    catalogs = connector.get_catalogs()
+    assert len(catalogs) > 0
+    assert connector.default_catalog() in catalogs
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_default_catalog(connector: DorisConnector):
+    """Test default catalog value."""
+    assert connector.default_catalog() == "internal"
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_switch_catalog(connector: DorisConnector, hive_catalog_setup: str):
+    """Test switching catalogs."""
+    original_catalog = connector.catalog_name
+    try:
+        connector.switch_catalog(hive_catalog_setup)
+        assert connector.catalog_name == hive_catalog_setup
+    finally:
+        connector.switch_catalog(original_catalog)
+    assert connector.catalog_name == original_catalog
+
+
+@pytest.mark.integration
+def test_get_databases_from_default_catalog(connector: DorisConnector):
+    """Test getting databases from default catalog."""
+    # Ensure we're in default catalog
+    connector.switch_catalog(connector.default_catalog())
+
+    databases = connector.get_databases()
+    assert isinstance(databases, list)
+    assert len(databases) > 0
+
+
+@pytest.mark.integration
+def test_get_databases_from_custom_catalog(connector: DorisConnector, hive_catalog_setup: str):
+    """Test getting databases from Hive catalog."""
+    original_catalog = connector.catalog_name
+    try:
+        connector.switch_catalog(hive_catalog_setup)
+        databases = connector.get_databases(catalog_name=hive_catalog_setup)
+        assert "default" in databases
+    finally:
+        connector.switch_catalog(original_catalog)
+
+
+@pytest.mark.integration
+def test_get_databases_exclude_system(connector: DorisConnector):
+    """Test that system databases are excluded by default."""
+    databases = connector.get_databases(include_sys=False)
+
+    # System databases should be filtered out
+    system_dbs = ["information_schema", "mysql", "__internal_schema"]
+    for sys_db in system_dbs:
+        assert sys_db not in databases
+
+
+@pytest.mark.integration
+def test_catalog_context_persists(connector: DorisConnector, hive_catalog_setup: str):
+    """Test that catalog context persists across operations."""
+    original_catalog = connector.catalog_name
+    try:
+        connector.switch_catalog(hive_catalog_setup)
+
+        # Catalog should persist
+        assert connector.catalog_name == hive_catalog_setup
+
+        # Get databases (should use the switched catalog)
+        databases = connector.get_databases()
+        assert isinstance(databases, list)
+
+        # Catalog should still be the same
+        assert connector.catalog_name == hive_catalog_setup
+    finally:
+        connector.switch_catalog(original_catalog)
+
+
+@pytest.mark.integration
+def test_switch_back_to_original_catalog(connector: DorisConnector, hive_catalog_setup: str):
+    """Test switching back to original catalog."""
+    original_catalog = connector.catalog_name
+
+    try:
+        # Switch to Hive catalog
+        connector.switch_catalog(hive_catalog_setup)
+        assert connector.catalog_name == hive_catalog_setup
+
+        # Switch back to original
+        connector.switch_catalog(original_catalog)
+        assert connector.catalog_name == original_catalog
+
+        # Verify we can still access databases
+        databases = connector.get_databases()
+        assert isinstance(databases, list)
+    finally:
+        connector.switch_catalog(original_catalog)

--- a/datus-doris/tests/integration/test_catalog_operations.py
+++ b/datus-doris/tests/integration/test_catalog_operations.py
@@ -4,110 +4,59 @@
 
 import pytest
 
-from datus_doris import DorisConnector
-
-# ==================== Catalog Tests (CatalogSupportMixin) ====================
+from datus_doris import DorisConfig, DorisConnector
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_get_catalogs(connector: DorisConnector):
-    """Test getting list of catalogs."""
+def test_catalog_discovery(connector: DorisConnector):
     catalogs = connector.get_catalogs()
-    assert len(catalogs) > 0
-    assert connector.default_catalog() in catalogs
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_default_catalog(connector: DorisConnector):
-    """Test default catalog value."""
     assert connector.default_catalog() == "internal"
+    assert "internal" in catalogs
 
 
 @pytest.mark.integration
-@pytest.mark.acceptance
-def test_switch_catalog(connector: DorisConnector, hive_catalog_setup: str):
-    """Test switching catalogs."""
-    original_catalog = connector.catalog_name
-    try:
-        connector.switch_catalog(hive_catalog_setup)
-        assert connector.catalog_name == hive_catalog_setup
-    finally:
-        connector.switch_catalog(original_catalog)
-    assert connector.catalog_name == original_catalog
-
-
-@pytest.mark.integration
-def test_get_databases_from_default_catalog(connector: DorisConnector):
-    """Test getting databases from default catalog."""
-    # Ensure we're in default catalog
-    connector.switch_catalog(connector.default_catalog())
-
-    databases = connector.get_databases()
-    assert isinstance(databases, list)
-    assert len(databases) > 0
-
-
-@pytest.mark.integration
-def test_get_databases_from_custom_catalog(connector: DorisConnector, hive_catalog_setup: str):
-    """Test getting databases from Hive catalog."""
-    original_catalog = connector.catalog_name
-    try:
-        connector.switch_catalog(hive_catalog_setup)
-        databases = connector.get_databases(catalog_name=hive_catalog_setup)
-        assert "default" in databases
-    finally:
-        connector.switch_catalog(original_catalog)
-
-
-@pytest.mark.integration
-def test_get_databases_exclude_system(connector: DorisConnector):
-    """Test that system databases are excluded by default."""
+def test_default_catalog_databases(
+    connector: DorisConnector,
+    config: DorisConfig,
+):
     databases = connector.get_databases(include_sys=False)
 
-    # System databases should be filtered out
-    system_dbs = ["information_schema", "mysql", "__internal_schema"]
-    for sys_db in system_dbs:
-        assert sys_db not in databases
+    assert config.database in databases
+    assert {
+        "information_schema",
+        "mysql",
+        "__internal_schema",
+    }.isdisjoint(databases)
 
 
 @pytest.mark.integration
-def test_catalog_context_persists(connector: DorisConnector, hive_catalog_setup: str):
-    """Test that catalog context persists across operations."""
-    original_catalog = connector.catalog_name
-    try:
-        connector.switch_catalog(hive_catalog_setup)
+def test_query_external_catalog_without_changing_context(
+    connector: DorisConnector,
+    hive_catalog_setup: str,
+):
+    original_context = connector.get_current_context()
 
-        # Catalog should persist
-        assert connector.catalog_name == hive_catalog_setup
-
-        # Get databases (should use the switched catalog)
-        databases = connector.get_databases()
-        assert isinstance(databases, list)
-
-        # Catalog should still be the same
-        assert connector.catalog_name == hive_catalog_setup
-    finally:
-        connector.switch_catalog(original_catalog)
+    assert "default" in connector.get_databases(
+        catalog_name=hive_catalog_setup,
+        include_sys=True,
+    )
+    assert connector.get_current_context() == original_context
 
 
 @pytest.mark.integration
-def test_switch_back_to_original_catalog(connector: DorisConnector, hive_catalog_setup: str):
-    """Test switching back to original catalog."""
+@pytest.mark.acceptance
+def test_switch_external_catalog_and_restore(
+    connector: DorisConnector,
+    hive_catalog_setup: str,
+):
     original_catalog = connector.catalog_name
-
     try:
-        # Switch to Hive catalog
         connector.switch_catalog(hive_catalog_setup)
         assert connector.catalog_name == hive_catalog_setup
-
-        # Switch back to original
-        connector.switch_catalog(original_catalog)
-        assert connector.catalog_name == original_catalog
-
-        # Verify we can still access databases
-        databases = connector.get_databases()
-        assert isinstance(databases, list)
+        assert connector.database_name == ""
+        assert "default" in connector.get_databases(include_sys=True)
     finally:
         connector.switch_catalog(original_catalog)
+
+    assert connector.catalog_name == original_catalog

--- a/datus-doris/tests/integration/test_connection.py
+++ b/datus-doris/tests/integration/test_connection.py
@@ -1,0 +1,70 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import os
+
+import pytest
+
+from datus_doris import DorisConfig, DorisConnector
+
+# ==================== Connection Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_connection_with_config_object(config: DorisConfig):
+    """Test connection using DorisConfig object."""
+    conn = DorisConnector(config)
+    assert conn.test_connection()
+    conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_connection_with_dict():
+    """Test connection using dict config."""
+    conn = DorisConnector(
+        {
+            "host": os.getenv("DORIS_HOST", "localhost"),
+            "port": int(os.getenv("DORIS_PORT", "9030")),
+            "username": os.getenv("DORIS_USER", "root"),
+            "password": os.getenv("DORIS_PASSWORD", ""),
+        }
+    )
+    assert conn.test_connection()
+    conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_context_manager(config: DorisConfig):
+    """Test connector as context manager."""
+    with DorisConnector(config) as conn:
+        assert conn.test_connection()
+    # Connection should be closed after context
+
+
+@pytest.mark.integration
+def test_test_connection_method(connector: DorisConnector):
+    """Test the test_connection method."""
+    result = connector.test_connection()
+    assert result is True
+
+
+@pytest.mark.integration
+def test_connection_cleanup_on_error(config: DorisConfig):
+    """Test connection cleanup when errors occur."""
+    conn = DorisConnector(config)
+
+    try:
+        conn.connect()
+        # Connection is open
+        assert conn.test_connection()
+    finally:
+        # Cleanup should handle PyMySQL errors gracefully
+        conn.close()
+        # Should not raise exception
+
+    # Verify connection is closed (no exception on re-close)
+    conn.close()

--- a/datus-doris/tests/integration/test_connection.py
+++ b/datus-doris/tests/integration/test_connection.py
@@ -2,69 +2,22 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import os
-
 import pytest
 
 from datus_doris import DorisConfig, DorisConnector
 
-# ==================== Connection Tests ====================
-
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_connection_with_config_object(config: DorisConfig):
-    """Test connection using DorisConfig object."""
+def test_connection_with_config(config: DorisConfig):
     conn = DorisConnector(config)
-    assert conn.test_connection()
-    conn.close()
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_connection_with_dict():
-    """Test connection using dict config."""
-    conn = DorisConnector(
-        {
-            "host": os.getenv("DORIS_HOST", "localhost"),
-            "port": int(os.getenv("DORIS_PORT", "9030")),
-            "username": os.getenv("DORIS_USER", "root"),
-            "password": os.getenv("DORIS_PASSWORD", ""),
-        }
-    )
-    assert conn.test_connection()
-    conn.close()
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_context_manager(config: DorisConfig):
-    """Test connector as context manager."""
-    with DorisConnector(config) as conn:
-        assert conn.test_connection()
-    # Connection should be closed after context
-
-
-@pytest.mark.integration
-def test_test_connection_method(connector: DorisConnector):
-    """Test the test_connection method."""
-    result = connector.test_connection()
-    assert result is True
-
-
-@pytest.mark.integration
-def test_connection_cleanup_on_error(config: DorisConfig):
-    """Test connection cleanup when errors occur."""
-    conn = DorisConnector(config)
-
     try:
-        conn.connect()
-        # Connection is open
         assert conn.test_connection()
     finally:
-        # Cleanup should handle PyMySQL errors gracefully
         conn.close()
-        # Should not raise exception
 
-    # Verify connection is closed (no exception on re-close)
-    conn.close()
+
+@pytest.mark.integration
+def test_connection_with_dict_and_context_manager(config: DorisConfig):
+    with DorisConnector(config.model_dump()) as conn:
+        assert conn.test_connection()

--- a/datus-doris/tests/integration/test_contract.py
+++ b/datus-doris/tests/integration/test_contract.py
@@ -1,0 +1,89 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import uuid
+
+import pytest
+
+from datus_db_core.testing import contract
+from datus_doris import DorisConfig, DorisConnector
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_deep_adapter_contract(connector: DorisConnector, config: DorisConfig):
+    """Cover catalog/database-qualified SELECT, quoted identifiers, typed values, and LIMIT."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"contract_{suffix}"
+    q = connector.quote_identifier
+    catalog = config.catalog or "internal"
+    database = config.database or "test"
+    table_ref = f"{q(catalog)}.{q(database)}.{q(table_name)}"
+
+    case = contract.TableContractCase(
+        adapter_name="doris",
+        table_name=table_name,
+        drop_sql=f"DROP TABLE IF EXISTS {table_ref}",
+        create_sql=f"""
+            CREATE TABLE {table_ref} (
+                {q("id")} BIGINT,
+                {q("Mixed Case")} VARCHAR(64),
+                {q("special-name")} VARCHAR(64),
+                {q("nullable_text")} VARCHAR(64),
+                {q("event_date")} DATE,
+                {q("event_ts")} DATETIME,
+                {q("amount")} DECIMAL(10, 2),
+                {q("bool_flag")} BOOLEAN
+            ) ENGINE=OLAP
+            DUPLICATE KEY({q("id")})
+            DISTRIBUTED BY HASH({q("id")}) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """,
+        insert_sqls=[
+            f"""
+            INSERT INTO {table_ref}
+                (
+                    {q("id")},
+                    {q("Mixed Case")},
+                    {q("special-name")},
+                    {q("nullable_text")},
+                    {q("event_date")},
+                    {q("event_ts")},
+                    {q("amount")},
+                    {q("bool_flag")}
+                )
+            VALUES
+                (1, 'Alpha', 'S-1', NULL, '2024-02-03', '2024-02-03 04:05:06', 123.45, TRUE),
+                (2, 'Beta', 'S-2', 'present', '2024-02-04', '2024-02-04 05:06:07', 67.89, FALSE)
+            """
+        ],
+        qualified_select_sql=f"""
+            SELECT
+                {q("id")} AS id_value,
+                {q("Mixed Case")} AS mixed_value,
+                {q("special-name")} AS special_value,
+                {q("nullable_text")} AS nullable_value,
+                {q("event_date")} AS event_date_value,
+                {q("event_ts")} AS event_ts_value,
+                {q("amount")} AS amount_value,
+                {q("bool_flag")} AS bool_value
+            FROM {table_ref}
+            ORDER BY {q("id")}
+        """,
+        limit_sql=f"SELECT {q('id')} AS id_value FROM {table_ref} ORDER BY {q('id')} LIMIT 1",
+        schema_kwargs={"catalog_name": catalog, "database_name": database},
+        expected_columns=(
+            "id",
+            "Mixed Case",
+            "special-name",
+            "nullable_text",
+            "event_date",
+            "event_ts",
+            "amount",
+            "bool_flag",
+        ),
+        dialect_select_sqls=(f"SELECT 1 AS rows_seen FROM {table_ref} WHERE {q('bool_flag')} = TRUE LIMIT 1",),
+    )
+
+    contract.assert_table_contract(connector, case)

--- a/datus-doris/tests/integration/test_materialized_views.py
+++ b/datus-doris/tests/integration/test_materialized_views.py
@@ -6,55 +6,29 @@ import pytest
 
 from datus_doris import DorisConfig, DorisConnector
 
-# ==================== Materialized View Tests (MaterializedViewSupportMixin) ====================
-
 METADATA_MV = "datus_metadata_mv"
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_get_materialized_views(connector: DorisConnector, config: DorisConfig):
-    """Test getting materialized view list."""
-    mvs = connector.get_materialized_views(catalog_name=config.catalog, database_name=config.database)
-    assert METADATA_MV in mvs
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_get_materialized_views_with_ddl(connector: DorisConnector):
-    """Test getting materialized views with DDL definitions."""
-    mvs = connector.get_materialized_views_with_ddl(database_name=connector.database_name)
-    mv = next(item for item in mvs if item["table_name"] == METADATA_MV)
-    assert "CREATE MATERIALIZED VIEW" in mv["definition"].upper()
-    assert mv["table_type"] == "mv"
-    assert mv["database_name"] == connector.database_name
-    assert mv["schema_name"] == ""
-    assert mv["catalog_name"] == connector.default_catalog()
-
-
-@pytest.mark.integration
-def test_materialized_view_identifier_includes_catalog(connector: DorisConnector, config: DorisConfig):
-    """Test materialized view identifier includes catalog."""
-    mvs = connector.get_materialized_views_with_ddl(
+def test_materialized_view_metadata(
+    connector: DorisConnector,
+    config: DorisConfig,
+    metadata_objects_setup,
+):
+    assert METADATA_MV in connector.get_materialized_views(
         catalog_name=config.catalog,
         database_name=config.database,
     )
-    mv = next(item for item in mvs if item["table_name"] == METADATA_MV)
-    assert mv["identifier"] == f"{config.catalog}.{config.database}.{METADATA_MV}"
 
-
-@pytest.mark.integration
-def test_get_materialized_views_from_specific_catalog(connector: DorisConnector, config: DorisConfig):
-    """Test getting materialized views from specific catalog."""
-    # Switch to the target catalog
-    connector.switch_catalog(config.catalog)
-
-    mvs = connector.get_materialized_views(catalog_name=config.catalog, database_name=config.database)
-    assert METADATA_MV in mvs
-
-    # Verify all MVs belong to the specified catalog
-    mvs_with_ddl = connector.get_materialized_views_with_ddl(catalog_name=config.catalog, database_name=config.database)
-    for mv in mvs_with_ddl:
-        assert mv["catalog_name"] == config.catalog
-        if config.database:
-            assert mv["database_name"] == config.database
+    materialized_views = connector.get_materialized_views_with_ddl(
+        catalog_name=config.catalog,
+        database_name=config.database,
+    )
+    materialized_view = next(item for item in materialized_views if item["table_name"] == METADATA_MV)
+    assert "CREATE MATERIALIZED VIEW" in materialized_view["definition"].upper()
+    assert materialized_view["table_type"] == "mv"
+    assert materialized_view["catalog_name"] == config.catalog
+    assert materialized_view["database_name"] == config.database
+    assert materialized_view["schema_name"] == ""
+    assert materialized_view["identifier"] == f"{config.catalog}.{config.database}.{METADATA_MV}"

--- a/datus-doris/tests/integration/test_materialized_views.py
+++ b/datus-doris/tests/integration/test_materialized_views.py
@@ -1,0 +1,60 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+
+from datus_doris import DorisConfig, DorisConnector
+
+# ==================== Materialized View Tests (MaterializedViewSupportMixin) ====================
+
+METADATA_MV = "datus_metadata_mv"
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_materialized_views(connector: DorisConnector, config: DorisConfig):
+    """Test getting materialized view list."""
+    mvs = connector.get_materialized_views(catalog_name=config.catalog, database_name=config.database)
+    assert METADATA_MV in mvs
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_materialized_views_with_ddl(connector: DorisConnector):
+    """Test getting materialized views with DDL definitions."""
+    mvs = connector.get_materialized_views_with_ddl(database_name=connector.database_name)
+    mv = next(item for item in mvs if item["table_name"] == METADATA_MV)
+    assert "CREATE MATERIALIZED VIEW" in mv["definition"].upper()
+    assert mv["table_type"] == "mv"
+    assert mv["database_name"] == connector.database_name
+    assert mv["schema_name"] == ""
+    assert mv["catalog_name"] == connector.default_catalog()
+
+
+@pytest.mark.integration
+def test_materialized_view_identifier_includes_catalog(connector: DorisConnector, config: DorisConfig):
+    """Test materialized view identifier includes catalog."""
+    mvs = connector.get_materialized_views_with_ddl(
+        catalog_name=config.catalog,
+        database_name=config.database,
+    )
+    mv = next(item for item in mvs if item["table_name"] == METADATA_MV)
+    assert mv["identifier"] == f"{config.catalog}.{config.database}.{METADATA_MV}"
+
+
+@pytest.mark.integration
+def test_get_materialized_views_from_specific_catalog(connector: DorisConnector, config: DorisConfig):
+    """Test getting materialized views from specific catalog."""
+    # Switch to the target catalog
+    connector.switch_catalog(config.catalog)
+
+    mvs = connector.get_materialized_views(catalog_name=config.catalog, database_name=config.database)
+    assert METADATA_MV in mvs
+
+    # Verify all MVs belong to the specified catalog
+    mvs_with_ddl = connector.get_materialized_views_with_ddl(catalog_name=config.catalog, database_name=config.database)
+    for mv in mvs_with_ddl:
+        assert mv["catalog_name"] == config.catalog
+        if config.database:
+            assert mv["database_name"] == config.database

--- a/datus-doris/tests/integration/test_metadata_retrieval.py
+++ b/datus-doris/tests/integration/test_metadata_retrieval.py
@@ -6,115 +6,69 @@ import pytest
 
 from datus_doris import DorisConfig, DorisConnector
 
-# ==================== Table Metadata Tests ====================
-
 METADATA_TABLE = "datus_metadata_table"
 METADATA_VIEW = "datus_metadata_view"
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_get_tables(connector: DorisConnector, config: DorisConfig):
-    """Test getting table list."""
-    tables = connector.get_tables()
-    assert f"{config.database}.{METADATA_TABLE}" in tables
+def test_table_metadata(
+    connector: DorisConnector,
+    config: DorisConfig,
+    metadata_objects_setup,
+):
+    assert f"{config.database}.{METADATA_TABLE}" in connector.get_tables()
+    assert METADATA_TABLE in connector.get_tables(
+        catalog_name=config.catalog,
+        database_name=config.database,
+    )
 
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_get_tables_with_ddl(connector: DorisConnector, config: DorisConfig):
-    """Test getting tables with DDL definitions."""
-    tables = connector.get_tables_with_ddl(catalog_name=config.catalog)
-
-    table = next(item for item in tables if item["table_name"] == METADATA_TABLE)
+    table = next(
+        item
+        for item in connector.get_tables_with_ddl(
+            catalog_name=config.catalog,
+            database_name=config.database,
+        )
+        if item["table_name"] == METADATA_TABLE
+    )
     assert "CREATE TABLE" in table["definition"].upper()
     assert table["table_type"] == "table"
+    assert table["catalog_name"] == config.catalog
     assert table["database_name"] == config.database
     assert table["schema_name"] == ""
-    assert table["catalog_name"] == config.catalog
-    assert table["identifier"] == f"{config.catalog}.{config.database}.{METADATA_TABLE}"
+    assert table["identifier"] == (f"{config.catalog}.{config.database}.{METADATA_TABLE}")
 
 
 @pytest.mark.integration
-def test_get_tables_with_catalog_filter(connector: DorisConnector, config: DorisConfig):
-    """Test getting tables with catalog filter."""
-    tables = connector.get_tables(catalog_name=config.catalog, database_name=config.database)
-    assert isinstance(tables, list)
+def test_view_metadata(
+    connector: DorisConnector,
+    config: DorisConfig,
+    metadata_objects_setup,
+):
+    assert f"{config.database}.{METADATA_VIEW}" in connector.get_views()
 
-    assert METADATA_TABLE in tables
-
-
-@pytest.mark.integration
-def test_get_tables_metadata_includes_catalog(connector: DorisConnector, config: DorisConfig):
-    """Test that table metadata includes catalog_name."""
-    tables = connector.get_tables_with_ddl(catalog_name=config.catalog, database_name=config.database)
-
-    for table in tables:
-        assert "catalog_name" in table
-        assert table["catalog_name"] == config.catalog
-    assert METADATA_TABLE in {table["table_name"] for table in tables}
-
-
-# ==================== View Metadata Tests ====================
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_get_views(connector: DorisConnector, config: DorisConfig):
-    """Test getting view list."""
-    views = connector.get_views()
-    assert f"{config.database}.{METADATA_VIEW}" in views
-
-
-@pytest.mark.integration
-def test_get_views_with_ddl(connector: DorisConnector, config: DorisConfig):
-    """Test getting views with DDL definitions."""
-    views = connector.get_views_with_ddl(catalog_name=config.catalog)
-
-    view = next(item for item in views if item["table_name"] == METADATA_VIEW)
+    view = next(
+        item
+        for item in connector.get_views_with_ddl(
+            catalog_name=config.catalog,
+            database_name=config.database,
+        )
+        if item["table_name"] == METADATA_VIEW
+    )
     assert "CREATE VIEW" in view["definition"].upper()
     assert view["table_type"] == "view"
+    assert view["catalog_name"] == config.catalog
     assert view["database_name"] == config.database
     assert view["schema_name"] == ""
-    assert view["catalog_name"] == config.catalog
+    assert view["identifier"] == (f"{config.catalog}.{config.database}.{METADATA_VIEW}")
 
 
 @pytest.mark.integration
-def test_get_views_identifier_format(connector: DorisConnector, config: DorisConfig):
-    """Test view identifier includes catalog."""
-    views = connector.get_views_with_ddl(catalog_name=config.catalog, database_name=config.database)
-
-    view = next(item for item in views if item["table_name"] == METADATA_VIEW)
-    assert view["identifier"] == f"{config.catalog}.{config.database}.{METADATA_VIEW}"
-
-
-# ==================== Sample Data Tests ====================
-
-
-@pytest.mark.integration
-@pytest.mark.acceptance
-def test_get_sample_rows_default(connector: DorisConnector):
-    """Test getting sample rows with defaults."""
-    sample_rows = connector.get_sample_rows()
-    assert METADATA_TABLE in {item["table_name"] for item in sample_rows}
-
-
-@pytest.mark.integration
-def test_get_sample_rows_with_catalog(connector: DorisConnector, config: DorisConfig):
-    """Test getting sample rows for specific catalog and database."""
-    sample_rows = connector.get_sample_rows(catalog_name=config.catalog, database_name=config.database)
-
-    item = next(row for row in sample_rows if row["table_name"] == METADATA_TABLE)
-    assert item["database_name"] == config.database
-    assert item["catalog_name"] == config.catalog
-    assert item["schema_name"] == ""
-    assert item["identifier"] == f"{config.catalog}.{config.database}.{METADATA_TABLE}"
-    assert "1,10" in item["sample_rows"]
-
-
-@pytest.mark.integration
-def test_get_sample_rows_specific_tables(connector: DorisConnector, config: DorisConfig):
-    """Test getting sample rows for specific tables."""
+def test_sample_rows(
+    connector: DorisConnector,
+    config: DorisConfig,
+    metadata_objects_setup,
+):
     sample_rows = connector.get_sample_rows(
         catalog_name=config.catalog,
         database_name=config.database,
@@ -123,5 +77,13 @@ def test_get_sample_rows_specific_tables(connector: DorisConnector, config: Dori
     )
 
     assert len(sample_rows) == 1
-    assert sample_rows[0]["table_name"] == METADATA_TABLE
-    assert sample_rows[0]["catalog_name"] == config.catalog
+    assert sample_rows[0] == {
+        "catalog_name": config.catalog,
+        "database_name": config.database,
+        "schema_name": "",
+        "table_name": METADATA_TABLE,
+        "table_type": "table",
+        "identifier": f"{config.catalog}.{config.database}.{METADATA_TABLE}",
+        "sample_rows": sample_rows[0]["sample_rows"],
+    }
+    assert "1,10" in sample_rows[0]["sample_rows"]

--- a/datus-doris/tests/integration/test_metadata_retrieval.py
+++ b/datus-doris/tests/integration/test_metadata_retrieval.py
@@ -1,0 +1,127 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+
+from datus_doris import DorisConfig, DorisConnector
+
+# ==================== Table Metadata Tests ====================
+
+METADATA_TABLE = "datus_metadata_table"
+METADATA_VIEW = "datus_metadata_view"
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_tables(connector: DorisConnector, config: DorisConfig):
+    """Test getting table list."""
+    tables = connector.get_tables()
+    assert f"{config.database}.{METADATA_TABLE}" in tables
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_tables_with_ddl(connector: DorisConnector, config: DorisConfig):
+    """Test getting tables with DDL definitions."""
+    tables = connector.get_tables_with_ddl(catalog_name=config.catalog)
+
+    table = next(item for item in tables if item["table_name"] == METADATA_TABLE)
+    assert "CREATE TABLE" in table["definition"].upper()
+    assert table["table_type"] == "table"
+    assert table["database_name"] == config.database
+    assert table["schema_name"] == ""
+    assert table["catalog_name"] == config.catalog
+    assert table["identifier"] == f"{config.catalog}.{config.database}.{METADATA_TABLE}"
+
+
+@pytest.mark.integration
+def test_get_tables_with_catalog_filter(connector: DorisConnector, config: DorisConfig):
+    """Test getting tables with catalog filter."""
+    tables = connector.get_tables(catalog_name=config.catalog, database_name=config.database)
+    assert isinstance(tables, list)
+
+    assert METADATA_TABLE in tables
+
+
+@pytest.mark.integration
+def test_get_tables_metadata_includes_catalog(connector: DorisConnector, config: DorisConfig):
+    """Test that table metadata includes catalog_name."""
+    tables = connector.get_tables_with_ddl(catalog_name=config.catalog, database_name=config.database)
+
+    for table in tables:
+        assert "catalog_name" in table
+        assert table["catalog_name"] == config.catalog
+    assert METADATA_TABLE in {table["table_name"] for table in tables}
+
+
+# ==================== View Metadata Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_views(connector: DorisConnector, config: DorisConfig):
+    """Test getting view list."""
+    views = connector.get_views()
+    assert f"{config.database}.{METADATA_VIEW}" in views
+
+
+@pytest.mark.integration
+def test_get_views_with_ddl(connector: DorisConnector, config: DorisConfig):
+    """Test getting views with DDL definitions."""
+    views = connector.get_views_with_ddl(catalog_name=config.catalog)
+
+    view = next(item for item in views if item["table_name"] == METADATA_VIEW)
+    assert "CREATE VIEW" in view["definition"].upper()
+    assert view["table_type"] == "view"
+    assert view["database_name"] == config.database
+    assert view["schema_name"] == ""
+    assert view["catalog_name"] == config.catalog
+
+
+@pytest.mark.integration
+def test_get_views_identifier_format(connector: DorisConnector, config: DorisConfig):
+    """Test view identifier includes catalog."""
+    views = connector.get_views_with_ddl(catalog_name=config.catalog, database_name=config.database)
+
+    view = next(item for item in views if item["table_name"] == METADATA_VIEW)
+    assert view["identifier"] == f"{config.catalog}.{config.database}.{METADATA_VIEW}"
+
+
+# ==================== Sample Data Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_get_sample_rows_default(connector: DorisConnector):
+    """Test getting sample rows with defaults."""
+    sample_rows = connector.get_sample_rows()
+    assert METADATA_TABLE in {item["table_name"] for item in sample_rows}
+
+
+@pytest.mark.integration
+def test_get_sample_rows_with_catalog(connector: DorisConnector, config: DorisConfig):
+    """Test getting sample rows for specific catalog and database."""
+    sample_rows = connector.get_sample_rows(catalog_name=config.catalog, database_name=config.database)
+
+    item = next(row for row in sample_rows if row["table_name"] == METADATA_TABLE)
+    assert item["database_name"] == config.database
+    assert item["catalog_name"] == config.catalog
+    assert item["schema_name"] == ""
+    assert item["identifier"] == f"{config.catalog}.{config.database}.{METADATA_TABLE}"
+    assert "1,10" in item["sample_rows"]
+
+
+@pytest.mark.integration
+def test_get_sample_rows_specific_tables(connector: DorisConnector, config: DorisConfig):
+    """Test getting sample rows for specific tables."""
+    sample_rows = connector.get_sample_rows(
+        catalog_name=config.catalog,
+        database_name=config.database,
+        tables=[METADATA_TABLE],
+        top_n=3,
+    )
+
+    assert len(sample_rows) == 1
+    assert sample_rows[0]["table_name"] == METADATA_TABLE
+    assert sample_rows[0]["catalog_name"] == config.catalog

--- a/datus-doris/tests/integration/test_sql_execution.py
+++ b/datus-doris/tests/integration/test_sql_execution.py
@@ -1,0 +1,273 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import uuid
+
+import pytest
+
+from datus_doris import DorisConfig, DorisConnector
+
+# ==================== Query Execution Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_execute_select_query(connector: DorisConnector):
+    """Test executing simple SELECT query."""
+    result = connector.execute({"sql_query": "SELECT 1 as num"}, result_format="list")
+    assert result.success
+    assert not result.error
+    assert result.sql_return == [{"num": 1}]
+
+
+@pytest.mark.integration
+def test_execute_explain_query(connector: DorisConnector, config: DorisConfig):
+    """Test executing EXPLAIN query."""
+    tables = connector.get_tables(catalog_name=config.catalog, database_name=config.database)
+
+    if len(tables) > 0:
+        table_name = tables[0]
+        full_name = connector.full_name(
+            catalog_name=config.catalog,
+            database_name=config.database,
+            table_name=table_name,
+        )
+
+        result = connector.execute({"sql_query": f"EXPLAIN SELECT * FROM {full_name} LIMIT 1"})
+        assert result.success
+        assert not result.error
+        assert result.sql_return
+    else:
+        pytest.skip("No tables available for EXPLAIN test")
+
+
+# ==================== DDL Operation Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_execute_ddl_create_drop(connector: DorisConnector, config: DorisConfig):
+    """Test DDL operations (CREATE/DROP table)."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"datus_test_{suffix}"
+
+    connector.switch_context(database_name=config.database)
+
+    create_sql = f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+        `id` BIGINT NOT NULL,
+        `name` VARCHAR(64)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "enable_unique_key_merge_on_write" = "true"
+    );
+    """
+
+    try:
+        create_result = connector.execute_ddl(create_sql)
+        assert create_result.success, f"Failed to create table: {create_result.error}"
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+@pytest.mark.integration
+def test_execute_ddl_create_materialized_view(connector: DorisConnector, config: DorisConfig):
+    """Test creating an independently queryable async materialized view."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"datus_base_{suffix}"
+    mv_name = f"datus_mv_{suffix}"
+
+    connector.switch_context(database_name=config.database)
+
+    # Create base table first
+    create_table_sql = f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+        `id` BIGINT NOT NULL,
+        `value` INT
+    ) ENGINE=OLAP
+    UNIQUE KEY (`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES ("replication_num" = "1",
+        "enable_unique_key_merge_on_write" = "true");
+    """
+
+    try:
+        create_result = connector.execute_ddl(create_table_sql)
+        assert create_result.success, create_result.error
+
+        create_mv_sql = f"""
+        CREATE MATERIALIZED VIEW {mv_name}
+        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1")
+        AS SELECT id, SUM(value) as total
+        FROM {table_name}
+        GROUP BY id;
+        """
+
+        mv_result = connector.execute_ddl(create_mv_sql)
+        assert mv_result.success, mv_result.error
+        assert mv_name in connector.get_materialized_views(database_name=config.database)
+    finally:
+        connector.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}")
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+# ==================== DML Operation Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_execute_insert(connector: DorisConnector, config: DorisConfig):
+    """Test INSERT operation."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"datus_insert_test_{suffix}"
+
+    connector.switch_context(database_name=config.database)
+
+    create_sql = f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+        `id` BIGINT NOT NULL,
+        `name` VARCHAR(64)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "enable_unique_key_merge_on_write" = "true"
+    );
+    """
+
+    try:
+        create_result = connector.execute_ddl(create_sql)
+        if not create_result.success:
+            pytest.skip(f"Unable to create test table: {create_result.error}")
+
+        # Insert data
+        insert_result = connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+        assert insert_result.success
+
+        # Verify
+        query_result = connector.execute(
+            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
+            result_format="list",
+        )
+        assert query_result.success
+        assert query_result.sql_return == [
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"},
+        ]
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+@pytest.mark.integration
+def test_execute_update(connector: DorisConnector, config: DorisConfig):
+    """Test UPDATE operation."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"datus_update_test_{suffix}"
+
+    connector.switch_context(database_name=config.database)
+
+    create_sql = f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+        `id` BIGINT NOT NULL,
+        `name` VARCHAR(64)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "enable_unique_key_merge_on_write" = "true"
+    );
+    """
+
+    try:
+        create_result = connector.execute_ddl(create_sql)
+        if not create_result.success:
+            pytest.skip(f"Unable to create test table: {create_result.error}")
+
+        # Insert initial data
+        connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+        # Update
+        update_result = connector.execute(
+            {"sql_query": f"UPDATE {table_name} SET name = 'Alice Updated' WHERE id = 1"},
+            result_format="list",
+        )
+        assert update_result.success
+
+        # Verify
+        query_result = connector.execute(
+            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
+            result_format="list",
+        )
+        assert query_result.sql_return == [
+            {"id": 1, "name": "Alice Updated"},
+            {"id": 2, "name": "Bob"},
+        ]
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+@pytest.mark.integration
+def test_execute_delete(connector: DorisConnector, config: DorisConfig):
+    """Test DELETE operation."""
+    suffix = uuid.uuid4().hex[:8]
+    table_name = f"datus_delete_test_{suffix}"
+
+    connector.switch_context(database_name=config.database)
+
+    create_sql = f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+        `id` BIGINT NOT NULL,
+        `name` VARCHAR(64)
+    ) ENGINE=OLAP
+    UNIQUE KEY (`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "enable_unique_key_merge_on_write" = "true"
+    );
+    """
+
+    try:
+        create_result = connector.execute_ddl(create_sql)
+        if not create_result.success:
+            pytest.skip(f"Unable to create test table: {create_result.error}")
+
+        # Insert initial data
+        connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+        # Delete
+        delete_result = connector.execute(
+            {"sql_query": f"DELETE FROM {table_name} WHERE id = 2"},
+            result_format="list",
+        )
+        assert delete_result.success
+
+        # Verify
+        query_result = connector.execute(
+            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
+            result_format="list",
+        )
+        assert query_result.sql_return == [{"id": 1, "name": "Alice"}]
+    finally:
+        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+
+
+# ==================== Error Handling Tests ====================
+
+
+@pytest.mark.integration
+def test_execute_error_handling(connector: DorisConnector):
+    """Test SQL error handling."""
+    # Execute query on non-existent table
+    result = connector.execute({"sql_query": "SELECT * FROM nonexistent_table_12345"})
+
+    # Should return error (not raise exception)
+    assert not result.success or result.error

--- a/datus-doris/tests/integration/test_sql_execution.py
+++ b/datus-doris/tests/integration/test_sql_execution.py
@@ -8,266 +8,152 @@ import pytest
 
 from datus_doris import DorisConfig, DorisConnector
 
-# ==================== Query Execution Tests ====================
+METADATA_TABLE = "datus_metadata_table"
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_execute_select_query(connector: DorisConnector):
-    """Test executing simple SELECT query."""
-    result = connector.execute({"sql_query": "SELECT 1 as num"}, result_format="list")
+def test_execute_select(connector: DorisConnector):
+    result = connector.execute(
+        {"sql_query": "SELECT 1 AS num"},
+        result_format="list",
+    )
+
     assert result.success
-    assert not result.error
+    assert result.error is None
     assert result.sql_return == [{"num": 1}]
 
 
 @pytest.mark.integration
-def test_execute_explain_query(connector: DorisConnector, config: DorisConfig):
-    """Test executing EXPLAIN query."""
-    tables = connector.get_tables(catalog_name=config.catalog, database_name=config.database)
+def test_execute_explain(
+    connector: DorisConnector,
+    config: DorisConfig,
+    metadata_objects_setup,
+):
+    table = connector.full_name(
+        catalog_name=config.catalog,
+        database_name=config.database,
+        table_name=METADATA_TABLE,
+    )
 
-    if len(tables) > 0:
-        table_name = tables[0]
-        full_name = connector.full_name(
-            catalog_name=config.catalog,
-            database_name=config.database,
-            table_name=table_name,
-        )
+    result = connector.execute({"sql_query": f"EXPLAIN SELECT * FROM {table} LIMIT 1"})
 
-        result = connector.execute({"sql_query": f"EXPLAIN SELECT * FROM {full_name} LIMIT 1"})
-        assert result.success
-        assert not result.error
-        assert result.sql_return
-    else:
-        pytest.skip("No tables available for EXPLAIN test")
-
-
-# ==================== DDL Operation Tests ====================
+    assert result.success
+    assert result.sql_return
 
 
 @pytest.mark.integration
-@pytest.mark.acceptance
-def test_execute_ddl_create_drop(connector: DorisConnector, config: DorisConfig):
-    """Test DDL operations (CREATE/DROP table)."""
-    suffix = uuid.uuid4().hex[:8]
-    table_name = f"datus_test_{suffix}"
-
-    connector.switch_context(database_name=config.database)
-
-    create_sql = f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        `id` BIGINT NOT NULL,
-        `name` VARCHAR(64)
-    ) ENGINE=OLAP
-    UNIQUE KEY (`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true"
-    );
-    """
-
-    try:
-        create_result = connector.execute_ddl(create_sql)
-        assert create_result.success, f"Failed to create table: {create_result.error}"
-    finally:
-        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
-
-
-@pytest.mark.integration
-def test_execute_ddl_create_materialized_view(connector: DorisConnector, config: DorisConfig):
-    """Test creating an independently queryable async materialized view."""
+def test_create_async_materialized_view(
+    connector: DorisConnector,
+    config: DorisConfig,
+):
     suffix = uuid.uuid4().hex[:8]
     table_name = f"datus_base_{suffix}"
     mv_name = f"datus_mv_{suffix}"
-
     connector.switch_context(database_name=config.database)
 
-    # Create base table first
-    create_table_sql = f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        `id` BIGINT NOT NULL,
-        `value` INT
-    ) ENGINE=OLAP
-    UNIQUE KEY (`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES ("replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true");
-    """
-
     try:
-        create_result = connector.execute_ddl(create_table_sql)
-        assert create_result.success, create_result.error
+        create_table = connector.execute_ddl(
+            f"""
+            CREATE TABLE `{table_name}` (
+                `id` BIGINT NOT NULL,
+                `value` INT
+            ) ENGINE=OLAP
+            UNIQUE KEY (`id`)
+            DISTRIBUTED BY HASH(`id`) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "enable_unique_key_merge_on_write" = "true"
+            )
+            """
+        )
+        assert create_table.success, create_table.error
 
-        create_mv_sql = f"""
-        CREATE MATERIALIZED VIEW {mv_name}
-        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
-        DISTRIBUTED BY HASH(id) BUCKETS 1
-        PROPERTIES ("replication_num" = "1")
-        AS SELECT id, SUM(value) as total
-        FROM {table_name}
-        GROUP BY id;
-        """
-
-        mv_result = connector.execute_ddl(create_mv_sql)
-        assert mv_result.success, mv_result.error
+        create_mv = connector.execute_ddl(
+            f"""
+            CREATE MATERIALIZED VIEW `{mv_name}`
+            BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+            AS SELECT id, SUM(value) AS total
+            FROM `{table_name}`
+            GROUP BY id
+            """
+        )
+        assert create_mv.success, create_mv.error
         assert mv_name in connector.get_materialized_views(database_name=config.database)
     finally:
-        connector.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}")
-        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
-
-
-# ==================== DML Operation Tests ====================
+        connector.execute_ddl(f"DROP MATERIALIZED VIEW IF EXISTS `{mv_name}`")
+        connector.execute_ddl(f"DROP TABLE IF EXISTS `{table_name}`")
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_execute_insert(connector: DorisConnector, config: DorisConfig):
-    """Test INSERT operation."""
-    suffix = uuid.uuid4().hex[:8]
-    table_name = f"datus_insert_test_{suffix}"
+def test_execute_insert(
+    connector: DorisConnector,
+    unique_key_table: str,
+):
+    result = connector.execute_insert(f"INSERT INTO `{unique_key_table}` (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+    assert result.success, result.error
 
-    connector.switch_context(database_name=config.database)
-
-    create_sql = f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        `id` BIGINT NOT NULL,
-        `name` VARCHAR(64)
-    ) ENGINE=OLAP
-    UNIQUE KEY (`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true"
-    );
-    """
-
-    try:
-        create_result = connector.execute_ddl(create_sql)
-        if not create_result.success:
-            pytest.skip(f"Unable to create test table: {create_result.error}")
-
-        # Insert data
-        insert_result = connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
-        assert insert_result.success
-
-        # Verify
-        query_result = connector.execute(
-            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
-            result_format="list",
-        )
-        assert query_result.success
-        assert query_result.sql_return == [
-            {"id": 1, "name": "Alice"},
-            {"id": 2, "name": "Bob"},
-        ]
-    finally:
-        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+    query = connector.execute(
+        {"sql_query": (f"SELECT id, name FROM `{unique_key_table}` ORDER BY id")},
+        result_format="list",
+    )
+    assert query.sql_return == [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+    ]
 
 
 @pytest.mark.integration
-def test_execute_update(connector: DorisConnector, config: DorisConfig):
-    """Test UPDATE operation."""
-    suffix = uuid.uuid4().hex[:8]
-    table_name = f"datus_update_test_{suffix}"
+def test_execute_update(
+    connector: DorisConnector,
+    unique_key_table: str,
+):
+    insert = connector.execute_insert(f"INSERT INTO `{unique_key_table}` (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+    assert insert.success, insert.error
 
-    connector.switch_context(database_name=config.database)
+    update = connector.execute(
+        {"sql_query": (f"UPDATE `{unique_key_table}` SET name = 'Alice Updated' WHERE id = 1")},
+        result_format="list",
+    )
+    assert update.success, update.error
 
-    create_sql = f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        `id` BIGINT NOT NULL,
-        `name` VARCHAR(64)
-    ) ENGINE=OLAP
-    UNIQUE KEY (`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true"
-    );
-    """
-
-    try:
-        create_result = connector.execute_ddl(create_sql)
-        if not create_result.success:
-            pytest.skip(f"Unable to create test table: {create_result.error}")
-
-        # Insert initial data
-        connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
-
-        # Update
-        update_result = connector.execute(
-            {"sql_query": f"UPDATE {table_name} SET name = 'Alice Updated' WHERE id = 1"},
-            result_format="list",
-        )
-        assert update_result.success
-
-        # Verify
-        query_result = connector.execute(
-            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
-            result_format="list",
-        )
-        assert query_result.sql_return == [
-            {"id": 1, "name": "Alice Updated"},
-            {"id": 2, "name": "Bob"},
-        ]
-    finally:
-        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
+    query = connector.execute(
+        {"sql_query": (f"SELECT id, name FROM `{unique_key_table}` ORDER BY id")},
+        result_format="list",
+    )
+    assert query.sql_return == [
+        {"id": 1, "name": "Alice Updated"},
+        {"id": 2, "name": "Bob"},
+    ]
 
 
 @pytest.mark.integration
-def test_execute_delete(connector: DorisConnector, config: DorisConfig):
-    """Test DELETE operation."""
-    suffix = uuid.uuid4().hex[:8]
-    table_name = f"datus_delete_test_{suffix}"
+def test_execute_delete(
+    connector: DorisConnector,
+    unique_key_table: str,
+):
+    insert = connector.execute_insert(f"INSERT INTO `{unique_key_table}` (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+    assert insert.success, insert.error
 
-    connector.switch_context(database_name=config.database)
+    delete = connector.execute(
+        {"sql_query": (f"DELETE FROM `{unique_key_table}` WHERE id = 2")},
+        result_format="list",
+    )
+    assert delete.success, delete.error
 
-    create_sql = f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        `id` BIGINT NOT NULL,
-        `name` VARCHAR(64)
-    ) ENGINE=OLAP
-    UNIQUE KEY (`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true"
-    );
-    """
-
-    try:
-        create_result = connector.execute_ddl(create_sql)
-        if not create_result.success:
-            pytest.skip(f"Unable to create test table: {create_result.error}")
-
-        # Insert initial data
-        connector.execute_insert(f"INSERT INTO {table_name} (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
-
-        # Delete
-        delete_result = connector.execute(
-            {"sql_query": f"DELETE FROM {table_name} WHERE id = 2"},
-            result_format="list",
-        )
-        assert delete_result.success
-
-        # Verify
-        query_result = connector.execute(
-            {"sql_query": f"SELECT id, name FROM {table_name} ORDER BY id"},
-            result_format="list",
-        )
-        assert query_result.sql_return == [{"id": 1, "name": "Alice"}]
-    finally:
-        connector.execute_ddl(f"DROP TABLE IF EXISTS {table_name}")
-
-
-# ==================== Error Handling Tests ====================
+    query = connector.execute(
+        {"sql_query": (f"SELECT id, name FROM `{unique_key_table}` ORDER BY id")},
+        result_format="list",
+    )
+    assert query.sql_return == [{"id": 1, "name": "Alice"}]
 
 
 @pytest.mark.integration
-def test_execute_error_handling(connector: DorisConnector):
-    """Test SQL error handling."""
-    # Execute query on non-existent table
+def test_execute_returns_sql_errors(connector: DorisConnector):
     result = connector.execute({"sql_query": "SELECT * FROM nonexistent_table_12345"})
 
-    # Should return error (not raise exception)
-    assert not result.success or result.error
+    assert result.success is False
+    assert result.error

--- a/datus-doris/tests/integration/test_tpch.py
+++ b/datus-doris/tests/integration/test_tpch.py
@@ -6,79 +6,50 @@ import pytest
 
 from datus_doris import DorisConnector
 
-# ==================== Metadata Tests ====================
-
 
 @pytest.mark.integration
-def test_tpch_get_tables(tpch_setup: DorisConnector):
-    """Test that TPC-H tables exist in the database."""
-    tables = tpch_setup.get_tables()
-    db = tpch_setup.doris_config.database
-    expected = {
-        f"{db}.tpch_region",
-        f"{db}.tpch_nation",
-        f"{db}.tpch_customer",
-        f"{db}.tpch_orders",
-        f"{db}.tpch_supplier",
+def test_tpch_metadata(tpch_setup: DorisConnector):
+    database = tpch_setup.doris_config.database
+    expected_tables = {
+        f"{database}.tpch_region",
+        f"{database}.tpch_nation",
+        f"{database}.tpch_customer",
+        f"{database}.tpch_orders",
+        f"{database}.tpch_supplier",
     }
-    table_set = set(tables)
-    assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"
+    assert expected_tables.issubset(set(tpch_setup.get_tables()))
 
-
-@pytest.mark.integration
-def test_tpch_get_columns(tpch_setup: DorisConnector):
-    """Test getting column schema for tpch_customer table."""
-    columns = tpch_setup.get_schema(table_name="tpch_customer")
-    assert len(columns) > 0
-    column_names = {col["name"] for col in columns}
-    assert "custkey" in column_names
-    assert "name" in column_names
-    assert "nationkey" in column_names
-    for col in columns:
-        assert "name" in col
-        assert "type" in col
-
-
-@pytest.mark.integration
-def test_tpch_get_columns_nation(tpch_setup: DorisConnector):
-    """Test getting column schema for tpch_nation table."""
-    columns = tpch_setup.get_schema(table_name="tpch_nation")
-    column_names = {col["name"] for col in columns}
-    assert "nationkey" in column_names
-    assert "name" in column_names
-    assert "regionkey" in column_names
-
-
-# ==================== Data Query Tests ====================
+    expected_columns = {
+        "tpch_customer": {"custkey", "name", "nationkey"},
+        "tpch_nation": {"nationkey", "name", "regionkey"},
+    }
+    for table, expected in expected_columns.items():
+        columns = tpch_setup.get_schema(table_name=table)
+        assert expected.issubset({column["name"] for column in columns})
+        assert all("type" in column for column in columns)
 
 
 @pytest.mark.integration
 @pytest.mark.acceptance
-def test_tpch_query_region(tpch_setup: DorisConnector):
-    """Test querying tpch_region - should have 5 regions."""
+@pytest.mark.parametrize(
+    ("table", "expected_rows"),
+    [("tpch_region", 5), ("tpch_nation", 25)],
+)
+def test_tpch_row_counts(
+    tpch_setup: DorisConnector,
+    table: str,
+    expected_rows: int,
+):
     result = tpch_setup.execute(
-        {"sql_query": "SELECT * FROM `tpch_region`"},
+        {"sql_query": f"SELECT * FROM `{table}`"},
         result_format="list",
     )
     assert result.success
-    assert len(result.sql_return) == 5
+    assert len(result.sql_return) == expected_rows
 
 
 @pytest.mark.integration
-@pytest.mark.acceptance
-def test_tpch_query_nation(tpch_setup: DorisConnector):
-    """Test querying tpch_nation - should have 25 nations."""
-    result = tpch_setup.execute(
-        {"sql_query": "SELECT * FROM `tpch_nation`"},
-        result_format="list",
-    )
-    assert result.success
-    assert len(result.sql_return) == 25
-
-
-@pytest.mark.integration
-def test_tpch_query_join(tpch_setup: DorisConnector):
-    """Test JOIN query: nation JOIN region."""
+def test_tpch_join(tpch_setup: DorisConnector):
     result = tpch_setup.execute(
         {
             "sql_query": (
@@ -90,21 +61,22 @@ def test_tpch_query_join(tpch_setup: DorisConnector):
         },
         result_format="list",
     )
+
     assert result.success
     assert len(result.sql_return) == 25
-    # ALGERIA is in AFRICA
-    first_row = result.sql_return[0]
-    assert first_row["nation_name"] == "ALGERIA"
-    assert first_row["region_name"] == "AFRICA"
+    assert result.sql_return[0] == {
+        "nation_name": "ALGERIA",
+        "region_name": "AFRICA",
+    }
 
 
 @pytest.mark.integration
-def test_tpch_query_aggregation(tpch_setup: DorisConnector):
-    """Test aggregation: count nations per region."""
+def test_tpch_aggregation(tpch_setup: DorisConnector):
     result = tpch_setup.execute(
         {
             "sql_query": (
-                "SELECT r.name AS region_name, COUNT(n.nationkey) AS nation_count "
+                "SELECT r.name AS region_name, "
+                "COUNT(n.nationkey) AS nation_count "
                 "FROM `tpch_region` r "
                 "JOIN `tpch_nation` n ON r.regionkey = n.regionkey "
                 "GROUP BY r.name "
@@ -113,15 +85,14 @@ def test_tpch_query_aggregation(tpch_setup: DorisConnector):
         },
         result_format="list",
     )
+
     assert result.success
-    assert len(result.sql_return) == 5  # 5 regions
-    total_nations = sum(row["nation_count"] for row in result.sql_return)
-    assert total_nations == 25  # 25 nations total
+    assert len(result.sql_return) == 5
+    assert sum(row["nation_count"] for row in result.sql_return) == 25
 
 
 @pytest.mark.integration
-def test_tpch_query_customer_orders(tpch_setup: DorisConnector):
-    """Test JOIN query: customer JOIN orders."""
+def test_tpch_customer_orders(tpch_setup: DorisConnector):
     result = tpch_setup.execute(
         {
             "sql_query": (
@@ -136,50 +107,30 @@ def test_tpch_query_customer_orders(tpch_setup: DorisConnector):
         },
         result_format="list",
     )
+
     assert result.success
-    assert len(result.sql_return) > 0
-    assert "order_count" in result.sql_return[0]
-    assert "total_spent" in result.sql_return[0]
-
-
-# ==================== Multi-Format Output Tests ====================
+    assert result.sql_return
+    assert {"order_count", "total_spent"}.issubset(result.sql_return[0])
 
 
 @pytest.mark.integration
-def test_tpch_query_csv_format(tpch_setup: DorisConnector):
-    """Test CSV result format with TPC-H data."""
+@pytest.mark.parametrize("result_format", ["csv", "arrow", "pandas"])
+def test_tpch_result_formats(
+    tpch_setup: DorisConnector,
+    result_format: str,
+):
     result = tpch_setup.execute(
-        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
-        result_format="csv",
+        {"sql_query": ("SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey")},
+        result_format=result_format,
     )
+
     assert result.success
-    assert "AFRICA" in result.sql_return
-    assert "ASIA" in result.sql_return
-
-
-@pytest.mark.integration
-def test_tpch_query_arrow_format(tpch_setup: DorisConnector):
-    """Test Arrow result format with TPC-H data."""
-    result = tpch_setup.execute(
-        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
-        result_format="arrow",
-    )
-    assert result.success
-    arrow_table = result.sql_return
-    assert arrow_table.num_rows == 5
-    assert "regionkey" in arrow_table.column_names
-    assert "name" in arrow_table.column_names
-
-
-@pytest.mark.integration
-def test_tpch_query_pandas_format(tpch_setup: DorisConnector):
-    """Test Pandas DataFrame result format with TPC-H data."""
-    result = tpch_setup.execute(
-        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
-        result_format="pandas",
-    )
-    assert result.success
-    df = result.sql_return
-    assert len(df) == 5
-    assert "regionkey" in df.columns
-    assert "name" in df.columns
+    if result_format == "csv":
+        assert "AFRICA" in result.sql_return
+        assert "ASIA" in result.sql_return
+    elif result_format == "arrow":
+        assert result.sql_return.num_rows == 5
+        assert result.sql_return.column_names == ["regionkey", "name"]
+    else:
+        assert len(result.sql_return) == 5
+        assert list(result.sql_return.columns) == ["regionkey", "name"]

--- a/datus-doris/tests/integration/test_tpch.py
+++ b/datus-doris/tests/integration/test_tpch.py
@@ -1,0 +1,185 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+
+from datus_doris import DorisConnector
+
+# ==================== Metadata Tests ====================
+
+
+@pytest.mark.integration
+def test_tpch_get_tables(tpch_setup: DorisConnector):
+    """Test that TPC-H tables exist in the database."""
+    tables = tpch_setup.get_tables()
+    db = tpch_setup.doris_config.database
+    expected = {
+        f"{db}.tpch_region",
+        f"{db}.tpch_nation",
+        f"{db}.tpch_customer",
+        f"{db}.tpch_orders",
+        f"{db}.tpch_supplier",
+    }
+    table_set = set(tables)
+    assert expected.issubset(table_set), f"Missing tables: {expected - table_set}"
+
+
+@pytest.mark.integration
+def test_tpch_get_columns(tpch_setup: DorisConnector):
+    """Test getting column schema for tpch_customer table."""
+    columns = tpch_setup.get_schema(table_name="tpch_customer")
+    assert len(columns) > 0
+    column_names = {col["name"] for col in columns}
+    assert "custkey" in column_names
+    assert "name" in column_names
+    assert "nationkey" in column_names
+    for col in columns:
+        assert "name" in col
+        assert "type" in col
+
+
+@pytest.mark.integration
+def test_tpch_get_columns_nation(tpch_setup: DorisConnector):
+    """Test getting column schema for tpch_nation table."""
+    columns = tpch_setup.get_schema(table_name="tpch_nation")
+    column_names = {col["name"] for col in columns}
+    assert "nationkey" in column_names
+    assert "name" in column_names
+    assert "regionkey" in column_names
+
+
+# ==================== Data Query Tests ====================
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_tpch_query_region(tpch_setup: DorisConnector):
+    """Test querying tpch_region - should have 5 regions."""
+    result = tpch_setup.execute(
+        {"sql_query": "SELECT * FROM `tpch_region`"},
+        result_format="list",
+    )
+    assert result.success
+    assert len(result.sql_return) == 5
+
+
+@pytest.mark.integration
+@pytest.mark.acceptance
+def test_tpch_query_nation(tpch_setup: DorisConnector):
+    """Test querying tpch_nation - should have 25 nations."""
+    result = tpch_setup.execute(
+        {"sql_query": "SELECT * FROM `tpch_nation`"},
+        result_format="list",
+    )
+    assert result.success
+    assert len(result.sql_return) == 25
+
+
+@pytest.mark.integration
+def test_tpch_query_join(tpch_setup: DorisConnector):
+    """Test JOIN query: nation JOIN region."""
+    result = tpch_setup.execute(
+        {
+            "sql_query": (
+                "SELECT n.name AS nation_name, r.name AS region_name "
+                "FROM `tpch_nation` n "
+                "JOIN `tpch_region` r ON n.regionkey = r.regionkey "
+                "ORDER BY n.nationkey"
+            )
+        },
+        result_format="list",
+    )
+    assert result.success
+    assert len(result.sql_return) == 25
+    # ALGERIA is in AFRICA
+    first_row = result.sql_return[0]
+    assert first_row["nation_name"] == "ALGERIA"
+    assert first_row["region_name"] == "AFRICA"
+
+
+@pytest.mark.integration
+def test_tpch_query_aggregation(tpch_setup: DorisConnector):
+    """Test aggregation: count nations per region."""
+    result = tpch_setup.execute(
+        {
+            "sql_query": (
+                "SELECT r.name AS region_name, COUNT(n.nationkey) AS nation_count "
+                "FROM `tpch_region` r "
+                "JOIN `tpch_nation` n ON r.regionkey = n.regionkey "
+                "GROUP BY r.name "
+                "ORDER BY r.name"
+            )
+        },
+        result_format="list",
+    )
+    assert result.success
+    assert len(result.sql_return) == 5  # 5 regions
+    total_nations = sum(row["nation_count"] for row in result.sql_return)
+    assert total_nations == 25  # 25 nations total
+
+
+@pytest.mark.integration
+def test_tpch_query_customer_orders(tpch_setup: DorisConnector):
+    """Test JOIN query: customer JOIN orders."""
+    result = tpch_setup.execute(
+        {
+            "sql_query": (
+                "SELECT c.name, COUNT(o.orderkey) AS order_count, "
+                "SUM(o.totalprice) AS total_spent "
+                "FROM `tpch_customer` c "
+                "JOIN `tpch_orders` o ON c.custkey = o.custkey "
+                "GROUP BY c.name "
+                "ORDER BY order_count DESC "
+                "LIMIT 5"
+            )
+        },
+        result_format="list",
+    )
+    assert result.success
+    assert len(result.sql_return) > 0
+    assert "order_count" in result.sql_return[0]
+    assert "total_spent" in result.sql_return[0]
+
+
+# ==================== Multi-Format Output Tests ====================
+
+
+@pytest.mark.integration
+def test_tpch_query_csv_format(tpch_setup: DorisConnector):
+    """Test CSV result format with TPC-H data."""
+    result = tpch_setup.execute(
+        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
+        result_format="csv",
+    )
+    assert result.success
+    assert "AFRICA" in result.sql_return
+    assert "ASIA" in result.sql_return
+
+
+@pytest.mark.integration
+def test_tpch_query_arrow_format(tpch_setup: DorisConnector):
+    """Test Arrow result format with TPC-H data."""
+    result = tpch_setup.execute(
+        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
+        result_format="arrow",
+    )
+    assert result.success
+    arrow_table = result.sql_return
+    assert arrow_table.num_rows == 5
+    assert "regionkey" in arrow_table.column_names
+    assert "name" in arrow_table.column_names
+
+
+@pytest.mark.integration
+def test_tpch_query_pandas_format(tpch_setup: DorisConnector):
+    """Test Pandas DataFrame result format with TPC-H data."""
+    result = tpch_setup.execute(
+        {"sql_query": "SELECT regionkey, name FROM `tpch_region` ORDER BY regionkey"},
+        result_format="pandas",
+    )
+    assert result.success
+    df = result.sql_return
+    assert len(df) == 5
+    assert "regionkey" in df.columns
+    assert "name" in df.columns

--- a/datus-doris/tests/unit/test_config.py
+++ b/datus-doris/tests/unit/test_config.py
@@ -7,264 +7,75 @@ from pydantic import ValidationError
 
 from datus_doris import DorisConfig
 
-# ==================== Basic Validation Tests ====================
-
 
 @pytest.mark.acceptance
-def test_config_with_all_required_fields():
-    """Test config initialization with all required fields."""
+def test_config_defaults():
     config = DorisConfig(username="test_user")
 
-    assert config.host == "127.0.0.1"
-    assert config.port == 9030
-    assert config.username == "test_user"
-    assert config.password == ""
-    assert config.catalog == "internal"
-    assert config.database is None
-    assert config.charset == "utf8mb4"
-    assert config.autocommit is True
-    assert config.timeout_seconds == 30
+    assert config.model_dump() == {
+        "host": "127.0.0.1",
+        "port": 9030,
+        "username": "test_user",
+        "password": "",
+        "catalog": "internal",
+        "database": None,
+        "charset": "utf8mb4",
+        "autocommit": True,
+        "timeout_seconds": 30,
+    }
 
 
 @pytest.mark.acceptance
-def test_config_with_custom_values():
-    """Test config with custom values."""
+def test_config_custom_values():
     config = DorisConfig(
         host="192.168.1.100",
         port=9031,
         username="admin",
-        password="secret123",
-        catalog="my_catalog",
-        database="mydb",
+        password="p@ss!w0rd",
+        catalog="hive-catalog",
+        database="analytics",
         charset="utf8",
         autocommit=False,
         timeout_seconds=60,
     )
 
-    assert config.host == "192.168.1.100"
-    assert config.port == 9031
-    assert config.username == "admin"
-    assert config.password == "secret123"
-    assert config.catalog == "my_catalog"
-    assert config.database == "mydb"
-    assert config.charset == "utf8"
-    assert config.autocommit is False
-    assert config.timeout_seconds == 60
+    assert config.model_dump() == {
+        "host": "192.168.1.100",
+        "port": 9031,
+        "username": "admin",
+        "password": "p@ss!w0rd",
+        "catalog": "hive-catalog",
+        "database": "analytics",
+        "charset": "utf8",
+        "autocommit": False,
+        "timeout_seconds": 60,
+    }
 
 
-@pytest.mark.acceptance
-def test_config_missing_required_field():
-    """Test that validation fails when required fields are missing."""
+def test_config_requires_username():
     with pytest.raises(ValidationError) as exc_info:
         DorisConfig()
 
-    errors = exc_info.value.errors()
-    assert len(errors) == 1
-    assert errors[0]["loc"] == ("username",)
-    assert errors[0]["type"] == "missing"
+    assert exc_info.value.errors()[0]["loc"] == ("username",)
 
 
-def test_config_invalid_port_type():
-    """Test that validation fails for invalid port type."""
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("port", "invalid"),
+        ("timeout_seconds", "invalid"),
+        ("autocommit", "invalid"),
+    ],
+)
+def test_config_rejects_invalid_field_types(field, value):
     with pytest.raises(ValidationError) as exc_info:
-        DorisConfig(username="test_user", port="invalid")
+        DorisConfig(username="test_user", **{field: value})
 
-    errors = exc_info.value.errors()
-    assert any(error["loc"] == ("port",) for error in errors)
-
-
-def test_config_invalid_timeout_type():
-    """Test that validation fails for invalid timeout type."""
-    with pytest.raises(ValidationError) as exc_info:
-        DorisConfig(username="test_user", timeout_seconds="invalid")
-
-    errors = exc_info.value.errors()
-    assert any(error["loc"] == ("timeout_seconds",) for error in errors)
+    assert any(error["loc"] == (field,) for error in exc_info.value.errors())
 
 
-def test_config_invalid_autocommit_type():
-    """Test that validation fails for invalid autocommit type."""
-    with pytest.raises(ValidationError) as exc_info:
-        DorisConfig(username="test_user", autocommit="invalid")
-
-    errors = exc_info.value.errors()
-    assert any(error["loc"] == ("autocommit",) for error in errors)
-
-
-@pytest.mark.acceptance
 def test_config_forbids_extra_fields():
-    """Test that extra fields are not allowed."""
     with pytest.raises(ValidationError) as exc_info:
         DorisConfig(username="test_user", extra_field="not_allowed")
 
-    errors = exc_info.value.errors()
-    assert any(error["type"] == "extra_forbidden" for error in errors)
-
-
-def test_config_from_dict():
-    """Test creating config from dictionary."""
-    config_dict = {
-        "host": "localhost",
-        "port": 9030,
-        "username": "root",
-        "password": "pass123",
-        "catalog": "test_catalog",
-        "database": "testdb",
-    }
-
-    config = DorisConfig(**config_dict)
-
-    assert config.host == "localhost"
-    assert config.port == 9030
-    assert config.username == "root"
-    assert config.password == "pass123"
-    assert config.catalog == "test_catalog"
-    assert config.database == "testdb"
-
-
-# ==================== Doris-Specific Field Tests ====================
-
-
-def test_config_default_catalog():
-    """Test default catalog value."""
-    config = DorisConfig(username="test_user")
-
-    assert config.catalog == "internal"
-
-
-def test_config_custom_catalog():
-    """Test custom catalog value."""
-    config = DorisConfig(username="test_user", catalog="custom_catalog")
-
-    assert config.catalog == "custom_catalog"
-
-
-def test_config_empty_catalog():
-    """Test empty catalog string."""
-    config = DorisConfig(username="test_user", catalog="")
-
-    assert config.catalog == ""
-
-
-def test_config_default_port_9030():
-    """Test default port is 9030 (not 3306 like MySQL)."""
-    config = DorisConfig(username="test_user")
-
-    assert config.port == 9030
-
-
-def test_config_catalog_with_special_characters():
-    """Test catalog with special characters."""
-    special_catalog = "test-catalog_123"
-    config = DorisConfig(username="test_user", catalog=special_catalog)
-
-    assert config.catalog == special_catalog
-
-
-# ==================== Default Value Tests ====================
-
-
-def test_config_default_host():
-    """Test default host value."""
-    config = DorisConfig(username="test_user")
-
-    assert config.host == "127.0.0.1"
-
-
-def test_config_default_charset():
-    """Test default charset value."""
-    config = DorisConfig(username="test_user")
-
-    assert config.charset == "utf8mb4"
-
-
-def test_config_default_autocommit():
-    """Test default autocommit value."""
-    config = DorisConfig(username="test_user")
-
-    assert config.autocommit is True
-
-
-def test_config_default_timeout():
-    """Test default timeout value."""
-    config = DorisConfig(username="test_user")
-
-    assert config.timeout_seconds == 30
-
-
-def test_config_with_none_database():
-    """Test config with None as database."""
-    config = DorisConfig(username="test_user", database=None)
-
-    assert config.database is None
-
-
-def test_config_with_empty_password():
-    """Test config with empty password."""
-    config = DorisConfig(username="test_user", password="")
-
-    assert config.password == ""
-
-
-# ==================== Edge Case Tests ====================
-
-
-@pytest.mark.acceptance
-def test_config_special_characters_in_password():
-    """Test config with special characters in password."""
-    special_password = "p@ss!w0rd#$%^&*()"
-    config = DorisConfig(username="test_user", password=special_password)
-
-    assert config.password == special_password
-
-
-def test_config_unicode_in_catalog():
-    """Test config with unicode characters in catalog name."""
-    unicode_catalog = "目录名"
-    config = DorisConfig(username="test_user", catalog=unicode_catalog)
-
-    assert config.catalog == unicode_catalog
-
-
-def test_config_large_port_number():
-    """Test config with large port number."""
-    config = DorisConfig(username="test_user", port=65535)
-
-    assert config.port == 65535
-
-
-def test_config_port_out_of_range():
-    """Test that port out of valid range is accepted (no validation)."""
-    config = DorisConfig(username="test_user", port=70000)
-    assert config.port == 70000
-
-
-def test_config_zero_timeout():
-    """Test that zero timeout is allowed."""
-    config = DorisConfig(username="test_user", timeout_seconds=0)
-
-    assert config.timeout_seconds == 0
-
-
-def test_config_to_dict():
-    """Test converting config to dictionary."""
-    config = DorisConfig(
-        host="localhost",
-        port=9030,
-        username="root",
-        password="pass123",
-        catalog="test_catalog",
-        database="testdb",
-    )
-
-    config_dict = config.model_dump()
-
-    assert config_dict["host"] == "localhost"
-    assert config_dict["port"] == 9030
-    assert config_dict["username"] == "root"
-    assert config_dict["password"] == "pass123"
-    assert config_dict["catalog"] == "test_catalog"
-    assert config_dict["database"] == "testdb"
-    assert config_dict["charset"] == "utf8mb4"
-    assert config_dict["autocommit"] is True
-    assert config_dict["timeout_seconds"] == 30
+    assert any(error["type"] == "extra_forbidden" for error in exc_info.value.errors())

--- a/datus-doris/tests/unit/test_config.py
+++ b/datus-doris/tests/unit/test_config.py
@@ -1,0 +1,270 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+from pydantic import ValidationError
+
+from datus_doris import DorisConfig
+
+# ==================== Basic Validation Tests ====================
+
+
+@pytest.mark.acceptance
+def test_config_with_all_required_fields():
+    """Test config initialization with all required fields."""
+    config = DorisConfig(username="test_user")
+
+    assert config.host == "127.0.0.1"
+    assert config.port == 9030
+    assert config.username == "test_user"
+    assert config.password == ""
+    assert config.catalog == "internal"
+    assert config.database is None
+    assert config.charset == "utf8mb4"
+    assert config.autocommit is True
+    assert config.timeout_seconds == 30
+
+
+@pytest.mark.acceptance
+def test_config_with_custom_values():
+    """Test config with custom values."""
+    config = DorisConfig(
+        host="192.168.1.100",
+        port=9031,
+        username="admin",
+        password="secret123",
+        catalog="my_catalog",
+        database="mydb",
+        charset="utf8",
+        autocommit=False,
+        timeout_seconds=60,
+    )
+
+    assert config.host == "192.168.1.100"
+    assert config.port == 9031
+    assert config.username == "admin"
+    assert config.password == "secret123"
+    assert config.catalog == "my_catalog"
+    assert config.database == "mydb"
+    assert config.charset == "utf8"
+    assert config.autocommit is False
+    assert config.timeout_seconds == 60
+
+
+@pytest.mark.acceptance
+def test_config_missing_required_field():
+    """Test that validation fails when required fields are missing."""
+    with pytest.raises(ValidationError) as exc_info:
+        DorisConfig()
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("username",)
+    assert errors[0]["type"] == "missing"
+
+
+def test_config_invalid_port_type():
+    """Test that validation fails for invalid port type."""
+    with pytest.raises(ValidationError) as exc_info:
+        DorisConfig(username="test_user", port="invalid")
+
+    errors = exc_info.value.errors()
+    assert any(error["loc"] == ("port",) for error in errors)
+
+
+def test_config_invalid_timeout_type():
+    """Test that validation fails for invalid timeout type."""
+    with pytest.raises(ValidationError) as exc_info:
+        DorisConfig(username="test_user", timeout_seconds="invalid")
+
+    errors = exc_info.value.errors()
+    assert any(error["loc"] == ("timeout_seconds",) for error in errors)
+
+
+def test_config_invalid_autocommit_type():
+    """Test that validation fails for invalid autocommit type."""
+    with pytest.raises(ValidationError) as exc_info:
+        DorisConfig(username="test_user", autocommit="invalid")
+
+    errors = exc_info.value.errors()
+    assert any(error["loc"] == ("autocommit",) for error in errors)
+
+
+@pytest.mark.acceptance
+def test_config_forbids_extra_fields():
+    """Test that extra fields are not allowed."""
+    with pytest.raises(ValidationError) as exc_info:
+        DorisConfig(username="test_user", extra_field="not_allowed")
+
+    errors = exc_info.value.errors()
+    assert any(error["type"] == "extra_forbidden" for error in errors)
+
+
+def test_config_from_dict():
+    """Test creating config from dictionary."""
+    config_dict = {
+        "host": "localhost",
+        "port": 9030,
+        "username": "root",
+        "password": "pass123",
+        "catalog": "test_catalog",
+        "database": "testdb",
+    }
+
+    config = DorisConfig(**config_dict)
+
+    assert config.host == "localhost"
+    assert config.port == 9030
+    assert config.username == "root"
+    assert config.password == "pass123"
+    assert config.catalog == "test_catalog"
+    assert config.database == "testdb"
+
+
+# ==================== Doris-Specific Field Tests ====================
+
+
+def test_config_default_catalog():
+    """Test default catalog value."""
+    config = DorisConfig(username="test_user")
+
+    assert config.catalog == "internal"
+
+
+def test_config_custom_catalog():
+    """Test custom catalog value."""
+    config = DorisConfig(username="test_user", catalog="custom_catalog")
+
+    assert config.catalog == "custom_catalog"
+
+
+def test_config_empty_catalog():
+    """Test empty catalog string."""
+    config = DorisConfig(username="test_user", catalog="")
+
+    assert config.catalog == ""
+
+
+def test_config_default_port_9030():
+    """Test default port is 9030 (not 3306 like MySQL)."""
+    config = DorisConfig(username="test_user")
+
+    assert config.port == 9030
+
+
+def test_config_catalog_with_special_characters():
+    """Test catalog with special characters."""
+    special_catalog = "test-catalog_123"
+    config = DorisConfig(username="test_user", catalog=special_catalog)
+
+    assert config.catalog == special_catalog
+
+
+# ==================== Default Value Tests ====================
+
+
+def test_config_default_host():
+    """Test default host value."""
+    config = DorisConfig(username="test_user")
+
+    assert config.host == "127.0.0.1"
+
+
+def test_config_default_charset():
+    """Test default charset value."""
+    config = DorisConfig(username="test_user")
+
+    assert config.charset == "utf8mb4"
+
+
+def test_config_default_autocommit():
+    """Test default autocommit value."""
+    config = DorisConfig(username="test_user")
+
+    assert config.autocommit is True
+
+
+def test_config_default_timeout():
+    """Test default timeout value."""
+    config = DorisConfig(username="test_user")
+
+    assert config.timeout_seconds == 30
+
+
+def test_config_with_none_database():
+    """Test config with None as database."""
+    config = DorisConfig(username="test_user", database=None)
+
+    assert config.database is None
+
+
+def test_config_with_empty_password():
+    """Test config with empty password."""
+    config = DorisConfig(username="test_user", password="")
+
+    assert config.password == ""
+
+
+# ==================== Edge Case Tests ====================
+
+
+@pytest.mark.acceptance
+def test_config_special_characters_in_password():
+    """Test config with special characters in password."""
+    special_password = "p@ss!w0rd#$%^&*()"
+    config = DorisConfig(username="test_user", password=special_password)
+
+    assert config.password == special_password
+
+
+def test_config_unicode_in_catalog():
+    """Test config with unicode characters in catalog name."""
+    unicode_catalog = "目录名"
+    config = DorisConfig(username="test_user", catalog=unicode_catalog)
+
+    assert config.catalog == unicode_catalog
+
+
+def test_config_large_port_number():
+    """Test config with large port number."""
+    config = DorisConfig(username="test_user", port=65535)
+
+    assert config.port == 65535
+
+
+def test_config_port_out_of_range():
+    """Test that port out of valid range is accepted (no validation)."""
+    config = DorisConfig(username="test_user", port=70000)
+    assert config.port == 70000
+
+
+def test_config_zero_timeout():
+    """Test that zero timeout is allowed."""
+    config = DorisConfig(username="test_user", timeout_seconds=0)
+
+    assert config.timeout_seconds == 0
+
+
+def test_config_to_dict():
+    """Test converting config to dictionary."""
+    config = DorisConfig(
+        host="localhost",
+        port=9030,
+        username="root",
+        password="pass123",
+        catalog="test_catalog",
+        database="testdb",
+    )
+
+    config_dict = config.model_dump()
+
+    assert config_dict["host"] == "localhost"
+    assert config_dict["port"] == 9030
+    assert config_dict["username"] == "root"
+    assert config_dict["password"] == "pass123"
+    assert config_dict["catalog"] == "test_catalog"
+    assert config_dict["database"] == "testdb"
+    assert config_dict["charset"] == "utf8mb4"
+    assert config_dict["autocommit"] is True
+    assert config_dict["timeout_seconds"] == 30

--- a/datus-doris/tests/unit/test_connector_unit.py
+++ b/datus-doris/tests/unit/test_connector_unit.py
@@ -44,18 +44,17 @@ def test_connector_rejects_invalid_config_type():
 
 
 @pytest.mark.parametrize(
-    ("catalog", "database", "mysql_database", "deferred_database", "effective_catalog"),
+    ("catalog", "database", "mysql_database", "effective_catalog"),
     [
-        ("internal", "analytics", "analytics", "", "internal"),
-        ("def", "analytics", "analytics", "", "internal"),
-        ("external", "analytics", "", "analytics", "external"),
+        ("internal", "analytics", "analytics", "internal"),
+        ("def", "analytics", "analytics", "internal"),
+        ("external", "analytics", "", "external"),
     ],
 )
 def test_connector_maps_doris_config_to_mysql(
     catalog,
     database,
     mysql_database,
-    deferred_database,
     effective_catalog,
 ):
     config = DorisConfig(
@@ -77,8 +76,8 @@ def test_connector_maps_doris_config_to_mysql(
         "admin",
     )
     assert mysql_config.database == mysql_database
-    assert connector._deferred_database == deferred_database
     assert connector.catalog_name == effective_catalog
+    assert connector.database_name == database
 
 
 @pytest.mark.parametrize(
@@ -171,6 +170,39 @@ def test_do_switch_context(connector, catalog, database, expected_sql):
     actual_sql = [str(call.args[0].text) for call in conn.execute.call_args_list]
     assert actual_sql == expected_sql
     assert conn.commit.call_count == len(expected_sql)
+
+
+def test_configured_external_database_is_applied_on_checkout():
+    connector = _connector(catalog="external", database="analytics")
+    conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    connector.engine = engine
+    connector._owns_engine = True
+
+    with connector._conn():
+        pass
+
+    actual_sql = [str(call.args[0].text) for call in conn.execute.call_args_list]
+    assert actual_sql == ["SWITCH `external`", "USE `analytics`"]
+
+
+def test_metadata_literals_escape_backslashes_before_quotes(connector):
+    rows = MagicMock()
+    rows.__len__.return_value = 0
+    connector.connect = MagicMock()
+    connector._execute_pandas = MagicMock(return_value=rows)
+    connector._get_materialized_view_metadata = MagicMock(return_value=[])
+    unsafe_name = "db\\'name"
+
+    connector._get_metadata(database_name=unsafe_name)
+    metadata_query = connector._execute_pandas.call_args.args[0]
+    assert "TABLE_SCHEMA = 'db\\\\''name'" in metadata_query
+
+    connector.get_schema(database_name=unsafe_name, table_name=unsafe_name)
+    schema_query = connector._execute_pandas.call_args.args[0]
+    assert "TABLE_SCHEMA = 'db\\\\''name'" in schema_query
+    assert "TABLE_NAME = 'db\\\\''name'" in schema_query
 
 
 def _connector_with_engine() -> DorisConnector:

--- a/datus-doris/tests/unit/test_connector_unit.py
+++ b/datus-doris/tests/unit/test_connector_unit.py
@@ -6,666 +6,265 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datus_db_core import CatalogSupportMixin, MaterializedViewSupportMixin, SQLType
+import datus_doris
+from datus_db_core import SQLType
 from datus_doris import DorisConfig, DorisConnector
 
-# ==================== Initialization Tests ====================
+
+def _connector(config=None, **overrides) -> DorisConnector:
+    config = config or DorisConfig(username="test_user", **overrides)
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        return DorisConnector(config)
+
+
+@pytest.fixture
+def connector() -> DorisConnector:
+    return _connector()
 
 
 @pytest.mark.acceptance
-def test_connector_initialization_with_config_object():
-    """Test connector initialization with DorisConfig object."""
-    config = DorisConfig(
-        host="localhost",
-        port=9030,
-        username="test_user",
-        password="test_pass",
-        catalog="test_catalog",
-        database="testdb",
-    )
+@pytest.mark.parametrize(
+    "config",
+    [
+        DorisConfig(username="test_user", catalog="internal"),
+        {"username": "test_user", "catalog": "internal"},
+    ],
+)
+def test_connector_initialization(config):
+    connector = _connector(config=config)
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert connector.doris_config == config
-        assert connector.catalog_name == "test_catalog"
-        assert connector.dialect == "doris"
+    assert isinstance(connector.doris_config, DorisConfig)
+    assert connector.catalog_name == "internal"
+    assert connector.dialect == "doris"
 
 
-@pytest.mark.acceptance
-def test_connector_initialization_with_dict():
-    """Test connector initialization with dict config."""
-    config_dict = {
-        "host": "192.168.1.100",
-        "port": 9031,
-        "username": "admin",
-        "password": "secret",
-        "catalog": "custom_catalog",
-        "database": "mydb",
-    }
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config_dict)
-
-        assert isinstance(connector.doris_config, DorisConfig)
-        assert connector.catalog_name == "custom_catalog"
-        assert connector.dialect == "doris"
-
-
-def test_connector_initialization_invalid_type():
-    """Test that connector raises TypeError for invalid config type."""
+def test_connector_rejects_invalid_config_type():
     with pytest.raises(TypeError, match="config must be DorisConfig or dict"):
         DorisConnector("invalid_config")
 
 
-def test_connector_stores_doris_config():
-    """Test that connector stores DorisConfig object."""
-    config = DorisConfig(username="test_user", catalog="my_catalog")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert hasattr(connector, "doris_config")
-        assert connector.doris_config.catalog == "my_catalog"
-
-
-def test_connector_passes_mysql_config_to_parent():
-    """Test that connector converts and passes MySQLConfig to parent."""
+@pytest.mark.parametrize(
+    ("catalog", "database", "mysql_database", "deferred_database", "effective_catalog"),
+    [
+        ("internal", "analytics", "analytics", "", "internal"),
+        ("def", "analytics", "analytics", "", "internal"),
+        ("external", "analytics", "", "analytics", "external"),
+    ],
+)
+def test_connector_maps_doris_config_to_mysql(
+    catalog,
+    database,
+    mysql_database,
+    deferred_database,
+    effective_catalog,
+):
     config = DorisConfig(
-        host="localhost",
-        port=9030,
-        username="user",
-        password="pass",
-        database="db",
+        host="doris.example",
+        port=9031,
+        username="admin",
+        password="secret",
+        catalog=catalog,
+        database=database,
     )
 
-    with patch("datus_mysql.MySQLConnector.__init__") as mock_init:
-        DorisConnector(config)
-
-        mock_init.assert_called_once()
-        mysql_config = mock_init.call_args[0][0]
-        assert mysql_config.host == "localhost"
-        assert mysql_config.port == 9030
-        assert mysql_config.username == "user"
-
-
-# ==================== Catalog Functionality Unit Tests ====================
-
-
-@pytest.mark.acceptance
-def test_internal_returns_default_catalog():
-    """Test that internal returns 'internal'."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+    with patch("datus_mysql.MySQLConnector.__init__") as parent_init:
         connector = DorisConnector(config)
 
-        assert connector.default_catalog() == "internal"
-
-
-def test_resolve_catalog_with_empty():
-    """Test _resolve_catalog with empty string falls back to default."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.catalog_name = ""
-
-        result = connector._resolve_catalog("")
-        assert result == "internal"
-
-
-def test_resolve_catalog_with_def():
-    """Test _resolve_catalog with 'def' string returns default."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector._resolve_catalog("def")
-        assert result == "internal"
-
-
-def test_get_current_context_resolves_default_catalog():
-    """Test current context exposes effective SQL coordinates."""
-    config = DorisConfig(username="test_user", database="ac_manage")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert connector.get_current_context() == {
-            "catalog_name": "internal",
-            "database_name": "ac_manage",
-            "schema_name": "",
-        }
-
-
-def test_get_current_context_normalizes_def_catalog():
-    """Test current context normalizes Doris catalog aliases."""
-    config = DorisConfig(username="test_user", catalog="def", database="ac_manage")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.catalog_name = "def"
-
-        assert connector.get_current_context()["catalog_name"] == "internal"
-
-
-def test_get_current_context_keeps_custom_catalog():
-    """Test current context keeps configured non-default catalogs."""
-    config = DorisConfig(username="test_user", catalog="external_catalog", database="analytics")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert connector.get_current_context() == {
-            "catalog_name": "external_catalog",
-            "database_name": "analytics",
-            "schema_name": "",
-        }
-
-
-def test_resolve_catalog_preserves_custom():
-    """Test _resolve_catalog preserves custom catalog."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector._resolve_catalog("my_catalog")
-        assert result == "my_catalog"
-
-
-@pytest.mark.acceptance
-def test_switch_catalog_updates_catalog_name():
-    """Test that switch_catalog updates catalog_name via switch_context."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        connector.switch_catalog("new_catalog")
-
-        assert connector.catalog_name == "new_catalog"
-
-
-def test_switch_catalog_calls_switch_context():
-    """Test that switch_catalog calls switch_context."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.switch_context = MagicMock()
-
-        connector.switch_catalog("target_catalog")
-
-        connector.switch_context.assert_called_once_with(catalog_name="target_catalog")
-
-
-def test_resolve_catalog_falls_back_to_connector_catalog():
-    """Test _resolve_catalog uses connector's catalog_name when no arg given."""
-    config = DorisConfig(username="test_user", catalog="configured_catalog")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector._resolve_catalog("")
-        assert result == "configured_catalog"
-
-
-def test_resolve_catalog_arg_takes_precedence():
-    """Test _resolve_catalog uses explicit arg over connector catalog."""
-    config = DorisConfig(username="test_user", catalog="configured_catalog")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector._resolve_catalog("explicit_catalog")
-        assert result == "explicit_catalog"
-
-
-# ==================== full_name() Method Tests ====================
-
-
-@pytest.mark.acceptance
-def test_full_name_with_catalog_and_database():
-    """Test full_name with catalog, database, and table."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(catalog_name="my_catalog", database_name="my_db", table_name="my_table")
-
-        assert result == "`my_catalog`.`my_db`.`my_table`"
-
-
-def test_full_name_with_catalog_only():
-    """Test full_name with catalog and table only."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(catalog_name="my_catalog", table_name="my_table")
-
-        assert result == "`my_table`"
-
-
-def test_full_name_with_database_no_catalog():
-    """Test full_name with database and table, no explicit catalog (uses default)."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(database_name="my_db", table_name="my_table")
-
-        # Empty catalog is reset to internal, so result includes it
-        assert result == "`internal`.`my_db`.`my_table`"
-
-
-def test_full_name_table_only():
-    """Test full_name with table only."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(table_name="my_table")
-
-        assert result == "`my_table`"
-
-
-def test_full_name_resets_empty_catalog_to_default():
-    """Test full_name resets empty catalog to default."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(catalog_name="", database_name="db", table_name="table")
-
-        # Empty catalog is reset to internal
-        assert result == "`internal`.`db`.`table`"
-
-
-@pytest.mark.acceptance
-def test_full_name_quotes_identifiers():
-    """Test full_name adds backticks to identifiers."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(catalog_name="catalog", database_name="database", table_name="table")
-
-        assert result.count("`") == 6  # 3 pairs of backticks
-
-
-def test_full_name_with_special_characters():
-    """Test full_name with special characters in names."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(
-            catalog_name="test-catalog",
-            database_name="test_db",
-            table_name="test-table",
+    mysql_config = parent_init.call_args.args[0]
+    assert (mysql_config.host, mysql_config.port, mysql_config.username) == (
+        "doris.example",
+        9031,
+        "admin",
+    )
+    assert mysql_config.database == mysql_database
+    assert connector._deferred_database == deferred_database
+    assert connector.catalog_name == effective_catalog
+
+
+@pytest.mark.parametrize(
+    ("catalog", "database", "expected"),
+    [
+        ("internal", "analytics", {"catalog_name": "internal", "database_name": "analytics", "schema_name": ""}),
+        ("def", "analytics", {"catalog_name": "internal", "database_name": "analytics", "schema_name": ""}),
+        (
+            "external",
+            "analytics",
+            {"catalog_name": "external", "database_name": "analytics", "schema_name": ""},
+        ),
+    ],
+)
+def test_get_current_context(catalog, database, expected):
+    connector = _connector(catalog=catalog, database=database)
+    assert connector.get_current_context() == expected
+
+
+@pytest.mark.parametrize(
+    ("configured_catalog", "requested_catalog", "expected"),
+    [
+        ("internal", "", "internal"),
+        ("internal", "def", "internal"),
+        ("configured", "", "configured"),
+        ("configured", "explicit", "explicit"),
+    ],
+)
+def test_resolve_catalog(configured_catalog, requested_catalog, expected):
+    connector = _connector(catalog=configured_catalog)
+    assert connector._resolve_catalog(requested_catalog) == expected
+
+
+def test_switch_catalog_delegates_and_clears_database(connector):
+    connector.database_name = "stale_database"
+    connector.switch_context = MagicMock()
+
+    connector.switch_catalog("external")
+
+    connector.switch_context.assert_called_once_with(catalog_name="external")
+    assert connector.database_name == ""
+
+
+@pytest.mark.parametrize(
+    ("catalog", "database", "table", "expected"),
+    [
+        ("catalog", "database", "table", "`catalog`.`database`.`table`"),
+        ("", "database", "table", "`internal`.`database`.`table`"),
+        ("catalog", "", "table", "`table`"),
+        ("", "", "table", "`table`"),
+        ("cat`alog", "db`name", "ta`ble", "`cat``alog`.`db``name`.`ta``ble`"),
+    ],
+)
+def test_full_name(connector, catalog, database, table, expected):
+    assert (
+        connector.full_name(
+            catalog_name=catalog,
+            database_name=database,
+            table_name=table,
         )
-
-        assert "`test-catalog`" in result
-        assert "`test_db`" in result
-        assert "`test-table`" in result
+        == expected
+    )
 
 
-def test_full_name_escapes_backticks():
-    """Test full_name escapes embedded identifier quoting characters."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        result = connector.full_name(catalog_name="cat`alog", database_name="db`name", table_name="ta`ble")
-
-        assert result == "`cat``alog`.`db``name`.`ta``ble`"
-
-
-# ==================== _sqlalchemy_schema() Tests ====================
+@pytest.mark.parametrize(
+    ("catalog", "database", "expected"),
+    [
+        ("catalog", "database", "catalog.database"),
+        ("catalog", "", None),
+        ("", "database", "internal.database"),
+    ],
+)
+def test_sqlalchemy_schema(connector, catalog, database, expected):
+    assert connector._sqlalchemy_schema(catalog_name=catalog, database_name=database) == expected
 
 
-def test_sqlalchemy_schema_with_catalog_and_database():
-    """Test _sqlalchemy_schema returns catalog.database format."""
-    config = DorisConfig(username="test_user")
+@pytest.mark.parametrize(
+    ("catalog", "database", "expected_sql"),
+    [
+        ("external", "", ["SWITCH `external`"]),
+        ("", "analytics", ["USE `analytics`"]),
+        ("external", "analytics", ["SWITCH `external`", "USE `analytics`"]),
+    ],
+)
+def test_do_switch_context(connector, catalog, database, expected_sql):
+    conn = MagicMock()
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.database_name = "my_db"
-        connector.catalog_name = "my_catalog"
+    connector.do_switch_context(conn, catalog_name=catalog, database_name=database)
 
-        result = connector._sqlalchemy_schema(catalog_name="test_catalog", database_name="test_db")
-
-        assert result == "test_catalog.test_db"
-
-
-def test_sqlalchemy_schema_with_catalog_only():
-    """Test _sqlalchemy_schema returns None when no database."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.database_name = None
-        connector.catalog_name = "my_catalog"
-
-        result = connector._sqlalchemy_schema(catalog_name="test_catalog")
-
-        assert result is None
+    actual_sql = [str(call.args[0].text) for call in conn.execute.call_args_list]
+    assert actual_sql == expected_sql
+    assert conn.commit.call_count == len(expected_sql)
 
 
-def test_sqlalchemy_schema_uses_catalog_without_registry_state():
-    """Test _sqlalchemy_schema always includes catalog for direct connector usage."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.catalog_name = "my_catalog"
-        connector.database_name = "my_db"
-
-        result = connector._sqlalchemy_schema(database_name="test_db")
-
-        assert result == "my_catalog.test_db"
+def _connector_with_engine() -> DorisConnector:
+    connector = _connector()
+    engine = MagicMock()
+    engine.connect.return_value = MagicMock()
+    connector.engine = engine
+    connector._owns_engine = True
+    return connector
 
 
-def test_sqlalchemy_schema_uses_default_catalog():
-    """Test _sqlalchemy_schema uses default catalog when not specified."""
-    config = DorisConfig(username="test_user")
+def test_switch_statement_routes_around_older_core_classifier():
+    connector = _connector_with_engine()
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.database_name = "my_db"
-        connector.catalog_name = None
+    with patch("datus_db_core.base.parse_sql_type", return_value=SQLType.UNKNOWN):
+        result = connector.execute(input_params={"sql_query": "SWITCH external"})
 
-        result = connector._sqlalchemy_schema(database_name="test_db")
-
-        assert "internal" in result
-        assert result == "internal.test_db"
-
-
-# ==================== close() Method PyMySQL Error Handling Tests ====================
-
-
-@pytest.mark.acceptance
-def test_do_switch_context_catalog():
-    """do_switch_context executes Doris SWITCH on the given connection."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_conn = MagicMock()
-
-        connector.do_switch_context(mock_conn, catalog_name="new_catalog")
-
-        mock_conn.execute.assert_called_once()
-        mock_conn.commit.assert_called_once()
-
-        sql_arg = str(mock_conn.execute.call_args[0][0].text)
-        assert "SWITCH" in sql_arg
-        assert "new_catalog" in sql_arg
-
-
-def test_do_switch_context_database():
-    """do_switch_context executes USE on the given connection."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_conn = MagicMock()
-
-        connector.do_switch_context(mock_conn, database_name="new_db")
-
-        mock_conn.execute.assert_called_once()
-        mock_conn.commit.assert_called_once()
-
-        sql_arg = str(mock_conn.execute.call_args[0][0].text)
-        assert "USE" in sql_arg
-        assert "new_db" in sql_arg
-
-
-def test_do_switch_context_catalog_and_database():
-    """do_switch_context handles both catalog and database on the given connection."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_conn = MagicMock()
-
-        connector.do_switch_context(mock_conn, catalog_name="cat", database_name="db")
-
-        # Two execute calls: SWITCH + USE
-        assert mock_conn.execute.call_count == 2
-        assert mock_conn.commit.call_count == 2
-
-
-def test_switch_catalog_statement():
-    """connector.execute('switch ...') updates catalog_name via execute_content_set."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_conn = MagicMock()
-        engine = MagicMock()
-        engine.connect.return_value = mock_conn
-        connector.engine = engine
-        connector._owns_engine = True
-        assert connector.catalog_name == "internal"
-
-        with patch("datus_db_core.base.parse_sql_type", return_value=SQLType.UNKNOWN):
-            connector.execute(input_params={"sql_query": "switch cat"})
-            assert connector.catalog_name == "cat"
-
-            connector.execute(input_params={"sql_query": "switch internal"})
-            assert connector.catalog_name == "internal"
+    assert result.success
+    assert connector.catalog_name == "external"
+    assert connector.database_name == ""
 
 
 def test_use_catalog_database_updates_both_context_levels():
-    """USE catalog.database keeps Doris context correct across core versions."""
-    config = DorisConfig(username="test_user")
+    connector = _connector_with_engine()
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_conn = MagicMock()
-        engine = MagicMock()
-        engine.connect.return_value = mock_conn
-        connector.engine = engine
-        connector._owns_engine = True
+    result = connector.execute_content_set("USE `hive-catalog`.`analytics`")
 
-        result = connector.execute_content_set("USE `hive-catalog`.`analytics`")
-
-        assert result.success
-        assert connector.catalog_name == "hive-catalog"
-        assert connector.database_name == "analytics"
+    assert result.success
+    assert connector.catalog_name == "hive-catalog"
+    assert connector.database_name == "analytics"
 
 
-def test_init_normalizes_def_catalog():
-    """config.catalog='def' should be treated as default (no catalog switch needed)."""
-    config = DorisConfig(username="test_user", catalog="def", database="mydb")
+@pytest.mark.parametrize(
+    "message",
+    [
+        "struct.error",
+        "struct.pack error",
+        "COMMAND.COM_QUIT failed",
+        "required argument is not an integer",
+    ],
+)
+def test_close_disposes_engine_for_known_pymysql_errors(connector, message):
+    connector.engine = MagicMock()
 
-    with patch("datus_mysql.MySQLConnector.__init__") as mock_init:
-        connector = DorisConnector(config)
+    with patch("datus_mysql.MySQLConnector.close", side_effect=Exception(message)):
+        connector.close()
 
-        # 'def' is default, so database should be in the MySQL connection string
-        mysql_config = mock_init.call_args[0][0]
-        assert mysql_config.database == "mydb"
-        assert connector._deferred_database == ""
-
-
-def test_close_ignores_struct_pack_error():
-    """Test close ignores struct.pack error."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.engine = None
-
-        with patch(
-            "datus_mysql.MySQLConnector.close",
-            side_effect=Exception("struct.pack error"),
-        ):
-            # Should not raise exception
-            connector.close()
-            assert connector.engine is None
+    assert connector.engine is None
+    assert connector._owns_engine is False
 
 
-def test_close_ignores_com_quit_error():
-    """Test close ignores COM_QUIT error."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.engine = None
-
-        with patch(
-            "datus_mysql.MySQLConnector.close",
-            side_effect=Exception("COMMAND.COM_QUIT failed"),
-        ):
-            # Should not raise exception
-            connector.close()
-            assert connector.engine is None
+def test_close_reraises_unexpected_errors(connector):
+    with (
+        patch("datus_mysql.MySQLConnector.close", side_effect=Exception("unexpected")),
+        pytest.raises(Exception, match="unexpected"),
+    ):
+        connector.close()
 
 
-def test_close_ignores_required_argument_error():
-    """Test close ignores 'required argument is not an integer' error."""
-    config = DorisConfig(username="test_user")
+def test_serialization_and_type(connector):
+    connector.host = "localhost"
+    connector.port = 9030
+    connector.username = "test_user"
+    connector.database_name = "analytics"
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.engine = None
-
-        with patch(
-            "datus_mysql.MySQLConnector.close",
-            side_effect=Exception("required argument is not an integer"),
-        ):
-            # Should not raise exception
-            connector.close()
-            assert connector.engine is None
-
-
-def test_close_clears_engine_on_pymysql_error():
-    """Test close clears engine on PyMySQL error."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.engine = None
-
-        with patch("datus_mysql.MySQLConnector.close", side_effect=Exception("struct.error")):
-            connector.close()
-            assert connector.engine is None
+    assert connector.to_dict() == {
+        "db_type": "doris",
+        "host": "localhost",
+        "port": 9030,
+        "user": "test_user",
+        "catalog": "internal",
+        "database": "analytics",
+    }
+    assert connector.get_type() == "doris"
 
 
-def test_close_disposes_engine_on_error():
-    """Test close disposes engine on PyMySQL error."""
-    config = DorisConfig(username="test_user")
+def test_context_manager_connects_and_closes(connector):
+    connector.connect = MagicMock()
+    connector.close = MagicMock()
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        mock_engine = MagicMock()
-        connector.engine = mock_engine
+    with connector as current:
+        assert current is connector
 
-        with patch("datus_mysql.MySQLConnector.close", side_effect=Exception("struct.pack")):
-            connector.close()
-
-            # Engine should be disposed and set to None
-            mock_engine.dispose.assert_called_once()
-            assert connector.engine is None
+    connector.connect.assert_called_once_with()
+    connector.close.assert_called_once_with()
 
 
-def test_close_reraises_unexpected_errors():
-    """Test close reraises unexpected errors."""
-    config = DorisConfig(username="test_user")
+def test_registers_doris_adapter():
+    with patch("datus_db_core.connector_registry.register") as register:
+        datus_doris.register()
 
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.engine = None
-
-        with patch(
-            "datus_mysql.MySQLConnector.close",
-            side_effect=Exception("Unexpected error"),
-        ):
-            with pytest.raises(Exception, match="Unexpected error"):
-                connector.close()
-
-
-# ==================== Utility Method Tests ====================
-
-
-def test_to_dict_includes_catalog():
-    """Test to_dict includes catalog field."""
-    config = DorisConfig(username="test_user", catalog="my_catalog")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.host = "localhost"
-        connector.port = 9030
-        connector.username = "test_user"
-        connector.database_name = "testdb"
-
-        result = connector.to_dict()
-
-        assert result["db_type"] == "doris"
-        assert result["catalog"] == "my_catalog"
-        assert result["host"] == "localhost"
-        assert result["port"] == 9030
-
-
-def test_get_type_returns_doris():
-    """Test get_type returns DORIS."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert connector.get_type() == "doris"
-
-
-def test_context_manager_support():
-    """Test connector supports context manager protocol."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-        connector.connect = MagicMock()
-        connector.close = MagicMock()
-
-        # Test context manager
-        with connector as conn:
-            assert conn is connector
-            connector.connect.assert_called_once()
-
-        connector.close.assert_called_once()
-
-
-# ==================== Mixin Interface Tests ====================
-
-
-@pytest.mark.acceptance
-def test_implements_catalog_support_mixin():
-    """Test connector implements CatalogSupportMixin."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert isinstance(connector, CatalogSupportMixin)
-
-
-def test_implements_materialized_view_support_mixin():
-    """Test connector implements MaterializedViewSupportMixin."""
-    config = DorisConfig(username="test_user")
-
-    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
-        connector = DorisConnector(config)
-
-        assert isinstance(connector, MaterializedViewSupportMixin)
+    register.assert_called_once_with(
+        "doris",
+        DorisConnector,
+        config_class=DorisConfig,
+        capabilities={"catalog", "database"},
+    )

--- a/datus-doris/tests/unit/test_connector_unit.py
+++ b/datus-doris/tests/unit/test_connector_unit.py
@@ -1,0 +1,671 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datus_db_core import CatalogSupportMixin, MaterializedViewSupportMixin, SQLType
+from datus_doris import DorisConfig, DorisConnector
+
+# ==================== Initialization Tests ====================
+
+
+@pytest.mark.acceptance
+def test_connector_initialization_with_config_object():
+    """Test connector initialization with DorisConfig object."""
+    config = DorisConfig(
+        host="localhost",
+        port=9030,
+        username="test_user",
+        password="test_pass",
+        catalog="test_catalog",
+        database="testdb",
+    )
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert connector.doris_config == config
+        assert connector.catalog_name == "test_catalog"
+        assert connector.dialect == "doris"
+
+
+@pytest.mark.acceptance
+def test_connector_initialization_with_dict():
+    """Test connector initialization with dict config."""
+    config_dict = {
+        "host": "192.168.1.100",
+        "port": 9031,
+        "username": "admin",
+        "password": "secret",
+        "catalog": "custom_catalog",
+        "database": "mydb",
+    }
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config_dict)
+
+        assert isinstance(connector.doris_config, DorisConfig)
+        assert connector.catalog_name == "custom_catalog"
+        assert connector.dialect == "doris"
+
+
+def test_connector_initialization_invalid_type():
+    """Test that connector raises TypeError for invalid config type."""
+    with pytest.raises(TypeError, match="config must be DorisConfig or dict"):
+        DorisConnector("invalid_config")
+
+
+def test_connector_stores_doris_config():
+    """Test that connector stores DorisConfig object."""
+    config = DorisConfig(username="test_user", catalog="my_catalog")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert hasattr(connector, "doris_config")
+        assert connector.doris_config.catalog == "my_catalog"
+
+
+def test_connector_passes_mysql_config_to_parent():
+    """Test that connector converts and passes MySQLConfig to parent."""
+    config = DorisConfig(
+        host="localhost",
+        port=9030,
+        username="user",
+        password="pass",
+        database="db",
+    )
+
+    with patch("datus_mysql.MySQLConnector.__init__") as mock_init:
+        DorisConnector(config)
+
+        mock_init.assert_called_once()
+        mysql_config = mock_init.call_args[0][0]
+        assert mysql_config.host == "localhost"
+        assert mysql_config.port == 9030
+        assert mysql_config.username == "user"
+
+
+# ==================== Catalog Functionality Unit Tests ====================
+
+
+@pytest.mark.acceptance
+def test_internal_returns_default_catalog():
+    """Test that internal returns 'internal'."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert connector.default_catalog() == "internal"
+
+
+def test_resolve_catalog_with_empty():
+    """Test _resolve_catalog with empty string falls back to default."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.catalog_name = ""
+
+        result = connector._resolve_catalog("")
+        assert result == "internal"
+
+
+def test_resolve_catalog_with_def():
+    """Test _resolve_catalog with 'def' string returns default."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector._resolve_catalog("def")
+        assert result == "internal"
+
+
+def test_get_current_context_resolves_default_catalog():
+    """Test current context exposes effective SQL coordinates."""
+    config = DorisConfig(username="test_user", database="ac_manage")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert connector.get_current_context() == {
+            "catalog_name": "internal",
+            "database_name": "ac_manage",
+            "schema_name": "",
+        }
+
+
+def test_get_current_context_normalizes_def_catalog():
+    """Test current context normalizes Doris catalog aliases."""
+    config = DorisConfig(username="test_user", catalog="def", database="ac_manage")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.catalog_name = "def"
+
+        assert connector.get_current_context()["catalog_name"] == "internal"
+
+
+def test_get_current_context_keeps_custom_catalog():
+    """Test current context keeps configured non-default catalogs."""
+    config = DorisConfig(username="test_user", catalog="external_catalog", database="analytics")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert connector.get_current_context() == {
+            "catalog_name": "external_catalog",
+            "database_name": "analytics",
+            "schema_name": "",
+        }
+
+
+def test_resolve_catalog_preserves_custom():
+    """Test _resolve_catalog preserves custom catalog."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector._resolve_catalog("my_catalog")
+        assert result == "my_catalog"
+
+
+@pytest.mark.acceptance
+def test_switch_catalog_updates_catalog_name():
+    """Test that switch_catalog updates catalog_name via switch_context."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        connector.switch_catalog("new_catalog")
+
+        assert connector.catalog_name == "new_catalog"
+
+
+def test_switch_catalog_calls_switch_context():
+    """Test that switch_catalog calls switch_context."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.switch_context = MagicMock()
+
+        connector.switch_catalog("target_catalog")
+
+        connector.switch_context.assert_called_once_with(catalog_name="target_catalog")
+
+
+def test_resolve_catalog_falls_back_to_connector_catalog():
+    """Test _resolve_catalog uses connector's catalog_name when no arg given."""
+    config = DorisConfig(username="test_user", catalog="configured_catalog")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector._resolve_catalog("")
+        assert result == "configured_catalog"
+
+
+def test_resolve_catalog_arg_takes_precedence():
+    """Test _resolve_catalog uses explicit arg over connector catalog."""
+    config = DorisConfig(username="test_user", catalog="configured_catalog")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector._resolve_catalog("explicit_catalog")
+        assert result == "explicit_catalog"
+
+
+# ==================== full_name() Method Tests ====================
+
+
+@pytest.mark.acceptance
+def test_full_name_with_catalog_and_database():
+    """Test full_name with catalog, database, and table."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(catalog_name="my_catalog", database_name="my_db", table_name="my_table")
+
+        assert result == "`my_catalog`.`my_db`.`my_table`"
+
+
+def test_full_name_with_catalog_only():
+    """Test full_name with catalog and table only."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(catalog_name="my_catalog", table_name="my_table")
+
+        assert result == "`my_table`"
+
+
+def test_full_name_with_database_no_catalog():
+    """Test full_name with database and table, no explicit catalog (uses default)."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(database_name="my_db", table_name="my_table")
+
+        # Empty catalog is reset to internal, so result includes it
+        assert result == "`internal`.`my_db`.`my_table`"
+
+
+def test_full_name_table_only():
+    """Test full_name with table only."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(table_name="my_table")
+
+        assert result == "`my_table`"
+
+
+def test_full_name_resets_empty_catalog_to_default():
+    """Test full_name resets empty catalog to default."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(catalog_name="", database_name="db", table_name="table")
+
+        # Empty catalog is reset to internal
+        assert result == "`internal`.`db`.`table`"
+
+
+@pytest.mark.acceptance
+def test_full_name_quotes_identifiers():
+    """Test full_name adds backticks to identifiers."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(catalog_name="catalog", database_name="database", table_name="table")
+
+        assert result.count("`") == 6  # 3 pairs of backticks
+
+
+def test_full_name_with_special_characters():
+    """Test full_name with special characters in names."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(
+            catalog_name="test-catalog",
+            database_name="test_db",
+            table_name="test-table",
+        )
+
+        assert "`test-catalog`" in result
+        assert "`test_db`" in result
+        assert "`test-table`" in result
+
+
+def test_full_name_escapes_backticks():
+    """Test full_name escapes embedded identifier quoting characters."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        result = connector.full_name(catalog_name="cat`alog", database_name="db`name", table_name="ta`ble")
+
+        assert result == "`cat``alog`.`db``name`.`ta``ble`"
+
+
+# ==================== _sqlalchemy_schema() Tests ====================
+
+
+def test_sqlalchemy_schema_with_catalog_and_database():
+    """Test _sqlalchemy_schema returns catalog.database format."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.database_name = "my_db"
+        connector.catalog_name = "my_catalog"
+
+        result = connector._sqlalchemy_schema(catalog_name="test_catalog", database_name="test_db")
+
+        assert result == "test_catalog.test_db"
+
+
+def test_sqlalchemy_schema_with_catalog_only():
+    """Test _sqlalchemy_schema returns None when no database."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.database_name = None
+        connector.catalog_name = "my_catalog"
+
+        result = connector._sqlalchemy_schema(catalog_name="test_catalog")
+
+        assert result is None
+
+
+def test_sqlalchemy_schema_uses_catalog_without_registry_state():
+    """Test _sqlalchemy_schema always includes catalog for direct connector usage."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.catalog_name = "my_catalog"
+        connector.database_name = "my_db"
+
+        result = connector._sqlalchemy_schema(database_name="test_db")
+
+        assert result == "my_catalog.test_db"
+
+
+def test_sqlalchemy_schema_uses_default_catalog():
+    """Test _sqlalchemy_schema uses default catalog when not specified."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.database_name = "my_db"
+        connector.catalog_name = None
+
+        result = connector._sqlalchemy_schema(database_name="test_db")
+
+        assert "internal" in result
+        assert result == "internal.test_db"
+
+
+# ==================== close() Method PyMySQL Error Handling Tests ====================
+
+
+@pytest.mark.acceptance
+def test_do_switch_context_catalog():
+    """do_switch_context executes Doris SWITCH on the given connection."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_conn = MagicMock()
+
+        connector.do_switch_context(mock_conn, catalog_name="new_catalog")
+
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
+
+        sql_arg = str(mock_conn.execute.call_args[0][0].text)
+        assert "SWITCH" in sql_arg
+        assert "new_catalog" in sql_arg
+
+
+def test_do_switch_context_database():
+    """do_switch_context executes USE on the given connection."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_conn = MagicMock()
+
+        connector.do_switch_context(mock_conn, database_name="new_db")
+
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
+
+        sql_arg = str(mock_conn.execute.call_args[0][0].text)
+        assert "USE" in sql_arg
+        assert "new_db" in sql_arg
+
+
+def test_do_switch_context_catalog_and_database():
+    """do_switch_context handles both catalog and database on the given connection."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_conn = MagicMock()
+
+        connector.do_switch_context(mock_conn, catalog_name="cat", database_name="db")
+
+        # Two execute calls: SWITCH + USE
+        assert mock_conn.execute.call_count == 2
+        assert mock_conn.commit.call_count == 2
+
+
+def test_switch_catalog_statement():
+    """connector.execute('switch ...') updates catalog_name via execute_content_set."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_conn = MagicMock()
+        engine = MagicMock()
+        engine.connect.return_value = mock_conn
+        connector.engine = engine
+        connector._owns_engine = True
+        assert connector.catalog_name == "internal"
+
+        with patch("datus_db_core.base.parse_sql_type", return_value=SQLType.UNKNOWN):
+            connector.execute(input_params={"sql_query": "switch cat"})
+            assert connector.catalog_name == "cat"
+
+            connector.execute(input_params={"sql_query": "switch internal"})
+            assert connector.catalog_name == "internal"
+
+
+def test_use_catalog_database_updates_both_context_levels():
+    """USE catalog.database keeps Doris context correct across core versions."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_conn = MagicMock()
+        engine = MagicMock()
+        engine.connect.return_value = mock_conn
+        connector.engine = engine
+        connector._owns_engine = True
+
+        result = connector.execute_content_set("USE `hive-catalog`.`analytics`")
+
+        assert result.success
+        assert connector.catalog_name == "hive-catalog"
+        assert connector.database_name == "analytics"
+
+
+def test_init_normalizes_def_catalog():
+    """config.catalog='def' should be treated as default (no catalog switch needed)."""
+    config = DorisConfig(username="test_user", catalog="def", database="mydb")
+
+    with patch("datus_mysql.MySQLConnector.__init__") as mock_init:
+        connector = DorisConnector(config)
+
+        # 'def' is default, so database should be in the MySQL connection string
+        mysql_config = mock_init.call_args[0][0]
+        assert mysql_config.database == "mydb"
+        assert connector._deferred_database == ""
+
+
+def test_close_ignores_struct_pack_error():
+    """Test close ignores struct.pack error."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.engine = None
+
+        with patch(
+            "datus_mysql.MySQLConnector.close",
+            side_effect=Exception("struct.pack error"),
+        ):
+            # Should not raise exception
+            connector.close()
+            assert connector.engine is None
+
+
+def test_close_ignores_com_quit_error():
+    """Test close ignores COM_QUIT error."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.engine = None
+
+        with patch(
+            "datus_mysql.MySQLConnector.close",
+            side_effect=Exception("COMMAND.COM_QUIT failed"),
+        ):
+            # Should not raise exception
+            connector.close()
+            assert connector.engine is None
+
+
+def test_close_ignores_required_argument_error():
+    """Test close ignores 'required argument is not an integer' error."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.engine = None
+
+        with patch(
+            "datus_mysql.MySQLConnector.close",
+            side_effect=Exception("required argument is not an integer"),
+        ):
+            # Should not raise exception
+            connector.close()
+            assert connector.engine is None
+
+
+def test_close_clears_engine_on_pymysql_error():
+    """Test close clears engine on PyMySQL error."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.engine = None
+
+        with patch("datus_mysql.MySQLConnector.close", side_effect=Exception("struct.error")):
+            connector.close()
+            assert connector.engine is None
+
+
+def test_close_disposes_engine_on_error():
+    """Test close disposes engine on PyMySQL error."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        mock_engine = MagicMock()
+        connector.engine = mock_engine
+
+        with patch("datus_mysql.MySQLConnector.close", side_effect=Exception("struct.pack")):
+            connector.close()
+
+            # Engine should be disposed and set to None
+            mock_engine.dispose.assert_called_once()
+            assert connector.engine is None
+
+
+def test_close_reraises_unexpected_errors():
+    """Test close reraises unexpected errors."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.engine = None
+
+        with patch(
+            "datus_mysql.MySQLConnector.close",
+            side_effect=Exception("Unexpected error"),
+        ):
+            with pytest.raises(Exception, match="Unexpected error"):
+                connector.close()
+
+
+# ==================== Utility Method Tests ====================
+
+
+def test_to_dict_includes_catalog():
+    """Test to_dict includes catalog field."""
+    config = DorisConfig(username="test_user", catalog="my_catalog")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.host = "localhost"
+        connector.port = 9030
+        connector.username = "test_user"
+        connector.database_name = "testdb"
+
+        result = connector.to_dict()
+
+        assert result["db_type"] == "doris"
+        assert result["catalog"] == "my_catalog"
+        assert result["host"] == "localhost"
+        assert result["port"] == 9030
+
+
+def test_get_type_returns_doris():
+    """Test get_type returns DORIS."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert connector.get_type() == "doris"
+
+
+def test_context_manager_support():
+    """Test connector supports context manager protocol."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+        connector.connect = MagicMock()
+        connector.close = MagicMock()
+
+        # Test context manager
+        with connector as conn:
+            assert conn is connector
+            connector.connect.assert_called_once()
+
+        connector.close.assert_called_once()
+
+
+# ==================== Mixin Interface Tests ====================
+
+
+@pytest.mark.acceptance
+def test_implements_catalog_support_mixin():
+    """Test connector implements CatalogSupportMixin."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert isinstance(connector, CatalogSupportMixin)
+
+
+def test_implements_materialized_view_support_mixin():
+    """Test connector implements MaterializedViewSupportMixin."""
+    config = DorisConfig(username="test_user")
+
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = DorisConnector(config)
+
+        assert isinstance(connector, MaterializedViewSupportMixin)

--- a/datus-doris/tests/unit/test_migration_mixin.py
+++ b/datus-doris/tests/unit/test_migration_mixin.py
@@ -1,0 +1,200 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for Doris MigrationTargetMixin implementation.
+
+Tests focus on the pure migration-hint/validation logic that does not require
+an active Doris connection. Uses DorisConnector.__new__ to bypass the
+constructor (which connects to a real server) — the Mixin methods are all
+self-contained state-free static logic.
+"""
+
+import pytest
+
+from datus_db_core import MigrationTargetMixin
+from datus_doris import DorisConnector
+
+
+@pytest.fixture
+def connector():
+    """Return a DorisConnector instance without invoking the constructor."""
+    return DorisConnector.__new__(DorisConnector)
+
+
+class TestMixinInheritance:
+    def test_doris_is_migration_target(self, connector):
+        assert isinstance(connector, MigrationTargetMixin)
+
+
+class TestDescribeMigrationCapabilities:
+    def test_returns_supported_dict(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert isinstance(result, dict)
+        assert result["supported"] is True
+
+    def test_dialect_family_is_mysql_like(self, connector):
+        result = connector.describe_migration_capabilities()
+        assert result["dialect_family"] == "mysql-like"
+
+    def test_requires_key_and_distribution(self, connector):
+        result = connector.describe_migration_capabilities()
+        requires_str = " ".join(result["requires"]).upper()
+        assert "DUPLICATE KEY" in requires_str or "UNIQUE KEY" in requires_str
+        assert "DISTRIBUTED BY" in requires_str
+
+    def test_does_not_forbid_auto_increment(self, connector):
+        result = connector.describe_migration_capabilities()
+        forbids_str = " ".join(result["forbids"]).upper()
+        assert "AUTO_INCREMENT" not in forbids_str
+
+    def test_type_hints_have_varchar_max(self, connector):
+        result = connector.describe_migration_capabilities()
+        hints_str = " ".join(result["type_hints"].values())
+        assert "65533" in hints_str
+
+    def test_example_ddl_is_complete(self, connector):
+        result = connector.describe_migration_capabilities()
+        ddl = result["example_ddl"].upper()
+        assert "CREATE TABLE" in ddl
+        assert "DUPLICATE KEY" in ddl or "UNIQUE KEY" in ddl
+        assert "DISTRIBUTED BY HASH" in ddl
+
+
+class TestValidateDdl:
+    def test_rejects_missing_key_definition(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert len(errors) > 0
+        assert any("KEY" in e.upper() for e in errors)
+
+    def test_rejects_missing_distributed_by(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)"""
+        errors = connector.validate_ddl(ddl)
+        assert len(errors) > 0
+        assert any("DISTRIBUTED BY" in e.upper() for e in errors)
+
+    def test_rejects_auto_increment_outside_unique_key_table(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT AUTO_INCREMENT,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any("AUTO_INCREMENT" in e.upper() for e in errors)
+
+    def test_accepts_auto_increment_in_unique_key_table(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL AUTO_INCREMENT,
+          name VARCHAR(255)
+        )
+        UNIQUE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_valid_ddl(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_unique_key_variant(self, connector):
+        ddl = """CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          name VARCHAR(255)
+        )
+        UNIQUE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    def test_accepts_aggregate_key(self, connector):
+        ddl = """CREATE TABLE db.t (
+          dt DATE NOT NULL,
+          region VARCHAR(50),
+          total_amount DECIMAL(18,2) SUM
+        )
+        AGGREGATE KEY(dt, region)
+        DISTRIBUTED BY HASH(region) BUCKETS 10"""
+        assert connector.validate_ddl(ddl) == []
+
+    @pytest.mark.parametrize(
+        ("clause", "expected"),
+        [
+            ("FOREIGN KEY (parent_id) REFERENCES parent(id)", "FOREIGN KEY"),
+            ("FULLTEXT INDEX idx_name (name)", "FULLTEXT"),
+            ("CHECK (id > 0)", "CHECK"),
+        ],
+    )
+    def test_rejects_unsupported_constraints_and_indexes(self, connector, clause, expected):
+        ddl = f"""CREATE TABLE db.t (
+          id BIGINT NOT NULL,
+          parent_id BIGINT,
+          name VARCHAR(255),
+          {clause}
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10"""
+        errors = connector.validate_ddl(ddl)
+        assert any(expected in error.upper() for error in errors)
+
+
+class TestSuggestTableLayout:
+    def test_picks_id_column_first(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["duplicate_key"] == ["id"]
+        assert layout["distributed_by"] == ["id"]
+        assert layout["buckets"] == 10
+
+    def test_picks_suffix_id_columns(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "order_id", "type": "BIGINT", "nullable": False},
+            {"name": "user_id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        keys = layout["duplicate_key"]
+        assert "order_id" in keys
+        assert "user_id" in keys
+
+    def test_max_three_keys(self, connector):
+        columns = [{"name": f"col{i}_id", "type": "BIGINT", "nullable": False} for i in range(10)]
+        layout = connector.suggest_table_layout(columns)
+        assert len(layout["duplicate_key"]) <= 3
+
+    def test_falls_back_to_first_column_when_no_integer(self, connector):
+        columns = [
+            {"name": "name", "type": "VARCHAR", "nullable": True},
+            {"name": "label", "type": "VARCHAR", "nullable": True},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        assert layout["duplicate_key"] == ["name"]
+
+    def test_empty_columns_returns_dict_with_empty_keys_or_empty(self, connector):
+        layout = connector.suggest_table_layout([])
+        # Either returns empty dict, or dict with empty key lists — both acceptable
+        assert isinstance(layout, dict)
+
+    def test_prefers_non_nullable_over_nullable(self, connector):
+        columns = [
+            {"name": "a_id", "type": "BIGINT", "nullable": True},
+            {"name": "b_id", "type": "BIGINT", "nullable": False},
+        ]
+        layout = connector.suggest_table_layout(columns)
+        # Both have _id suffix and INT type; non-nullable should rank first
+        assert layout["duplicate_key"][0] == "b_id"

--- a/datus-doris/tests/unit/test_migration_mixin.py
+++ b/datus-doris/tests/unit/test_migration_mixin.py
@@ -2,199 +2,129 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Tests for Doris MigrationTargetMixin implementation.
-
-Tests focus on the pure migration-hint/validation logic that does not require
-an active Doris connection. Uses DorisConnector.__new__ to bypass the
-constructor (which connects to a real server) — the Mixin methods are all
-self-contained state-free static logic.
-"""
-
 import pytest
 
-from datus_db_core import MigrationTargetMixin
 from datus_doris import DorisConnector
 
 
 @pytest.fixture
 def connector():
-    """Return a DorisConnector instance without invoking the constructor."""
     return DorisConnector.__new__(DorisConnector)
 
 
-class TestMixinInheritance:
-    def test_doris_is_migration_target(self, connector):
-        assert isinstance(connector, MigrationTargetMixin)
+def test_describe_migration_capabilities(connector):
+    result = connector.describe_migration_capabilities()
+
+    assert result["supported"] is True
+    assert result["dialect_family"] == "mysql-like"
+    assert result["requires"] == [
+        "One of DUPLICATE KEY / UNIQUE KEY / AGGREGATE KEY",
+        "DISTRIBUTED BY HASH(cols) BUCKETS N",
+    ]
+    assert result["forbids"] == ["FOREIGN KEY", "FULLTEXT INDEX", "CHECK"]
+    assert result["type_hints"]["unbounded VARCHAR"] == "VARCHAR(65533)"
+    assert "DUPLICATE KEY" in result["example_ddl"]
+    assert "DISTRIBUTED BY HASH" in result["example_ddl"]
 
 
-class TestDescribeMigrationCapabilities:
-    def test_returns_supported_dict(self, connector):
-        result = connector.describe_migration_capabilities()
-        assert isinstance(result, dict)
-        assert result["supported"] is True
-
-    def test_dialect_family_is_mysql_like(self, connector):
-        result = connector.describe_migration_capabilities()
-        assert result["dialect_family"] == "mysql-like"
-
-    def test_requires_key_and_distribution(self, connector):
-        result = connector.describe_migration_capabilities()
-        requires_str = " ".join(result["requires"]).upper()
-        assert "DUPLICATE KEY" in requires_str or "UNIQUE KEY" in requires_str
-        assert "DISTRIBUTED BY" in requires_str
-
-    def test_does_not_forbid_auto_increment(self, connector):
-        result = connector.describe_migration_capabilities()
-        forbids_str = " ".join(result["forbids"]).upper()
-        assert "AUTO_INCREMENT" not in forbids_str
-
-    def test_type_hints_have_varchar_max(self, connector):
-        result = connector.describe_migration_capabilities()
-        hints_str = " ".join(result["type_hints"].values())
-        assert "65533" in hints_str
-
-    def test_example_ddl_is_complete(self, connector):
-        result = connector.describe_migration_capabilities()
-        ddl = result["example_ddl"].upper()
-        assert "CREATE TABLE" in ddl
-        assert "DUPLICATE KEY" in ddl or "UNIQUE KEY" in ddl
-        assert "DISTRIBUTED BY HASH" in ddl
-
-
-class TestValidateDdl:
-    def test_rejects_missing_key_definition(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT NOT NULL,
-          name VARCHAR(255)
-        )
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        errors = connector.validate_ddl(ddl)
-        assert len(errors) > 0
-        assert any("KEY" in e.upper() for e in errors)
-
-    def test_rejects_missing_distributed_by(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT NOT NULL,
-          name VARCHAR(255)
-        )
-        DUPLICATE KEY(id)"""
-        errors = connector.validate_ddl(ddl)
-        assert len(errors) > 0
-        assert any("DISTRIBUTED BY" in e.upper() for e in errors)
-
-    def test_rejects_auto_increment_outside_unique_key_table(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT AUTO_INCREMENT,
-          name VARCHAR(255)
-        )
-        DUPLICATE KEY(id)
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        errors = connector.validate_ddl(ddl)
-        assert any("AUTO_INCREMENT" in e.upper() for e in errors)
-
-    def test_accepts_auto_increment_in_unique_key_table(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT NOT NULL AUTO_INCREMENT,
-          name VARCHAR(255)
-        )
-        UNIQUE KEY(id)
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        assert connector.validate_ddl(ddl) == []
-
-    def test_accepts_valid_ddl(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT NOT NULL,
-          name VARCHAR(255)
-        )
-        DUPLICATE KEY(id)
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        assert connector.validate_ddl(ddl) == []
-
-    def test_accepts_unique_key_variant(self, connector):
-        ddl = """CREATE TABLE db.t (
-          id BIGINT NOT NULL,
-          name VARCHAR(255)
-        )
-        UNIQUE KEY(id)
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        assert connector.validate_ddl(ddl) == []
-
-    def test_accepts_aggregate_key(self, connector):
-        ddl = """CREATE TABLE db.t (
-          dt DATE NOT NULL,
-          region VARCHAR(50),
-          total_amount DECIMAL(18,2) SUM
-        )
-        AGGREGATE KEY(dt, region)
-        DISTRIBUTED BY HASH(region) BUCKETS 10"""
-        assert connector.validate_ddl(ddl) == []
-
-    @pytest.mark.parametrize(
-        ("clause", "expected"),
-        [
-            ("FOREIGN KEY (parent_id) REFERENCES parent(id)", "FOREIGN KEY"),
-            ("FULLTEXT INDEX idx_name (name)", "FULLTEXT"),
-            ("CHECK (id > 0)", "CHECK"),
-        ],
-    )
-    def test_rejects_unsupported_constraints_and_indexes(self, connector, clause, expected):
-        ddl = f"""CREATE TABLE db.t (
-          id BIGINT NOT NULL,
-          parent_id BIGINT,
-          name VARCHAR(255),
-          {clause}
-        )
-        DUPLICATE KEY(id)
-        DISTRIBUTED BY HASH(id) BUCKETS 10"""
-        errors = connector.validate_ddl(ddl)
-        assert any(expected in error.upper() for error in errors)
+@pytest.mark.parametrize(
+    ("ddl", "expected_error"),
+    [
+        (
+            "CREATE TABLE db.t (id BIGINT) DISTRIBUTED BY HASH(id) BUCKETS 10",
+            "must define one of",
+        ),
+        (
+            "CREATE TABLE db.t (id BIGINT) DUPLICATE KEY(id)",
+            "DISTRIBUTED BY",
+        ),
+        (
+            "CREATE TABLE db.t (id BIGINT AUTO_INCREMENT) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10",
+            "AUTO_INCREMENT",
+        ),
+        (
+            "CREATE TABLE db.t (id BIGINT, FOREIGN KEY (id) REFERENCES p(id)) "
+            "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10",
+            "FOREIGN KEY",
+        ),
+        (
+            "CREATE TABLE db.t (id BIGINT, FULLTEXT INDEX idx (id)) "
+            "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10",
+            "FULLTEXT",
+        ),
+        (
+            "CREATE TABLE db.t (id BIGINT, CHECK (id > 0)) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10",
+            "CHECK",
+        ),
+    ],
+)
+def test_validate_ddl_rejects_invalid_layouts(connector, ddl, expected_error):
+    assert any(expected_error in error for error in connector.validate_ddl(ddl))
 
 
-class TestSuggestTableLayout:
-    def test_picks_id_column_first(self, connector):
-        columns = [
-            {"name": "name", "type": "VARCHAR", "nullable": True},
-            {"name": "id", "type": "BIGINT", "nullable": False},
-        ]
-        layout = connector.suggest_table_layout(columns)
-        assert layout["duplicate_key"] == ["id"]
-        assert layout["distributed_by"] == ["id"]
-        assert layout["buckets"] == 10
+@pytest.mark.parametrize(
+    "key_clause",
+    [
+        "DUPLICATE KEY(id)",
+        "UNIQUE KEY(id)",
+        "AGGREGATE KEY(id)",
+    ],
+)
+def test_validate_ddl_accepts_supported_key_models(connector, key_clause):
+    ddl = f"CREATE TABLE db.t (id BIGINT NOT NULL) {key_clause} DISTRIBUTED BY HASH(id) BUCKETS 10"
+    assert connector.validate_ddl(ddl) == []
 
-    def test_picks_suffix_id_columns(self, connector):
-        columns = [
-            {"name": "name", "type": "VARCHAR", "nullable": True},
-            {"name": "order_id", "type": "BIGINT", "nullable": False},
-            {"name": "user_id", "type": "BIGINT", "nullable": False},
-        ]
-        layout = connector.suggest_table_layout(columns)
-        keys = layout["duplicate_key"]
-        assert "order_id" in keys
-        assert "user_id" in keys
 
-    def test_max_three_keys(self, connector):
-        columns = [{"name": f"col{i}_id", "type": "BIGINT", "nullable": False} for i in range(10)]
-        layout = connector.suggest_table_layout(columns)
-        assert len(layout["duplicate_key"]) <= 3
+def test_validate_ddl_accepts_auto_increment_for_unique_key(connector):
+    ddl = "CREATE TABLE db.t (id BIGINT AUTO_INCREMENT) UNIQUE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10"
+    assert connector.validate_ddl(ddl) == []
 
-    def test_falls_back_to_first_column_when_no_integer(self, connector):
-        columns = [
-            {"name": "name", "type": "VARCHAR", "nullable": True},
-            {"name": "label", "type": "VARCHAR", "nullable": True},
-        ]
-        layout = connector.suggest_table_layout(columns)
-        assert layout["duplicate_key"] == ["name"]
 
-    def test_empty_columns_returns_dict_with_empty_keys_or_empty(self, connector):
-        layout = connector.suggest_table_layout([])
-        # Either returns empty dict, or dict with empty key lists — both acceptable
-        assert isinstance(layout, dict)
+@pytest.mark.parametrize(
+    ("columns", "expected_keys"),
+    [
+        ([], []),
+        ([{"name": "name", "type": "VARCHAR", "nullable": True}], ["name"]),
+        (
+            [
+                {"name": "name", "type": "VARCHAR", "nullable": True},
+                {"name": "id", "type": "BIGINT", "nullable": False},
+            ],
+            ["id"],
+        ),
+        (
+            [
+                {"name": "a_id", "type": "BIGINT", "nullable": True},
+                {"name": "b_id", "type": "BIGINT", "nullable": False},
+            ],
+            ["b_id", "a_id"],
+        ),
+    ],
+)
+def test_suggest_table_layout(connector, columns, expected_keys):
+    assert connector.suggest_table_layout(columns) == {
+        "duplicate_key": expected_keys,
+        "distributed_by": expected_keys,
+        "buckets": 10,
+    }
 
-    def test_prefers_non_nullable_over_nullable(self, connector):
-        columns = [
-            {"name": "a_id", "type": "BIGINT", "nullable": True},
-            {"name": "b_id", "type": "BIGINT", "nullable": False},
-        ]
-        layout = connector.suggest_table_layout(columns)
-        # Both have _id suffix and INT type; non-nullable should rank first
-        assert layout["duplicate_key"][0] == "b_id"
+
+def test_suggest_table_layout_limits_keys_to_three(connector):
+    columns = [{"name": f"col{i}_id", "type": "BIGINT", "nullable": False} for i in range(5)]
+    assert len(connector.suggest_table_layout(columns)["duplicate_key"]) == 3
+
+
+@pytest.mark.parametrize(
+    ("source_type", "expected"),
+    [
+        ("HUGEINT", "LARGEINT"),
+        ("TIMESTAMP(6)", "DATETIME"),
+        ("TIMESTAMP WITH TIME ZONE", "DATETIME"),
+        ("TEXT", "STRING"),
+        ("TIME", "VARCHAR(20)"),
+        ("UUID", "VARCHAR(36)"),
+        ("DECIMAL(18,2)", None),
+    ],
+)
+def test_map_source_type(connector, source_type, expected):
+    assert connector.map_source_type("postgres", source_type) == expected

--- a/datus-doris/tests/unit/test_migration_mixin.py
+++ b/datus-doris/tests/unit/test_migration_mixin.py
@@ -94,6 +94,46 @@ def test_validate_ddl_ignores_keywords_inside_identifiers_and_comments(connector
 
 
 @pytest.mark.parametrize(
+    "ddl",
+    [
+        """
+        CREATE TABLE db.t (`FULLTEXT` VARCHAR(20), id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10
+        """,
+        """
+        CREATE TABLE db.t ("FULLTEXT" VARCHAR(20), id BIGINT)
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10
+        """,
+        """
+        CREATE TABLE db.t (
+            id BIGINT,
+            note VARCHAR(255) DEFAULT 'FULLTEXT CHECK(id) FOREIGN KEY AUTO_INCREMENT ON DUPLICATE KEY'
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10
+        """,
+    ],
+)
+def test_validate_ddl_ignores_keywords_inside_quoted_regions(connector, ddl):
+    assert connector.validate_ddl(ddl) == []
+
+
+def test_validate_ddl_does_not_accept_required_clauses_inside_string_literals(connector):
+    ddl = """
+    CREATE TABLE db.t (
+        note VARCHAR(255) DEFAULT 'DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)'
+    )
+    """
+
+    errors = connector.validate_ddl(ddl)
+
+    assert any("must define one of" in error for error in errors)
+    assert any("DISTRIBUTED BY" in error for error in errors)
+
+
+@pytest.mark.parametrize(
     ("columns", "expected_keys"),
     [
         ([], []),

--- a/datus-doris/tests/unit/test_migration_mixin.py
+++ b/datus-doris/tests/unit/test_migration_mixin.py
@@ -80,6 +80,19 @@ def test_validate_ddl_accepts_auto_increment_for_unique_key(connector):
     assert connector.validate_ddl(ddl) == []
 
 
+def test_validate_ddl_ignores_keywords_inside_identifiers_and_comments(connector):
+    ddl = """
+    CREATE TABLE db.t (
+        checksum_value BIGINT,
+        check_flag BOOLEAN
+    )
+    DUPLICATE KEY(checksum_value)
+    DISTRIBUTED BY HASH(checksum_value) BUCKETS 10
+    -- FULLTEXT and CHECK(id > 0) are not active clauses
+    """
+    assert connector.validate_ddl(ddl) == []
+
+
 @pytest.mark.parametrize(
     ("columns", "expected_keys"),
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.12"
 license = {file = "LICENSE"}
 
 [tool.uv.workspace]
-members = ["datus-db-core", "datus-mysql", "datus-postgresql", "datus-sqlalchemy", "datus-starrocks", "datus-snowflake", "datus-clickzetta", "datus-clickhouse", "datus-hive", "datus-redshift", "datus-spark", "datus-trino", "datus-greenplum"]
+members = ["datus-db-core", "datus-mysql", "datus-postgresql", "datus-sqlalchemy", "datus-starrocks", "datus-doris", "datus-snowflake", "datus-clickzetta", "datus-clickhouse", "datus-hive", "datus-redshift", "datus-spark", "datus-trino", "datus-greenplum"]
 
 [dependency-groups]
 
@@ -62,4 +62,4 @@ ignore = [
 max-complexity = 10
 
 [tool.ruff.lint.isort]
-known-first-party = ["datus_db_core", "datus_sqlalchemy", "datus_mysql", "datus_postgresql", "datus_redshift", "datus_snowflake", "datus_clickhouse", "datus_clickzetta", "datus_starrocks", "datus_trino", "datus_spark", "datus_hive", "datus_greenplum"]
+known-first-party = ["datus_db_core", "datus_sqlalchemy", "datus_mysql", "datus_postgresql", "datus_redshift", "datus_snowflake", "datus_clickhouse", "datus_clickzetta", "datus_starrocks", "datus_doris", "datus_trino", "datus_spark", "datus_hive", "datus_greenplum"]


### PR DESCRIPTION
## Why

Datus DB adapters support StarRocks but do not currently provide an Apache Doris adapter. Doris needs its own catalog switching, metadata, asynchronous materialized view, and OLAP DDL behavior even though it shares the MySQL wire protocol.

## What changed

- add the `datus-doris` package and `doris` adapter entry point
- implement Doris catalog/database context, catalog-aware table/view/schema/sample metadata, and asynchronous materialized view discovery with DDL
- add Doris migration capability, layout, validation, and type-mapping guidance
- extend shared SQL context parsing for Doris `SWITCH` and `USE catalog.database`
- add Doris FE/BE 4.0.7 and Hive Metastore 4.0.1 integration services with readiness probes
- add focused, independent Doris unit, integration, acceptance, and TPC-H coverage
- wire the adapter into workspace, CI selection, release workflows, and documentation

## Impact

Installing `datus-doris` registers a first-class Doris adapter with catalog and database capabilities. The adapter supports the same query/result formats and metadata workflows as the StarRocks adapter while using Doris-specific SQL and metadata APIs.

## Validation

- `ci/run-unit-tests.sh datus-doris` (`65 passed`)
- all 14 workspace package unit-test suites passed
- `ci/run-integration-tests.sh doris` (`27 passed` against clean Docker volumes; no skips)
- `python3 ci/check_package_release_readiness.py --package datus-doris --expected-version 0.1.0 --check-dependent-bounds --build`
- isolated wheel install and adapter entry-point smoke test with published dependencies
- `uv lock --check`
- `ruff format --check` and `ruff check`
- `twine check` for the generated wheel and source distribution
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class Apache Doris adapter support, including catalog/database switching, metadata/SQL execution, materialized views, and Doris migration/DDL validation.
  * Added Doris TPC-H initialization tooling plus local Docker-based test scripts; enhanced Doris readiness gating.
* **Documentation**
  * Added an end-to-end Doris adapter guide and updated adapter listings/architecture.
* **Bug Fixes**
  * Improved SQL preprocessing/parsing for quoted/backticked regions, comment handling, and Doris-specific `USE`/`SWITCH` behavior; strengthened Doris DDL validation and metadata querying.
* **Tests / CI**
  * Improved changed-package/adapter detection and diagnostics in integration/unit runs; expanded Doris and SQL utility test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->