### PR TITLE
[Feature] Add MaxCompute adapter with dynamic namespace support

### DIFF
--- a/.github/workflows/maxcompute-cloud-tests.yml
+++ b/.github/workflows/maxcompute-cloud-tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/maxcompute-cloud-tests.yml
+++ b/.github/workflows/maxcompute-cloud-tests.yml
@@ -1,0 +1,59 @@
+name: MaxCompute Cloud Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 18 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maxcompute-cloud-tests
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MAXCOMPUTE_ENDPOINT: ${{ secrets.MAXCOMPUTE_ENDPOINT }}
+      MAXCOMPUTE_ACCESS_KEY_ID: ${{ secrets.MAXCOMPUTE_ACCESS_KEY_ID }}
+      MAXCOMPUTE_ACCESS_KEY_SECRET: ${{ secrets.MAXCOMPUTE_ACCESS_KEY_SECRET }}
+      MAXCOMPUTE_TWO_LEVEL_PROJECT: ${{ secrets.MAXCOMPUTE_TWO_LEVEL_PROJECT }}
+      MAXCOMPUTE_THREE_LEVEL_PROJECT: ${{ secrets.MAXCOMPUTE_THREE_LEVEL_PROJECT }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Verify cloud test configuration
+        shell: bash
+        run: |
+          required=(
+            MAXCOMPUTE_ENDPOINT
+            MAXCOMPUTE_ACCESS_KEY_ID
+            MAXCOMPUTE_ACCESS_KEY_SECRET
+            MAXCOMPUTE_TWO_LEVEL_PROJECT
+            MAXCOMPUTE_THREE_LEVEL_PROJECT
+          )
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required repository secret: ${name}"
+              exit 1
+            fi
+          done
+
+      - name: Run two-level and three-level tests
+        run: |
+          uv run --all-packages --with pytest \
+            pytest datus-maxcompute/tests/integration -m integration --verbose

--- a/.github/workflows/package-release-readiness.yml
+++ b/.github/workflows/package-release-readiness.yml
@@ -21,6 +21,7 @@ on:
           - datus-spark
           - datus-trino
           - datus-greenplum
+          - datus-maxcompute
       expected_version:
         description: "Expected package version, for example 0.1.5"
         required: true

--- a/.github/workflows/prepare-package-release-pr.yml
+++ b/.github/workflows/prepare-package-release-pr.yml
@@ -21,6 +21,7 @@ on:
           - datus-spark
           - datus-trino
           - datus-greenplum
+          - datus-maxcompute
       version:
         description: "New canonical package version, for example 0.1.5"
         required: true

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -21,6 +21,7 @@ on:
           - datus-spark
           - datus-trino
           - datus-greenplum
+          - datus-maxcompute
       version:
         description: "Release version. Use auto to publish the latest PyPI version + 0.0.1 without downgrading main."
         required: false

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Plugin Adapters (Independent packages, install as needed)
 └── Native SDK Adapters
     ├── datus-snowflake
     ├── datus-clickzetta
+    ├── datus-maxcompute
 ```
 
 ## Implemented Adapters
@@ -107,6 +108,23 @@ pip install datus-clickzetta
 
 ---
 
+### 6. datus-maxcompute
+Alibaba Cloud MaxCompute adapter (PyODPS).
+
+**Installation**:
+```bash
+pip install datus-maxcompute
+```
+
+**Features**:
+- Automatic two-level (`project.table`) and three-level (`project.schema.table`) namespace detection
+- SQL execution through MaxCompute jobs with explicit per-project namespace hints
+- Unlimited Instance Tunnel reads in Arrow, pandas, list, and CSV formats
+- Tables, views, materialized views, DDL, columns, partitions, and sample-row metadata
+- Dedicated cloud integration coverage for both namespace models
+
+---
+
 ## Development Guide
 
 ### Development Environment Setup
@@ -126,6 +144,7 @@ pip install -e datus-sqlalchemy
 pip install -e datus-mysql
 pip install -e datus-starrocks
 pip install -e datus-snowflake
+pip install -e datus-maxcompute
 ```
 
 **Note**: The root `pyproject.toml` is only for development environment management. End users should install individual packages.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pip install datus-maxcompute
 **Features**:
 - Automatic two-level (`project.table`) and three-level (`project.schema.table`) namespace detection
 - SQL execution through MaxCompute jobs with explicit per-project namespace hints
-- Unlimited Instance Tunnel reads in Arrow, pandas, list, and CSV formats
+- Instance Tunnel reads in Arrow, pandas, list, and CSV formats, with bounded CSV iteration
 - Tables, views, materialized views, DDL, columns, partitions, and sample-row metadata
 - Dedicated cloud integration coverage for both namespace models
 

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -18,6 +18,7 @@ PACKAGE_SPECS=(
   "datus-redshift:datus-redshift/tests/unit"
   "datus-snowflake:datus-snowflake/tests"
   "datus-clickzetta:datus-clickzetta/tests/unit"
+  "datus-maxcompute:datus-maxcompute/tests/unit"
 )
 
 usage() {

--- a/datus-db-core/datus_db_core/base.py
+++ b/datus-db-core/datus_db_core/base.py
@@ -266,6 +266,17 @@ class BaseSqlConnector(ABC):
     def get_type(self) -> str:
         return self.dialect
 
+    def get_effective_capabilities(self) -> Set[str]:
+        """Return capabilities for this configured connector instance.
+
+        Most adapters use their registered static capabilities. Adapters whose
+        namespace model depends on the connected service may override this
+        method without requiring callers to know the database type.
+        """
+        from datus_db_core.registry import connector_registry
+
+        return connector_registry.get_capabilities(self.dialect)
+
     @abstractmethod
     def execute_queries(self, queries: List[str]) -> List[Any]:
         raise NotImplementedError()

--- a/datus-db-core/datus_db_core/registry.py
+++ b/datus-db-core/datus_db_core/registry.py
@@ -20,11 +20,17 @@ class AdapterMetadata:
         connector_class: Type,
         config_class: Optional[Type] = None,
         display_name: Optional[str] = None,
+        parser_dialect: Optional[str] = None,
+        identifier_parser: Optional[Callable] = None,
+        sql_generation_notes: Optional[Any] = None,
     ):
         self.db_type = db_type
         self.connector_class = connector_class
         self.config_class = config_class
         self.display_name = display_name or db_type.capitalize()
+        self.parser_dialect = parser_dialect
+        self.identifier_parser = identifier_parser
+        self.sql_generation_notes = sql_generation_notes
 
     def get_config_fields(self) -> Dict[str, Dict[str, Any]]:
         if not self.config_class:
@@ -89,6 +95,10 @@ class ConnectorRegistry:
         capabilities: Optional[Set[str]] = None,
         uri_builder: Optional[Callable] = None,
         context_resolver: Optional[Callable] = None,
+        *,
+        parser_dialect: Optional[str] = None,
+        identifier_parser: Optional[Callable] = None,
+        sql_generation_notes: Optional[Any] = None,
     ):
         key = cls._resolve_key(db_type)
         with cls._lock:
@@ -107,6 +117,9 @@ class ConnectorRegistry:
                 connector_class=connector_class,
                 config_class=config_class,
                 display_name=display_name,
+                parser_dialect=parser_dialect,
+                identifier_parser=identifier_parser,
+                sql_generation_notes=sql_generation_notes,
             )
         logger.debug(f"Registered connector: {db_type} -> {connector_class.__name__}")
 
@@ -202,6 +215,10 @@ class ConnectorRegistry:
         capabilities: Optional[Set[str]] = None,
         uri_builder: Optional[Callable] = None,
         context_resolver: Optional[Callable] = None,
+        *,
+        parser_dialect: Optional[str] = None,
+        identifier_parser: Optional[Callable] = None,
+        sql_generation_notes: Optional[Any] = None,
     ):
         key = cls._resolve_key(db_type)
         if capabilities is not None:
@@ -210,10 +227,22 @@ class ConnectorRegistry:
             cls._uri_builders[key] = uri_builder
         if context_resolver:
             cls._context_resolvers[key] = context_resolver
+        metadata = cls._metadata.get(key)
+        if metadata:
+            if parser_dialect is not None:
+                metadata.parser_dialect = parser_dialect
+            if identifier_parser is not None:
+                metadata.identifier_parser = identifier_parser
+            if sql_generation_notes is not None:
+                metadata.sql_generation_notes = sql_generation_notes
 
     @classmethod
     def has_capabilities(cls, db_type: str) -> bool:
         return cls._resolve_key(db_type) in cls._capabilities
+
+    @classmethod
+    def get_capabilities(cls, db_type: str) -> Set[str]:
+        return cls._capabilities.get(cls._resolve_key(db_type), set()).copy()
 
     @classmethod
     def support_catalog(cls, db_type: str) -> bool:
@@ -234,6 +263,21 @@ class ConnectorRegistry:
     @classmethod
     def get_context_resolver(cls, db_type: str) -> Optional[Callable]:
         return cls._context_resolvers.get(cls._resolve_key(db_type))
+
+    @classmethod
+    def get_parser_dialect(cls, db_type: str) -> Optional[str]:
+        metadata = cls.get_metadata(db_type)
+        return metadata.parser_dialect if metadata else None
+
+    @classmethod
+    def get_identifier_parser(cls, db_type: str) -> Optional[Callable]:
+        metadata = cls.get_metadata(db_type)
+        return metadata.identifier_parser if metadata else None
+
+    @classmethod
+    def get_sql_generation_notes(cls, db_type: str) -> Optional[Any]:
+        metadata = cls.get_metadata(db_type)
+        return metadata.sql_generation_notes if metadata else None
 
 
 # Global instance

--- a/datus-db-core/datus_db_core/sql_utils.py
+++ b/datus-db-core/datus_db_core/sql_utils.py
@@ -19,8 +19,18 @@ _SQLITE = "sqlite"
 _DUCKDB = "duckdb"
 
 
+def _registered_parser_dialect(dialect: str) -> Optional[str]:
+    # Imported lazily to avoid a registry -> connector -> sql_utils cycle.
+    from datus_db_core.registry import connector_registry
+
+    return connector_registry.get_parser_dialect(dialect)
+
+
 def parse_read_dialect(dialect: str = "snowflake") -> str:
     db = (dialect or "").strip().lower()
+    registered = _registered_parser_dialect(db)
+    if registered:
+        return registered
     if db in ("postgres", "postgresql", "redshift", "greenplum"):
         return "postgres"
     if db in ("spark", "databricks", "hive", "starrocks"):
@@ -32,6 +42,9 @@ def parse_read_dialect(dialect: str = "snowflake") -> str:
 
 def parse_dialect(dialect: str = "snowflake") -> str:
     db = (dialect or "").strip().lower()
+    registered = _registered_parser_dialect(db)
+    if registered:
+        return registered
     if db in ("postgres", "postgresql"):
         return "postgres"
     if db in ("mssql", "sqlserver"):

--- a/datus-db-core/tests/unit/test_base.py
+++ b/datus-db-core/tests/unit/test_base.py
@@ -13,6 +13,7 @@ from datus_db_core.base import BaseSqlConnector, list_to_in_str, to_sql_literal
 from datus_db_core.config import ConnectionConfig
 from datus_db_core.constants import SQLType
 from datus_db_core.models import ExecuteSQLInput, ExecuteSQLResult
+from datus_db_core.registry import ConnectorRegistry
 
 
 class ConcreteConnector(BaseSqlConnector):
@@ -165,6 +166,19 @@ class TestBaseSqlConnectorInit:
         connector = ConcreteConnector(config=config, dialect="mysql")
         assert connector.dialect == "mysql"
         assert connector.timeout_seconds == 60
+
+    def test_effective_capabilities_default_to_registry(self):
+        original_connectors = ConnectorRegistry._connectors.copy()
+        original_metadata = ConnectorRegistry._metadata.copy()
+        original_capabilities = ConnectorRegistry._capabilities.copy()
+        try:
+            ConnectorRegistry.register("customdb", ConcreteConnector, capabilities={"database", "schema"})
+            connector = ConcreteConnector(dialect="customdb")
+            assert connector.get_effective_capabilities() == {"database", "schema"}
+        finally:
+            ConnectorRegistry._connectors = original_connectors
+            ConnectorRegistry._metadata = original_metadata
+            ConnectorRegistry._capabilities = original_capabilities
 
 
 class TestClose:

--- a/datus-db-core/tests/unit/test_registry.py
+++ b/datus-db-core/tests/unit/test_registry.py
@@ -103,6 +103,20 @@ class TestRegister:
         ConnectorRegistry.register("testdb", DummyConnector, context_resolver=resolver)
         assert ConnectorRegistry.get_context_resolver("testdb") is resolver
 
+    def test_register_with_optional_hooks(self):
+        identifier_parser = MagicMock()
+        notes = MagicMock()
+        ConnectorRegistry.register(
+            "testdb",
+            DummyConnector,
+            parser_dialect="hive",
+            identifier_parser=identifier_parser,
+            sql_generation_notes=notes,
+        )
+        assert ConnectorRegistry.get_parser_dialect("testdb") == "hive"
+        assert ConnectorRegistry.get_identifier_parser("testdb") is identifier_parser
+        assert ConnectorRegistry.get_sql_generation_notes("testdb") is notes
+
 
 class TestCreateConnector:
     def test_create_with_class(self):
@@ -217,6 +231,12 @@ class TestCapabilities:
         assert ConnectorRegistry.support_catalog("testdb")
         assert ConnectorRegistry.support_schema("testdb")
 
+    def test_capabilities_returns_copy(self):
+        ConnectorRegistry.register("testdb", DummyConnector, capabilities={"database"})
+        capabilities = ConnectorRegistry.get_capabilities("testdb")
+        capabilities.add("schema")
+        assert ConnectorRegistry.get_capabilities("testdb") == {"database"}
+
     def test_unregistered_db_no_capabilities(self):
         assert not ConnectorRegistry.support_catalog("unknown_db")
         assert not ConnectorRegistry.support_database("unknown_db")
@@ -263,6 +283,11 @@ class TestListAndQuery:
 
     def test_get_context_resolver_missing(self):
         assert ConnectorRegistry.get_context_resolver("nonexistent") is None
+
+    def test_optional_hooks_missing(self):
+        assert ConnectorRegistry.get_parser_dialect("nonexistent") is None
+        assert ConnectorRegistry.get_identifier_parser("nonexistent") is None
+        assert ConnectorRegistry.get_sql_generation_notes("nonexistent") is None
 
 
 class TestAdapterMetadata:

--- a/datus-db-core/tests/unit/test_sql_utils.py
+++ b/datus-db-core/tests/unit/test_sql_utils.py
@@ -4,7 +4,10 @@
 
 """Unit tests for sql_utils module."""
 
+import pytest
+
 from datus_db_core.constants import SQLType
+from datus_db_core.registry import ConnectorRegistry
 from datus_db_core.sql_utils import (
     _first_statement,
     metadata_identifier,
@@ -14,6 +17,17 @@ from datus_db_core.sql_utils import (
     parse_sql_type,
     strip_sql_comments,
 )
+
+
+@pytest.fixture(autouse=True)
+def restore_registry_metadata():
+    saved_connectors = ConnectorRegistry._connectors.copy()
+    saved_metadata = ConnectorRegistry._metadata.copy()
+    saved_capabilities = ConnectorRegistry._capabilities.copy()
+    yield
+    ConnectorRegistry._connectors = saved_connectors
+    ConnectorRegistry._metadata = saved_metadata
+    ConnectorRegistry._capabilities = saved_capabilities
 
 
 class TestParseReadDialect:
@@ -41,6 +55,10 @@ class TestParseReadDialect:
         assert parse_read_dialect("") == ""
         assert parse_read_dialect(None) == ""
 
+    def test_registered_parser_dialect(self):
+        ConnectorRegistry.register("customdb", object, parser_dialect="hive")
+        assert parse_read_dialect("customdb") == "hive"
+
 
 class TestParseDialect:
     def test_postgres_variants(self):
@@ -54,6 +72,10 @@ class TestParseDialect:
     def test_passthrough(self):
         assert parse_dialect("snowflake") == "snowflake"
         assert parse_dialect("mysql") == "mysql"
+
+    def test_registered_parser_dialect(self):
+        ConnectorRegistry.register("customdb", object, parser_dialect="hive")
+        assert parse_dialect("customdb") == "hive"
 
 
 class TestStripSqlComments:

--- a/datus-maxcompute/README.md
+++ b/datus-maxcompute/README.md
@@ -1,0 +1,20 @@
+# Datus MaxCompute Adapter
+
+Alibaba Cloud MaxCompute adapter for Datus. It supports both legacy
+`project.table` projects and schema-enabled `project.schema.table` projects.
+
+## Configuration
+
+```yaml
+database:
+  type: maxcompute
+  database: ${MAXCOMPUTE_PROJECT}
+  endpoint: ${MAXCOMPUTE_ENDPOINT}
+  access_key_id: ${MAXCOMPUTE_ACCESS_KEY_ID}
+  access_key_secret: ${MAXCOMPUTE_ACCESS_KEY_SECRET}
+  namespace_mode: auto
+```
+
+For a three-level project, `schema` is optional and defaults to `default`.
+Successful automatic detection is cached per connector. Errors other than the
+specific MaxCompute response for a non-three-level project are propagated.

--- a/datus-maxcompute/datus_maxcompute/__init__.py
+++ b/datus-maxcompute/datus_maxcompute/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from .config import MaxComputeConfig
+from .connector import MaxComputeConnector
+from .handlers import (
+    MAXCOMPUTE_SQL_GENERATION_NOTES,
+    build_maxcompute_uri,
+    parse_maxcompute_identifier,
+    resolve_maxcompute_context,
+)
+
+__version__ = "0.1.0"
+__all__ = ["MaxComputeConnector", "MaxComputeConfig", "register"]
+
+
+def register():
+    """Register the MaxCompute connector and its generic integration hooks."""
+    from datus_db_core import connector_registry
+
+    connector_registry.register(
+        "maxcompute",
+        MaxComputeConnector,
+        config_class=MaxComputeConfig,
+        capabilities={"database", "schema"},
+        uri_builder=build_maxcompute_uri,
+        context_resolver=resolve_maxcompute_context,
+        parser_dialect="hive",
+        identifier_parser=parse_maxcompute_identifier,
+        sql_generation_notes=MAXCOMPUTE_SQL_GENERATION_NOTES,
+    )

--- a/datus-maxcompute/datus_maxcompute/config.py
+++ b/datus-maxcompute/datus_maxcompute/config.py
@@ -1,0 +1,52 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, SecretStr, field_validator
+
+
+class MaxComputeConfig(BaseModel):
+    """Connection and execution settings for Alibaba Cloud MaxCompute."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    project: str = Field(
+        ...,
+        validation_alias=AliasChoices("project", "database"),
+        description="MaxCompute project name",
+    )
+    endpoint: str = Field(..., description="MaxCompute service endpoint")
+    access_key_id: SecretStr = Field(
+        ...,
+        description="Alibaba Cloud AccessKey ID",
+        json_schema_extra={"input_type": "password"},
+    )
+    access_key_secret: SecretStr = Field(
+        ...,
+        description="Alibaba Cloud AccessKey secret",
+        json_schema_extra={"input_type": "password"},
+    )
+    schema_name: Optional[str] = Field(
+        default=None,
+        alias="schema",
+        description="Default schema for a schema-enabled project",
+    )
+    quota_name: Optional[str] = Field(default=None, description="MaxCompute quota name")
+    tunnel_endpoint: Optional[str] = Field(default=None, description="Optional Instance Tunnel endpoint")
+    namespace_mode: Literal["auto", "two_level", "three_level"] = Field(
+        default="auto",
+        description="Namespace mode; auto detects whether the project supports schemas",
+    )
+    timeout_seconds: int = Field(default=30, gt=0, description="Connection timeout in seconds")
+    query_timeout_seconds: int = Field(default=600, gt=0, description="SQL job timeout in seconds")
+    default_hints: Dict[str, Any] = Field(default_factory=dict, description="Default MaxCompute SQL hints")
+
+    @field_validator("project", "endpoint")
+    @classmethod
+    def validate_non_empty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value

--- a/datus-maxcompute/datus_maxcompute/connector.py
+++ b/datus-maxcompute/datus_maxcompute/connector.py
@@ -1,0 +1,647 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union, override
+
+import pandas as pd
+import pyarrow as pa
+from pydantic import BaseModel, SecretStr
+
+from datus_db_core import (
+    TABLE_TYPE,
+    BaseSqlConnector,
+    DatusDbException,
+    ErrorCode,
+    ExecuteSQLResult,
+    get_logger,
+)
+
+from .config import MaxComputeConfig
+from .handlers import parse_maxcompute_identifier
+
+try:
+    from odps import ODPS
+    from odps.errors import InternalServerError, WaitTimeoutError
+    from odps.rest import RestClient
+except ImportError as exc:  # pragma: no cover - protected by package dependency
+    ODPS = None  # type: ignore[assignment]
+    RestClient = object  # type: ignore[assignment,misc]
+    InternalServerError = WaitTimeoutError = Exception  # type: ignore[misc,assignment]
+    _PYODPS_IMPORT_ERROR: Optional[Exception] = exc
+else:
+    _PYODPS_IMPORT_ERROR = None
+
+logger = get_logger(__name__)
+
+_NOT_THREE_LEVEL_MARKER = "is not 3-tier model project"
+_UNSUPPORTED_SQL_RE = re.compile(
+    r"^\s*(?:begin(?:\s+transaction)?|start\s+transaction|commit|rollback|grant|revoke)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _secret_value(value: Union[SecretStr, str]) -> str:
+    return value.get_secret_value() if isinstance(value, SecretStr) else str(value)
+
+
+class _TimeoutRestClient(RestClient):
+    """PyODPS REST client with connector-local request timeouts."""
+
+    def __init__(self, *args, timeout_seconds: int = 30, **kwargs):
+        self._request_timeout = (timeout_seconds, timeout_seconds)
+        super().__init__(*args, **kwargs)
+
+    def request(self, url, method, stream=False, **kwargs):
+        kwargs.setdefault("timeout", self._request_timeout)
+        return super().request(url, method, stream=stream, **kwargs)
+
+
+def _coerce_config(config: Union[MaxComputeConfig, Dict[str, Any], BaseModel]) -> MaxComputeConfig:
+    if isinstance(config, MaxComputeConfig):
+        return config
+    if isinstance(config, dict):
+        return MaxComputeConfig.model_validate(config)
+
+    def get(*names: str, default: Any = None) -> Any:
+        for name in names:
+            value = getattr(config, name, None)
+            if value is not None and value != "":
+                return value
+        return default
+
+    return MaxComputeConfig(
+        project=get("project", "database"),
+        endpoint=get("endpoint"),
+        access_key_id=get("access_key_id", "username"),
+        access_key_secret=get("access_key_secret", "password"),
+        schema=get("schema_name", "schema"),
+        quota_name=get("quota_name"),
+        tunnel_endpoint=get("tunnel_endpoint"),
+        namespace_mode=get("namespace_mode", default="auto"),
+        timeout_seconds=get("timeout_seconds", default=30),
+        query_timeout_seconds=get("query_timeout_seconds", default=600),
+        default_hints=get("default_hints", default={}),
+    )
+
+
+class MaxComputeConnector(BaseSqlConnector):
+    """MaxCompute connector backed by the official PyODPS SDK."""
+
+    def __init__(self, config: Union[MaxComputeConfig, Dict[str, Any], BaseModel]):
+        if ODPS is None:
+            raise DatusDbException(
+                ErrorCode.COMMON_MISSING_DEPENDENCY,
+                message_args={"dependency": "pyodps"},
+            ) from _PYODPS_IMPORT_ERROR
+
+        parsed_config = _coerce_config(config)
+        super().__init__(parsed_config, dialect="maxcompute")
+        self.config = parsed_config
+        self.project = parsed_config.project
+        self.endpoint = parsed_config.endpoint
+        self.query_timeout_seconds = parsed_config.query_timeout_seconds
+        self.quota_name = parsed_config.quota_name
+        self.tunnel_endpoint = parsed_config.tunnel_endpoint
+        self.namespace_mode_setting = parsed_config.namespace_mode
+        self.default_hints = dict(parsed_config.default_hints)
+        self._namespace_mode: Optional[Literal["two_level", "three_level"]] = None
+        self._default_catalog = ""
+        self._default_database = self.project
+        self._default_schema = parsed_config.schema_name or ""
+        self._odps = ODPS(
+            _secret_value(parsed_config.access_key_id),
+            _secret_value(parsed_config.access_key_secret),
+            project=self.project,
+            endpoint=self.endpoint,
+            schema=parsed_config.schema_name,
+            tunnel_endpoint=self.tunnel_endpoint,
+            quota_name=self.quota_name,
+            rest_client_cls=_TimeoutRestClient,
+            rest_client_kwargs={"timeout_seconds": parsed_config.timeout_seconds},
+        )
+        self.connection = self._odps
+
+    def connect(self):
+        self.connection = self._odps
+        self._ensure_namespace_mode()
+
+    def close(self):
+        # PyODPS uses request-scoped HTTP sessions and exposes no connection close.
+        self.connection = None
+
+    @staticmethod
+    def _is_two_level_project_error(exc: Exception) -> bool:
+        return _NOT_THREE_LEVEL_MARKER in str(exc).lower()
+
+    def _ensure_namespace_mode(self) -> Literal["two_level", "three_level"]:
+        if self._namespace_mode:
+            return self._namespace_mode
+        if self.namespace_mode_setting != "auto":
+            self._namespace_mode = self.namespace_mode_setting
+        else:
+            try:
+                list(self._odps.list_schemas(project=self.project))
+                self._namespace_mode = "three_level"
+            except InternalServerError as exc:
+                if not self._is_two_level_project_error(exc):
+                    raise
+                self._namespace_mode = "two_level"
+
+        if self._namespace_mode == "three_level":
+            self._default_schema = self.config.schema_name or "default"
+        else:
+            self._default_schema = ""
+        return self._namespace_mode
+
+    @property
+    def namespace_mode(self) -> Literal["two_level", "three_level"]:
+        return self._ensure_namespace_mode()
+
+    @override
+    def get_effective_capabilities(self) -> Set[str]:
+        capabilities = {"database"}
+        if self.namespace_mode == "three_level":
+            capabilities.add("schema")
+        return capabilities
+
+    @override
+    def get_current_context(self) -> Dict[str, str]:
+        self.connect()
+        return {
+            "catalog_name": "",
+            "database_name": self.project,
+            "schema_name": self.schema_name if self.namespace_mode == "three_level" else "",
+        }
+
+    def _validate_context(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> Tuple[str, str]:
+        if catalog_name:
+            raise DatusDbException(
+                ErrorCode.COMMON_UNSUPPORTED,
+                message=f"MaxCompute does not expose a catalog namespace: {catalog_name}",
+            )
+        project = database_name or self.project
+        if project != self.project:
+            raise DatusDbException(
+                ErrorCode.COMMON_UNSUPPORTED,
+                message=(
+                    f"This datasource is bound to MaxCompute project '{self.project}'; "
+                    f"cross-project access to '{project}' is not supported"
+                ),
+            )
+
+        if self.namespace_mode == "two_level":
+            if schema_name:
+                raise DatusDbException(
+                    ErrorCode.COMMON_UNSUPPORTED,
+                    message=f"Project '{self.project}' uses project.table and has no schema namespace",
+                )
+            return project, ""
+        return project, schema_name or self.schema_name or "default"
+
+    @override
+    def do_switch_context(
+        self,
+        conn: Any,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ):
+        self._validate_context(catalog_name, database_name, schema_name)
+
+    def _job_hints(self) -> Dict[str, Any]:
+        hints = dict(self.default_hints)
+        hints["odps.namespace.schema"] = "true" if self.namespace_mode == "three_level" else "false"
+        return hints
+
+    @staticmethod
+    def _reject_unsupported_sql(sql: str):
+        if _UNSUPPORTED_SQL_RE.match(sql):
+            raise DatusDbException(
+                ErrorCode.COMMON_UNSUPPORTED,
+                message="MaxCompute adapter does not support transactions or GRANT/REVOKE statements",
+            )
+
+    def _run_instance(
+        self,
+        sql: str,
+        database_name: str = "",
+        schema_name: str = "",
+        catalog_name: str = "",
+    ):
+        self._reject_unsupported_sql(sql)
+        project, schema = self._validate_context(catalog_name, database_name, schema_name)
+        kwargs: Dict[str, Any] = {
+            "project": project,
+            "hints": self._job_hints(),
+        }
+        if schema:
+            kwargs["default_schema"] = schema
+        if self.quota_name:
+            kwargs["quota_name"] = self.quota_name
+        instance = self._odps.run_sql(sql, **kwargs)
+        try:
+            instance.wait_for_success(timeout=self.query_timeout_seconds)
+        except (WaitTimeoutError, TimeoutError) as exc:
+            try:
+                instance.stop()
+            finally:
+                raise DatusDbException(
+                    ErrorCode.DB_EXECUTION_TIMEOUT,
+                    message_args={"error_message": str(exc)},
+                ) from exc
+        return instance
+
+    def _read_arrow(self, instance, max_rows: Optional[int] = None) -> pa.Table:
+        reader_kwargs: Dict[str, Any] = {
+            "tunnel": True,
+            "arrow": True,
+            "limit": False,
+            "timeout": self.timeout_seconds,
+        }
+        if self.tunnel_endpoint:
+            reader_kwargs["endpoint"] = self.tunnel_endpoint
+        if self.quota_name:
+            reader_kwargs["quota_name"] = self.quota_name
+        with instance.open_reader(**reader_kwargs) as reader:
+            return reader.read_all(count=max_rows)
+
+    def _query_arrow(
+        self,
+        sql: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        max_rows: Optional[int] = None,
+    ) -> pa.Table:
+        instance = self._run_instance(
+            sql,
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+        )
+        return self._read_arrow(instance, max_rows=max_rows)
+
+    @staticmethod
+    def _query_result(sql: str, table: pa.Table, result_format: str) -> ExecuteSQLResult:
+        if result_format == "arrow":
+            sql_return: Any = table
+        elif result_format == "pandas":
+            sql_return = table.to_pandas()
+        elif result_format == "list":
+            sql_return = table.to_pylist()
+        else:
+            sql_return = table.to_pandas().to_csv(index=False)
+        return ExecuteSQLResult(
+            success=True,
+            sql_query=sql,
+            sql_return=sql_return,
+            row_count=table.num_rows,
+            result_format=result_format,
+        )
+
+    @override
+    def execute_query(
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> ExecuteSQLResult:
+        try:
+            table = self._query_arrow(sql, catalog_name, database_name, schema_name)
+            return self._query_result(sql, table, result_format)
+        except Exception as exc:
+            return ExecuteSQLResult(
+                success=False,
+                error=str(exc),
+                sql_query=sql,
+                result_format=result_format,
+            )
+
+    @override
+    def execute_explain(
+        self,
+        sql: str,
+        result_format: Literal["csv", "arrow", "pandas", "list"] = "csv",
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> ExecuteSQLResult:
+        return self.execute_query(sql, result_format, catalog_name, database_name, schema_name)
+
+    def execute_arrow(self, sql: str) -> ExecuteSQLResult:
+        return self.execute_query(sql, result_format="arrow")
+
+    @override
+    def execute_pandas(self, sql: str) -> ExecuteSQLResult:
+        return self.execute_query(sql, result_format="pandas")
+
+    @override
+    def execute_csv(self, sql: str) -> ExecuteSQLResult:
+        return self.execute_query(sql, result_format="csv")
+
+    def _execute_non_query(
+        self,
+        sql: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> ExecuteSQLResult:
+        try:
+            instance = self._run_instance(sql, database_name, schema_name, catalog_name)
+            return ExecuteSQLResult(
+                success=True,
+                sql_query=sql,
+                sql_return=instance.id,
+                row_count=None,
+                result_format="",
+            )
+        except Exception as exc:
+            return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql, result_format="")
+
+    @override
+    def execute_ddl(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self._execute_non_query(sql, catalog_name, database_name, schema_name)
+
+    @override
+    def execute_insert(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self._execute_non_query(sql, catalog_name, database_name, schema_name)
+
+    @override
+    def execute_update(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self._execute_non_query(sql, catalog_name, database_name, schema_name)
+
+    @override
+    def execute_delete(
+        self, sql: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> ExecuteSQLResult:
+        return self._execute_non_query(sql, catalog_name, database_name, schema_name)
+
+    @override
+    def execute_content_set(self, sql_query: str) -> ExecuteSQLResult:
+        return ExecuteSQLResult(
+            success=False,
+            error="MaxCompute context switching SQL is not supported; pass project/schema as execution context",
+            sql_query=sql_query,
+            result_format="",
+        )
+
+    @override
+    def execute_queries(self, queries: List[str]) -> List[ExecuteSQLResult]:
+        return [self.execute({"sql_query": sql}) for sql in queries]
+
+    @override
+    def execute_csv_iterator(
+        self, query: str, max_rows: int = 100, with_header: bool = True
+    ) -> Iterator[Tuple[str, ...]]:
+        try:
+            table = self._query_arrow(query, max_rows=max(0, int(max_rows)))
+        except Exception as exc:
+            raise DatusDbException(ErrorCode.DB_EXECUTION_ERROR, message=str(exc)) from exc
+        if with_header:
+            yield tuple(table.column_names)
+        for row in table.to_pylist():
+            yield tuple("" if row[name] is None else str(row[name]) for name in table.column_names)
+
+    @override
+    def test_connection(self):
+        self.connect()
+        self._odps.get_project(self.project).reload()
+        return True
+
+    @override
+    def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
+        self._validate_context(catalog_name=catalog_name)
+        return [self.project]
+
+    def get_schemas(self, catalog_name: str = "", database_name: str = "", include_sys: bool = False) -> List[str]:
+        project, _ = self._validate_context(catalog_name, database_name)
+        if self.namespace_mode == "two_level":
+            return []
+        return [schema.name for schema in self._odps.list_schemas(project=project)]
+
+    @staticmethod
+    def _table_type(table: Any) -> str:
+        value = getattr(table, "type", "")
+        return str(getattr(value, "value", value)).upper()
+
+    def _list_objects(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> Tuple[str, str, List[Any]]:
+        project, schema = self._validate_context(catalog_name, database_name, schema_name)
+        objects = list(self._odps.list_tables(project=project, schema=schema or None))
+        return project, schema, objects
+
+    @override
+    def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
+        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [table.name for table in objects if self._table_type(table) not in {"VIRTUAL_VIEW", "MATERIALIZED_VIEW"}]
+
+    @override
+    def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
+        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [table.name for table in objects if self._table_type(table) == "VIRTUAL_VIEW"]
+
+    def get_materialized_views(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[str]:
+        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [table.name for table in objects if self._table_type(table) == "MATERIALIZED_VIEW"]
+
+    def _resolve_table(
+        self,
+        table_name: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> Tuple[str, str, str]:
+        parsed = parse_maxcompute_identifier(table_name)
+        parsed_project = parsed["database_name"]
+        parsed_schema = parsed["schema_name"]
+        project, schema = self._validate_context(
+            catalog_name,
+            parsed_project or database_name,
+            parsed_schema or schema_name,
+        )
+        return project, schema, parsed["table_name"]
+
+    def _get_table(
+        self,
+        table_name: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ):
+        project, schema, name = self._resolve_table(table_name, catalog_name, database_name, schema_name)
+        return project, schema, self._odps.get_table(name, project=project, schema=schema or None)
+
+    @override
+    def get_schema(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+    ) -> List[Dict[str, Any]]:
+        if not table_name:
+            return []
+        _, _, table = self._get_table(table_name, catalog_name, database_name, schema_name)
+        table.reload()
+        partitions = {column.name for column in table.table_schema.partitions}
+        result = []
+        for index, column in enumerate(table.table_schema.columns):
+            result.append(
+                {
+                    "cid": index,
+                    "name": column.name,
+                    "type": str(column.type),
+                    "comment": getattr(column, "comment", None),
+                    "nullable": getattr(column, "nullable", True) is not False,
+                    "pk": False,
+                    "default_value": None,
+                    "is_partition": column.name in partitions,
+                }
+            )
+        return result
+
+    def _metadata_entry(self, project: str, schema: str, table: Any, table_type: str) -> Dict[str, str]:
+        return {
+            "identifier": self.identifier(
+                database_name=project,
+                schema_name=schema,
+                table_name=table.name,
+            ),
+            "catalog_name": "",
+            "database_name": project,
+            "schema_name": schema,
+            "table_name": table.name,
+            "table_type": table_type,
+            "definition": table.get_ddl(),
+        }
+
+    @override
+    def get_tables_with_ddl(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        tables: Optional[List[str]] = None,
+    ) -> List[Dict[str, str]]:
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        requested = {self._resolve_table(name, database_name=project, schema_name=schema)[2] for name in tables or []}
+        return [
+            self._metadata_entry(project, schema, table, "table")
+            for table in objects
+            if self._table_type(table) not in {"VIRTUAL_VIEW", "MATERIALIZED_VIEW"}
+            and (not requested or table.name in requested)
+        ]
+
+    @override
+    def get_views_with_ddl(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[Dict[str, str]]:
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [
+            self._metadata_entry(project, schema, table, "view")
+            for table in objects
+            if self._table_type(table) == "VIRTUAL_VIEW"
+        ]
+
+    def get_materialized_views_with_ddl(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> List[Dict[str, str]]:
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [
+            self._metadata_entry(project, schema, table, "mv")
+            for table in objects
+            if self._table_type(table) == "MATERIALIZED_VIEW"
+        ]
+
+    @override
+    def get_sample_rows(
+        self,
+        tables: Optional[List[str]] = None,
+        top_n: int = 5,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_type: TABLE_TYPE = "table",
+    ) -> List[Dict[str, Any]]:
+        project, schema = self._validate_context(catalog_name, database_name, schema_name)
+        table_names = tables or self.get_tables(database_name=project, schema_name=schema)
+        result: List[Dict[str, Any]] = []
+        for table_name in table_names:
+            resolved_project, resolved_schema, name = self._resolve_table(
+                table_name,
+                database_name=project,
+                schema_name=schema,
+            )
+            query = (
+                f"SELECT * FROM "
+                f"{self.full_name(database_name=resolved_project, schema_name=resolved_schema, table_name=name)} "
+                f"LIMIT {int(top_n)}"
+            )
+            query_result = self.execute_query(
+                query,
+                result_format="pandas",
+                database_name=resolved_project,
+                schema_name=resolved_schema,
+            )
+            if not query_result.success:
+                logger.warning("Failed to sample MaxCompute table %s: %s", name, query_result.error)
+                continue
+            frame: pd.DataFrame = query_result.sql_return
+            result.append(
+                {
+                    "identifier": self.identifier(
+                        database_name=resolved_project,
+                        schema_name=resolved_schema,
+                        table_name=name,
+                    ),
+                    "catalog_name": "",
+                    "database_name": resolved_project,
+                    "schema_name": resolved_schema,
+                    "table_name": name,
+                    "table_type": table_type,
+                    "sample_rows": frame.to_csv(index=False),
+                }
+            )
+        return result
+
+    @override
+    def quote_identifier(self, name: str) -> str:
+        return f"`{name.replace('`', '``')}`"
+
+    @override
+    def full_name(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+    ) -> str:
+        project, schema, name = self._resolve_table(table_name, catalog_name, database_name, schema_name)
+        parts = [project]
+        if schema:
+            parts.append(schema)
+        parts.append(name)
+        return ".".join(self.quote_identifier(part) for part in parts)

--- a/datus-maxcompute/datus_maxcompute/connector.py
+++ b/datus-maxcompute/datus_maxcompute/connector.py
@@ -17,7 +17,9 @@ from datus_db_core import (
     DatusDbException,
     ErrorCode,
     ExecuteSQLResult,
+    SQLType,
     get_logger,
+    parse_sql_type,
 )
 
 from .config import MaxComputeConfig
@@ -274,6 +276,18 @@ class MaxComputeConnector(BaseSqlConnector):
         with instance.open_reader(**reader_kwargs) as reader:
             return reader.read_all(count=max_rows)
 
+    def _read_task_result(self, instance, sql_type: SQLType, max_rows: Optional[int] = None) -> pa.Table:
+        """Read text results produced by non-SELECT MaxCompute SQL jobs."""
+        raw_result = str(instance.get_task_result() or "")
+        if sql_type == SQLType.EXPLAIN:
+            stripped_result = raw_result.strip("\r\n")
+            values = [stripped_result] if stripped_result.strip() else []
+        else:
+            values = [line.rstrip() for line in raw_result.splitlines() if line.strip()]
+        if max_rows is not None:
+            values = values[:max_rows]
+        return pa.table({"result": pa.array(values, type=pa.string())})
+
     def _query_arrow(
         self,
         sql: str,
@@ -288,6 +302,9 @@ class MaxComputeConnector(BaseSqlConnector):
             database_name=database_name,
             schema_name=schema_name,
         )
+        sql_type = parse_sql_type(sql, self.dialect)
+        if sql_type in {SQLType.METADATA_SHOW, SQLType.EXPLAIN}:
+            return self._read_task_result(instance, sql_type, max_rows=max_rows)
         return self._read_arrow(instance, max_rows=max_rows)
 
     @staticmethod
@@ -459,6 +476,10 @@ class MaxComputeConnector(BaseSqlConnector):
         requested_project: str,
         requested_schema: str,
     ) -> str:
+        if schema and requested_project and not requested_schema:
+            # MaxCompute parses every two-part identifier as project.table.
+            # Keep the three-level listing unambiguous and round-trippable.
+            return ".".join((project, schema, name))
         parts = []
         if not requested_project:
             parts.append(project)

--- a/datus-maxcompute/datus_maxcompute/connector.py
+++ b/datus-maxcompute/datus_maxcompute/connector.py
@@ -69,7 +69,7 @@ def _coerce_config(config: Union[MaxComputeConfig, Dict[str, Any], BaseModel]) -
     def get(*names: str, default: Any = None) -> Any:
         for name in names:
             value = getattr(config, name, None)
-            if value is not None and value != "":
+            if value is not None and value != "" and not callable(value):
                 return value
         return default
 
@@ -451,21 +451,49 @@ class MaxComputeConnector(BaseSqlConnector):
         objects = list(self._odps.list_tables(project=project, schema=schema or None))
         return project, schema, objects
 
+    @staticmethod
+    def _qualify_listed_name(
+        name: str,
+        project: str,
+        schema: str,
+        requested_project: str,
+        requested_schema: str,
+    ) -> str:
+        parts = []
+        if not requested_project:
+            parts.append(project)
+        if schema and not requested_schema:
+            parts.append(schema)
+        parts.append(name)
+        return ".".join(parts)
+
     @override
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
-        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
-        return [table.name for table in objects if self._table_type(table) not in {"VIRTUAL_VIEW", "MATERIALIZED_VIEW"}]
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [
+            self._qualify_listed_name(table.name, project, schema, database_name, schema_name)
+            for table in objects
+            if self._table_type(table) not in {"VIRTUAL_VIEW", "MATERIALIZED_VIEW"}
+        ]
 
     @override
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
-        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
-        return [table.name for table in objects if self._table_type(table) == "VIRTUAL_VIEW"]
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [
+            self._qualify_listed_name(table.name, project, schema, database_name, schema_name)
+            for table in objects
+            if self._table_type(table) == "VIRTUAL_VIEW"
+        ]
 
     def get_materialized_views(
         self, catalog_name: str = "", database_name: str = "", schema_name: str = ""
     ) -> List[str]:
-        _, _, objects = self._list_objects(catalog_name, database_name, schema_name)
-        return [table.name for table in objects if self._table_type(table) == "MATERIALIZED_VIEW"]
+        project, schema, objects = self._list_objects(catalog_name, database_name, schema_name)
+        return [
+            self._qualify_listed_name(table.name, project, schema, database_name, schema_name)
+            for table in objects
+            if self._table_type(table) == "MATERIALIZED_VIEW"
+        ]
 
     def _resolve_table(
         self,

--- a/datus-maxcompute/datus_maxcompute/handlers.py
+++ b/datus-maxcompute/datus_maxcompute/handlers.py
@@ -5,7 +5,7 @@
 """Generic integration hooks exposed by the MaxCompute adapter."""
 
 from typing import Any, Dict, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 
 def _clean(value: Any) -> str:
@@ -34,6 +34,19 @@ def build_maxcompute_uri(db_config) -> str:
     """Build a credential-free URI used for datasource identity and context."""
     project = _config_value(db_config, "project", "database")
     endpoint = _config_value(db_config, "endpoint")
+    parsed_endpoint = urlparse(endpoint)
+    if parsed_endpoint.username is not None or parsed_endpoint.password is not None:
+        raise ValueError("MaxCompute endpoint must not contain user information")
+    endpoint = urlunparse(
+        (
+            parsed_endpoint.scheme,
+            parsed_endpoint.netloc,
+            parsed_endpoint.path,
+            parsed_endpoint.params,
+            "",
+            "",
+        )
+    )
     schema = _config_value(db_config, "schema_name", "schema")
     query = {"endpoint": endpoint}
     if schema:
@@ -72,11 +85,15 @@ def parse_maxcompute_identifier(full_table_name: str) -> Dict[str, str]:
 
 
 def _split_identifier(identifier: str) -> list[str]:
+    text = (identifier or "").strip()
+    if not text:
+        return []
+
     parts: list[str] = []
     current: list[str] = []
     quote = ""
     pairs = {"`": "`", '"': '"', "[": "]"}
-    for char in (identifier or "").strip():
+    for char in text:
         if quote:
             if char == quote:
                 quote = ""
@@ -87,14 +104,18 @@ def _split_identifier(identifier: str) -> list[str]:
             quote = pairs[char]
         elif char == ".":
             value = "".join(current).strip()
-            if value:
-                parts.append(value)
+            if not value:
+                raise ValueError(f"Invalid MaxCompute table identifier: {identifier}")
+            parts.append(value)
             current = []
         else:
             current.append(char)
+    if quote:
+        raise ValueError(f"Invalid MaxCompute table identifier: {identifier}")
     value = "".join(current).strip()
-    if value:
-        parts.append(value)
+    if not value:
+        raise ValueError(f"Invalid MaxCompute table identifier: {identifier}")
+    parts.append(value)
     return parts
 
 

--- a/datus-maxcompute/datus_maxcompute/handlers.py
+++ b/datus-maxcompute/datus_maxcompute/handlers.py
@@ -1,0 +1,108 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Generic integration hooks exposed by the MaxCompute adapter."""
+
+from typing import Any, Dict, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    if hasattr(value, "get_secret_value"):
+        value = value.get_secret_value()
+    return str(value).strip()
+
+
+def _config_value(db_config, *names: str) -> str:
+    for name in names:
+        value = _clean(getattr(db_config, name, None))
+        if value:
+            return value
+    extra = getattr(db_config, "extra", None)
+    if isinstance(extra, dict):
+        for name in names:
+            value = _clean(extra.get(name))
+            if value:
+                return value
+    return ""
+
+
+def build_maxcompute_uri(db_config) -> str:
+    """Build a credential-free URI used for datasource identity and context."""
+    project = _config_value(db_config, "project", "database")
+    endpoint = _config_value(db_config, "endpoint")
+    schema = _config_value(db_config, "schema_name", "schema")
+    query = {"endpoint": endpoint}
+    if schema:
+        query["schema"] = schema
+    return f"maxcompute://{project}?{urlencode(query)}"
+
+
+def resolve_maxcompute_context(db_config, uri: str) -> Tuple[str, str, str, str]:
+    parsed = urlparse(uri)
+    params = parse_qs(parsed.query)
+    project = parsed.netloc or _config_value(db_config, "project", "database")
+    schema = (params.get("schema") or [""])[0]
+    if not schema:
+        schema = _config_value(db_config, "schema_name", "schema")
+    return "maxcompute", "", project, schema
+
+
+def parse_maxcompute_identifier(full_table_name: str) -> Dict[str, str]:
+    """Parse Datus identifiers for both MaxCompute namespace models.
+
+    Two components always mean ``project.table``. Three components mean
+    ``project.schema.table``; ``schema.table`` is intentionally not inferred.
+    """
+    parts = _split_identifier(full_table_name)
+    result = {"catalog_name": "", "database_name": "", "schema_name": "", "table_name": ""}
+    if not parts:
+        return result
+    if len(parts) > 3:
+        raise ValueError(f"Invalid MaxCompute table identifier: {full_table_name}")
+    result["table_name"] = parts[-1]
+    if len(parts) >= 2:
+        result["database_name"] = parts[0]
+    if len(parts) == 3:
+        result["schema_name"] = parts[1]
+    return result
+
+
+def _split_identifier(identifier: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    quote = ""
+    pairs = {"`": "`", '"': '"', "[": "]"}
+    for char in (identifier or "").strip():
+        if quote:
+            if char == quote:
+                quote = ""
+            else:
+                current.append(char)
+            continue
+        if char in pairs:
+            quote = pairs[char]
+        elif char == ".":
+            value = "".join(current).strip()
+            if value:
+                parts.append(value)
+            current = []
+        else:
+            current.append(char)
+    value = "".join(current).strip()
+    if value:
+        parts.append(value)
+    return parts
+
+
+MAXCOMPUTE_SQL_GENERATION_NOTES = """
+MaxCompute namespace rules:
+- Use project.table for a two-level project.
+- Use project.schema.table for a schema-enabled three-level project.
+- Do not infer schema.table from a two-part identifier; Datus treats it as project.table.
+- Do not generate transaction control statements. UPDATE and DELETE require a compatible
+  transactional table and may be rejected by MaxCompute for ordinary tables.
+""".strip()

--- a/datus-maxcompute/pyproject.toml
+++ b/datus-maxcompute/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
-name = "datus-db-core"
-version = "0.1.5"
-description = "Core database abstractions for Datus adapters"
+name = "datus-maxcompute"
+version = "0.1.0"
+description = "Alibaba Cloud MaxCompute database adapter for Datus"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "DatusAI", email = "support@datus.ai"}
 ]
-keywords = ["datus", "database", "adapter", "core"]
+keywords = ["datus", "database", "maxcompute", "odps", "adapter"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -18,8 +18,11 @@ classifiers = [
 ]
 
 dependencies = [
+    "datus-db-core>=0.1.5",
+    "pandas>=2.0.0",
+    "pyarrow>=10.0.0",
     "pydantic>=2.0.0",
-    "sqlglot>=20.0.0",
+    "pyodps>=0.13.0",
 ]
 
 [project.urls]
@@ -27,9 +30,15 @@ Homepage = "https://github.com/Datus-ai/datus-db-adapters"
 Repository = "https://github.com/Datus-ai/datus-db-adapters"
 Issues = "https://github.com/Datus-ai/datus-db-adapters/issues"
 
+[project.entry-points."datus.adapters"]
+maxcompute = "datus_maxcompute:register"
+
+[tool.uv.sources]
+datus-db-core = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["datus_db_core"]
+packages = ["datus_maxcompute"]

--- a/datus-maxcompute/tests/integration/test_cloud_projects.py
+++ b/datus-maxcompute/tests/integration/test_cloud_projects.py
@@ -71,6 +71,25 @@ def test_namespace_detection_crud_and_metadata(project_env, expected_mode, expec
         assert query.success, query.error
         assert query.sql_return == [{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]
 
+        show = connector.execute(
+            {"sql_query": "SHOW TABLES", "result_format": "list"},
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        assert show.success, show.error
+        assert any(row["result"] == table_name or row["result"].endswith(f":{table_name}") for row in show.sql_return)
+
+        explain = connector.execute(
+            {
+                "sql_query": f"EXPLAIN SELECT id FROM {full_name} LIMIT 1",
+                "result_format": "list",
+            },
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        assert explain.success, explain.error
+        assert explain.sql_return and "job" in explain.sql_return[0]["result"].lower()
+
         preview_rows = list(
             connector.execute_csv_iterator(
                 f"SELECT id, name FROM {full_name} ORDER BY id",

--- a/datus-maxcompute/tests/integration/test_cloud_projects.py
+++ b/datus-maxcompute/tests/integration/test_cloud_projects.py
@@ -1,0 +1,107 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+import os
+import uuid
+
+import pytest
+
+from datus_maxcompute import MaxComputeConfig, MaxComputeConnector
+
+pytestmark = pytest.mark.integration
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        pytest.skip(f"{name} is required for MaxCompute cloud integration tests")
+    return value
+
+
+def _connector(project: str) -> MaxComputeConnector:
+    return MaxComputeConnector(
+        MaxComputeConfig(
+            project=project,
+            endpoint=_required_env("MAXCOMPUTE_ENDPOINT"),
+            access_key_id=_required_env("MAXCOMPUTE_ACCESS_KEY_ID"),
+            access_key_secret=_required_env("MAXCOMPUTE_ACCESS_KEY_SECRET"),
+            namespace_mode="auto",
+            query_timeout_seconds=300,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("project_env", "expected_mode", "expected_capabilities"),
+    [
+        ("MAXCOMPUTE_TWO_LEVEL_PROJECT", "two_level", {"database"}),
+        ("MAXCOMPUTE_THREE_LEVEL_PROJECT", "three_level", {"database", "schema"}),
+    ],
+)
+def test_namespace_detection_crud_and_metadata(project_env, expected_mode, expected_capabilities):
+    connector = _connector(_required_env(project_env))
+    table_name = f"datus_adapter_ci_{uuid.uuid4().hex[:12]}"
+    schema_name = "default" if expected_mode == "three_level" else ""
+    full_name = connector.full_name(schema_name=schema_name, table_name=table_name)
+
+    assert connector.namespace_mode == expected_mode
+    assert connector.get_effective_capabilities() == expected_capabilities
+
+    try:
+        create = connector.execute_ddl(
+            f"CREATE TABLE {full_name} (id BIGINT, name STRING) LIFECYCLE 1",
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        assert create.success, create.error
+
+        insert = connector.execute_insert(
+            f"INSERT INTO TABLE {full_name} SELECT 1 AS id, 'alpha' AS name UNION ALL SELECT 2 AS id, 'beta' AS name",
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        assert insert.success, insert.error
+
+        query = connector.execute_query(
+            f"SELECT id, name FROM {full_name} ORDER BY id",
+            result_format="list",
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        assert query.success, query.error
+        assert query.sql_return == [{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]
+
+        preview_rows = list(
+            connector.execute_csv_iterator(
+                f"SELECT id, name FROM {full_name} ORDER BY id",
+                max_rows=1,
+            )
+        )
+        assert preview_rows == [("id", "name"), ("1", "alpha")]
+
+        assert table_name in connector.get_tables(
+            database_name=connector.project,
+            schema_name=schema_name,
+        )
+        columns = connector.get_schema(
+            database_name=connector.project,
+            schema_name=schema_name,
+            table_name=table_name,
+        )
+        assert [(column["name"], column["type"]) for column in columns] == [
+            ("id", "BIGINT"),
+            ("name", "STRING"),
+        ]
+        ddl_rows = connector.get_tables_with_ddl(
+            database_name=connector.project,
+            schema_name=schema_name,
+            tables=[table_name],
+        )
+        assert len(ddl_rows) == 1
+        assert table_name in ddl_rows[0]["definition"]
+    finally:
+        connector.execute_ddl(
+            f"DROP TABLE IF EXISTS {full_name}",
+            database_name=connector.project,
+            schema_name=schema_name,
+        )

--- a/datus-maxcompute/tests/unit/test_config.py
+++ b/datus-maxcompute/tests/unit/test_config.py
@@ -35,14 +35,15 @@ def test_config_accepts_schema_alias():
 
 
 @pytest.mark.parametrize("field", ["project", "endpoint"])
-def test_config_rejects_empty_required_strings(field):
+@pytest.mark.parametrize("empty_value", ["", " "])
+def test_config_rejects_empty_required_strings(field, empty_value):
     values = {
         "project": "project_a",
         "endpoint": "https://service.example/api",
         "access_key_id": "id",
         "access_key_secret": "secret",
     }
-    values[field] = " "
+    values[field] = empty_value
     with pytest.raises(ValidationError):
         MaxComputeConfig(**values)
 

--- a/datus-maxcompute/tests/unit/test_config.py
+++ b/datus-maxcompute/tests/unit/test_config.py
@@ -1,0 +1,58 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+import pytest
+from pydantic import ValidationError
+
+from datus_maxcompute import MaxComputeConfig
+
+
+def test_config_accepts_database_alias_and_hides_secrets():
+    config = MaxComputeConfig(
+        database="project_a",
+        endpoint="https://service.example/api",
+        access_key_id="id-value",
+        access_key_secret="secret-value",
+    )
+
+    assert config.project == "project_a"
+    assert config.namespace_mode == "auto"
+    assert config.query_timeout_seconds == 600
+    assert "secret-value" not in repr(config)
+    assert "id-value" not in repr(config)
+
+
+def test_config_accepts_schema_alias():
+    config = MaxComputeConfig(
+        project="project_a",
+        endpoint="https://service.example/api",
+        access_key_id="id",
+        access_key_secret="secret",
+        schema="analytics",
+    )
+
+    assert config.schema_name == "analytics"
+
+
+@pytest.mark.parametrize("field", ["project", "endpoint"])
+def test_config_rejects_empty_required_strings(field):
+    values = {
+        "project": "project_a",
+        "endpoint": "https://service.example/api",
+        "access_key_id": "id",
+        "access_key_secret": "secret",
+    }
+    values[field] = " "
+    with pytest.raises(ValidationError):
+        MaxComputeConfig(**values)
+
+
+def test_config_rejects_unknown_namespace_mode():
+    with pytest.raises(ValidationError):
+        MaxComputeConfig(
+            project="project_a",
+            endpoint="https://service.example/api",
+            access_key_id="id",
+            access_key_secret="secret",
+            namespace_mode="guess",
+        )

--- a/datus-maxcompute/tests/unit/test_connector.py
+++ b/datus-maxcompute/tests/unit/test_connector.py
@@ -167,6 +167,49 @@ def test_csv_iterator_limits_tunnel_download(config):
     reader.read_all.assert_called_once_with(count=1)
 
 
+def test_metadata_show_reads_task_result_without_tunnel(config):
+    connector, odps = make_connector(config)
+    instance, _ = make_instance()
+    instance.get_task_result.return_value = "\norders\ncustomers\n\n"
+    odps.run_sql.return_value = instance
+
+    result = connector.execute({"sql_query": "SHOW TABLES", "result_format": "list"})
+
+    assert result.success
+    assert result.sql_return == [{"result": "orders"}, {"result": "customers"}]
+    assert result.row_count == 2
+    instance.get_task_result.assert_called_once_with()
+    instance.open_reader.assert_not_called()
+
+
+def test_empty_metadata_show_returns_typed_empty_result(config):
+    connector, odps = make_connector(config)
+    instance, _ = make_instance()
+    instance.get_task_result.return_value = "\n"
+    odps.run_sql.return_value = instance
+
+    result = connector.execute_query("SHOW TABLES", result_format="arrow")
+
+    assert result.success
+    assert result.sql_return.num_rows == 0
+    assert result.sql_return.schema.field("result").type == pa.string()
+    instance.open_reader.assert_not_called()
+
+
+def test_explain_preserves_multiline_task_result(config):
+    connector, odps = make_connector(config)
+    instance, _ = make_instance()
+    instance.get_task_result.return_value = "\njob0 is root job\n\n  VALUES: _c0 : {1}\n"
+    odps.run_sql.return_value = instance
+
+    result = connector.execute({"sql_query": "EXPLAIN SELECT 1", "result_format": "list"})
+
+    assert result.success
+    assert result.sql_return == [{"result": "job0 is root job\n\n  VALUES: _c0 : {1}"}]
+    assert result.row_count == 1
+    instance.open_reader.assert_not_called()
+
+
 def test_two_level_query_uses_false_hint_and_no_schema(config):
     explicit = config.model_copy(update={"namespace_mode": "two_level"})
     connector, odps = make_connector(explicit)
@@ -236,20 +279,33 @@ def test_lists_objects_by_type(config):
     ]
 
     assert connector.get_tables(schema_name="analytics") == ["project_a.orders"]
-    assert connector.get_views(database_name="project_a") == ["default.orders_view"]
+    assert connector.get_views(database_name="project_a") == ["project_a.default.orders_view"]
     assert connector.get_materialized_views() == ["project_a.default.orders_mv"]
 
 
-def test_listed_names_only_include_namespace_levels_omitted_by_caller(config):
+def test_listed_names_round_trip_across_context_shapes(config):
     connector, odps = make_connector(config)
     odps.list_tables.return_value = [
         SimpleNamespace(name="orders", type=SimpleNamespace(value="MANAGED_TABLE")),
     ]
 
     assert connector.get_tables() == ["project_a.default.orders"]
-    assert connector.get_tables(database_name="project_a") == ["default.orders"]
+    assert connector.get_tables(database_name="project_a") == ["project_a.default.orders"]
     assert connector.get_tables(schema_name="analytics") == ["project_a.orders"]
     assert connector.get_tables(database_name="project_a", schema_name="analytics") == ["orders"]
+    assert connector.full_name(table_name="project_a.default.orders") == "`project_a`.`default`.`orders`"
+    assert (
+        connector.full_name(database_name="project_a", table_name="project_a.default.orders")
+        == "`project_a`.`default`.`orders`"
+    )
+    assert (
+        connector.full_name(schema_name="analytics", table_name="project_a.orders")
+        == "`project_a`.`analytics`.`orders`"
+    )
+    assert (
+        connector.full_name(database_name="project_a", schema_name="analytics", table_name="orders")
+        == "`project_a`.`analytics`.`orders`"
+    )
 
 
 def test_get_schema_includes_partition_columns(config):

--- a/datus-maxcompute/tests/unit/test_connector.py
+++ b/datus-maxcompute/tests/unit/test_connector.py
@@ -7,10 +7,12 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 import pytest
 from odps.errors import InternalServerError, WaitTimeoutError
+from odps.rest import RestClient
+from pydantic import BaseModel
 
 from datus_db_core import DatusDbException
 from datus_maxcompute import MaxComputeConfig, MaxComputeConnector
-from datus_maxcompute.connector import _TimeoutRestClient
+from datus_maxcompute.connector import _coerce_config, _TimeoutRestClient
 
 
 @pytest.fixture
@@ -112,6 +114,47 @@ def test_connector_configures_local_rest_request_timeout(config):
     assert kwargs["rest_client_kwargs"] == {"timeout_seconds": 30}
 
 
+def test_timeout_rest_client_injects_default_and_preserves_explicit_timeout():
+    client = object.__new__(_TimeoutRestClient)
+    client._request_timeout = (30, 30)
+    with patch.object(RestClient, "request", return_value="ok") as request:
+        assert client.request("https://service.example", "GET") == "ok"
+        request.assert_called_once_with(
+            "https://service.example",
+            "GET",
+            stream=False,
+            timeout=(30, 30),
+        )
+
+        request.reset_mock()
+        client.request("https://service.example", "POST", timeout=(5, 5))
+        request.assert_called_once_with(
+            "https://service.example",
+            "POST",
+            stream=False,
+            timeout=(5, 5),
+        )
+
+
+def test_generic_pydantic_config_ignores_inherited_schema_method():
+    class GenericConfig(BaseModel):
+        project: str
+        endpoint: str
+        access_key_id: str
+        access_key_secret: str
+
+    parsed = _coerce_config(
+        GenericConfig(
+            project="project_a",
+            endpoint="https://service.example/api",
+            access_key_id="id",
+            access_key_secret="secret",
+        )
+    )
+
+    assert parsed.schema_name is None
+
+
 def test_csv_iterator_limits_tunnel_download(config):
     connector, odps = make_connector(config)
     instance, reader = make_instance(pa.table({"id": [1, 2]}))
@@ -192,9 +235,21 @@ def test_lists_objects_by_type(config):
         SimpleNamespace(name="orders_mv", type=SimpleNamespace(value="MATERIALIZED_VIEW")),
     ]
 
-    assert connector.get_tables(schema_name="analytics") == ["orders"]
-    assert connector.get_views(schema_name="analytics") == ["orders_view"]
-    assert connector.get_materialized_views(schema_name="analytics") == ["orders_mv"]
+    assert connector.get_tables(schema_name="analytics") == ["project_a.orders"]
+    assert connector.get_views(database_name="project_a") == ["default.orders_view"]
+    assert connector.get_materialized_views() == ["project_a.default.orders_mv"]
+
+
+def test_listed_names_only_include_namespace_levels_omitted_by_caller(config):
+    connector, odps = make_connector(config)
+    odps.list_tables.return_value = [
+        SimpleNamespace(name="orders", type=SimpleNamespace(value="MANAGED_TABLE")),
+    ]
+
+    assert connector.get_tables() == ["project_a.default.orders"]
+    assert connector.get_tables(database_name="project_a") == ["default.orders"]
+    assert connector.get_tables(schema_name="analytics") == ["project_a.orders"]
+    assert connector.get_tables(database_name="project_a", schema_name="analytics") == ["orders"]
 
 
 def test_get_schema_includes_partition_columns(config):

--- a/datus-maxcompute/tests/unit/test_connector.py
+++ b/datus-maxcompute/tests/unit/test_connector.py
@@ -1,0 +1,224 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pytest
+from odps.errors import InternalServerError, WaitTimeoutError
+
+from datus_db_core import DatusDbException
+from datus_maxcompute import MaxComputeConfig, MaxComputeConnector
+from datus_maxcompute.connector import _TimeoutRestClient
+
+
+@pytest.fixture
+def config():
+    return MaxComputeConfig(
+        project="project_a",
+        endpoint="https://service.example/api",
+        access_key_id="id",
+        access_key_secret="secret",
+        query_timeout_seconds=17,
+    )
+
+
+def make_connector(config, list_schemas=None):
+    odps = MagicMock()
+    odps.list_schemas.return_value = [SimpleNamespace(name="default")] if list_schemas is None else list_schemas
+    with patch("datus_maxcompute.connector.ODPS", return_value=odps):
+        connector = MaxComputeConnector(config)
+    return connector, odps
+
+
+def make_instance(table=None):
+    instance = MagicMock()
+    instance.id = "instance-123"
+    reader = MagicMock()
+    reader.__enter__.return_value = reader
+    reader.__exit__.return_value = False
+    if table is None:
+        table = pa.table({"id": [1, 2], "name": ["a", "b"]})
+    reader.read_all.return_value = table
+    instance.open_reader.return_value = reader
+    return instance, reader
+
+
+def test_auto_detects_and_caches_three_level(config):
+    connector, odps = make_connector(config)
+
+    assert connector.namespace_mode == "three_level"
+    assert connector.get_effective_capabilities() == {"database", "schema"}
+    assert connector.schema_name == "default"
+    assert connector.namespace_mode == "three_level"
+    odps.list_schemas.assert_called_once_with(project="project_a")
+
+
+def test_auto_detects_two_level_only_for_exact_service_error(config):
+    error = InternalServerError("Project project_a is not 3-tier model project.")
+    connector, odps = make_connector(config, list_schemas=error)
+    odps.list_schemas.side_effect = error
+
+    assert connector.namespace_mode == "two_level"
+    assert connector.get_effective_capabilities() == {"database"}
+    assert connector.schema_name == ""
+
+
+def test_auto_detection_propagates_other_internal_errors(config):
+    connector, odps = make_connector(config)
+    odps.list_schemas.side_effect = InternalServerError("temporary internal failure")
+
+    with pytest.raises(InternalServerError, match="temporary"):
+        _ = connector.namespace_mode
+
+
+def test_explicit_mode_does_not_probe_schema_api(config):
+    explicit = config.model_copy(update={"namespace_mode": "two_level"})
+    connector, odps = make_connector(explicit)
+
+    assert connector.namespace_mode == "two_level"
+    odps.list_schemas.assert_not_called()
+
+
+def test_query_uses_schema_hint_and_unlimited_arrow_tunnel(config):
+    connector, odps = make_connector(config)
+    instance, reader = make_instance()
+    odps.run_sql.return_value = instance
+
+    result = connector.execute_query("SELECT 1", result_format="list")
+
+    assert result.success
+    assert result.sql_return == [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+    assert result.row_count == 2
+    odps.run_sql.assert_called_once_with(
+        "SELECT 1",
+        project="project_a",
+        default_schema="default",
+        hints={"odps.namespace.schema": "true"},
+    )
+    instance.wait_for_success.assert_called_once_with(timeout=17)
+    reader_call = instance.open_reader.call_args.kwargs
+    assert reader_call == {"tunnel": True, "arrow": True, "limit": False, "timeout": 30}
+    reader.read_all.assert_called_once_with(count=None)
+
+
+def test_connector_configures_local_rest_request_timeout(config):
+    with patch("datus_maxcompute.connector.ODPS") as odps_constructor:
+        MaxComputeConnector(config)
+
+    kwargs = odps_constructor.call_args.kwargs
+    assert kwargs["rest_client_cls"] is _TimeoutRestClient
+    assert kwargs["rest_client_kwargs"] == {"timeout_seconds": 30}
+
+
+def test_csv_iterator_limits_tunnel_download(config):
+    connector, odps = make_connector(config)
+    instance, reader = make_instance(pa.table({"id": [1, 2]}))
+    reader.read_all.return_value = pa.table({"id": [1]})
+    odps.run_sql.return_value = instance
+
+    rows = list(connector.execute_csv_iterator("SELECT id FROM orders", max_rows=1))
+
+    assert rows == [("id",), ("1",)]
+    reader.read_all.assert_called_once_with(count=1)
+
+
+def test_two_level_query_uses_false_hint_and_no_schema(config):
+    explicit = config.model_copy(update={"namespace_mode": "two_level"})
+    connector, odps = make_connector(explicit)
+    instance, _ = make_instance()
+    odps.run_sql.return_value = instance
+
+    result = connector.execute_query("SELECT 1", result_format="arrow")
+
+    assert result.success
+    odps.run_sql.assert_called_once_with(
+        "SELECT 1",
+        project="project_a",
+        hints={"odps.namespace.schema": "false"},
+    )
+
+
+def test_timeout_stops_instance(config):
+    connector, odps = make_connector(config)
+    instance, _ = make_instance()
+    instance.wait_for_success.side_effect = WaitTimeoutError("too slow")
+    odps.run_sql.return_value = instance
+
+    result = connector.execute_ddl("CREATE TABLE t (id BIGINT)")
+
+    assert not result.success
+    assert "timed out" in result.error.lower()
+    instance.stop.assert_called_once()
+
+
+def test_non_query_returns_instance_id_without_fake_row_count(config):
+    connector, odps = make_connector(config)
+    instance, _ = make_instance()
+    odps.run_sql.return_value = instance
+
+    result = connector.execute_insert("INSERT INTO t VALUES (1)")
+
+    assert result.success
+    assert result.sql_return == "instance-123"
+    assert result.row_count is None
+
+
+def test_rejects_cross_project_and_schema_on_two_level(config):
+    explicit = config.model_copy(update={"namespace_mode": "two_level"})
+    connector, _ = make_connector(explicit)
+
+    with pytest.raises(DatusDbException, match="cross-project"):
+        connector.get_tables(database_name="other_project")
+    with pytest.raises(DatusDbException, match="has no schema"):
+        connector.get_tables(schema_name="analytics")
+
+
+def test_full_name_follows_detected_namespace(config):
+    three_level, _ = make_connector(config)
+    two_level, _ = make_connector(config.model_copy(update={"namespace_mode": "two_level"}))
+
+    assert three_level.full_name(table_name="orders") == "`project_a`.`default`.`orders`"
+    assert two_level.full_name(table_name="orders") == "`project_a`.`orders`"
+    assert three_level.full_name(table_name="project_a.analytics.orders") == "`project_a`.`analytics`.`orders`"
+
+
+def test_lists_objects_by_type(config):
+    connector, odps = make_connector(config)
+    odps.list_tables.return_value = [
+        SimpleNamespace(name="orders", type=SimpleNamespace(value="MANAGED_TABLE")),
+        SimpleNamespace(name="orders_view", type=SimpleNamespace(value="VIRTUAL_VIEW")),
+        SimpleNamespace(name="orders_mv", type=SimpleNamespace(value="MATERIALIZED_VIEW")),
+    ]
+
+    assert connector.get_tables(schema_name="analytics") == ["orders"]
+    assert connector.get_views(schema_name="analytics") == ["orders_view"]
+    assert connector.get_materialized_views(schema_name="analytics") == ["orders_mv"]
+
+
+def test_get_schema_includes_partition_columns(config):
+    connector, odps = make_connector(config)
+    column = SimpleNamespace(name="id", type="bigint", comment="identifier", nullable=False)
+    partition = SimpleNamespace(name="ds", type="string", comment=None, nullable=True)
+    table = MagicMock()
+    table.table_schema.columns = [column, partition]
+    table.table_schema.partitions = [partition]
+    odps.get_table.return_value = table
+
+    result = connector.get_schema(schema_name="analytics", table_name="orders")
+
+    assert result[0]["name"] == "id"
+    assert result[0]["nullable"] is False
+    assert result[1]["is_partition"] is True
+    table.reload.assert_called_once()
+
+
+def test_rejects_transactions_before_submission(config):
+    connector, odps = make_connector(config)
+
+    result = connector.execute_ddl("BEGIN TRANSACTION")
+
+    assert not result.success
+    assert "does not support transactions" in result.error
+    odps.run_sql.assert_not_called()

--- a/datus-maxcompute/tests/unit/test_handlers.py
+++ b/datus-maxcompute/tests/unit/test_handlers.py
@@ -40,6 +40,31 @@ def test_uri_reads_adapter_fields_from_agent_extra():
     assert resolve_maxcompute_context(config, uri) == ("maxcompute", "", "project_a", "")
 
 
+def test_uri_strips_endpoint_query_and_fragment():
+    config = SimpleNamespace(
+        project="project_a",
+        endpoint="https://service.example/api?token=sensitive#fragment",
+        schema_name="",
+    )
+
+    uri = build_maxcompute_uri(config)
+
+    assert "sensitive" not in uri
+    assert "fragment" not in uri
+    assert "https%3A%2F%2Fservice.example%2Fapi" in uri
+
+
+def test_uri_rejects_endpoint_userinfo():
+    config = SimpleNamespace(
+        project="project_a",
+        endpoint="https://id:secret@service.example/api",
+        schema_name="",
+    )
+
+    with pytest.raises(ValueError, match="user information"):
+        build_maxcompute_uri(config)
+
+
 @pytest.mark.parametrize(
     ("identifier", "expected"),
     [
@@ -57,3 +82,19 @@ def test_parse_identifier_supports_both_namespace_models(identifier, expected):
 def test_parse_identifier_rejects_more_than_three_levels():
     with pytest.raises(ValueError, match="Invalid MaxCompute"):
         parse_maxcompute_identifier("catalog.project.schema.table")
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "project..orders",
+        ".orders",
+        "project.",
+        "`project.orders",
+        '"project.orders',
+        "[project.orders",
+    ],
+)
+def test_parse_identifier_rejects_malformed_components(identifier):
+    with pytest.raises(ValueError, match="Invalid MaxCompute"):
+        parse_maxcompute_identifier(identifier)

--- a/datus-maxcompute/tests/unit/test_handlers.py
+++ b/datus-maxcompute/tests/unit/test_handlers.py
@@ -1,0 +1,59 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+from types import SimpleNamespace
+
+import pytest
+
+from datus_maxcompute.handlers import (
+    build_maxcompute_uri,
+    parse_maxcompute_identifier,
+    resolve_maxcompute_context,
+)
+
+
+def test_uri_is_credential_free_and_preserves_context():
+    config = SimpleNamespace(
+        project="project_a",
+        endpoint="https://service.example/api",
+        schema_name="analytics",
+        access_key_id="sensitive-id",
+        access_key_secret="sensitive-secret",
+    )
+
+    uri = build_maxcompute_uri(config)
+
+    assert "sensitive" not in uri
+    assert resolve_maxcompute_context(config, uri) == ("maxcompute", "", "project_a", "analytics")
+
+
+def test_uri_reads_adapter_fields_from_agent_extra():
+    config = SimpleNamespace(
+        database="project_a",
+        schema="",
+        extra={"endpoint": "https://service.example/api"},
+    )
+
+    uri = build_maxcompute_uri(config)
+
+    assert "service.example" in uri
+    assert resolve_maxcompute_context(config, uri) == ("maxcompute", "", "project_a", "")
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("orders", ("", "", "orders")),
+        ("project_a.orders", ("project_a", "", "orders")),
+        ("project_a.analytics.orders", ("project_a", "analytics", "orders")),
+        ("`project.a`.`analytics`.`orders`", ("project.a", "analytics", "orders")),
+    ],
+)
+def test_parse_identifier_supports_both_namespace_models(identifier, expected):
+    parsed = parse_maxcompute_identifier(identifier)
+    assert (parsed["database_name"], parsed["schema_name"], parsed["table_name"]) == expected
+
+
+def test_parse_identifier_rejects_more_than_three_levels():
+    with pytest.raises(ValueError, match="Invalid MaxCompute"):
+        parse_maxcompute_identifier("catalog.project.schema.table")

--- a/datus-maxcompute/tests/unit/test_registration.py
+++ b/datus-maxcompute/tests/unit/test_registration.py
@@ -25,3 +25,33 @@ def test_registration_exposes_generic_hooks():
         ConnectorRegistry._capabilities = saved_capabilities
         ConnectorRegistry._uri_builders = saved_uri_builders
         ConnectorRegistry._context_resolvers = saved_context_resolvers
+
+
+def test_register_handlers_updates_adapter_metadata_hooks():
+    saved_connectors = ConnectorRegistry._connectors.copy()
+    saved_metadata = ConnectorRegistry._metadata.copy()
+    saved_capabilities = ConnectorRegistry._capabilities.copy()
+    saved_uri_builders = ConnectorRegistry._uri_builders.copy()
+    saved_context_resolvers = ConnectorRegistry._context_resolvers.copy()
+
+    def parse_identifier(value):
+        return {"table_name": value}
+
+    try:
+        register()
+        ConnectorRegistry.register_handlers(
+            "maxcompute",
+            parser_dialect="odps",
+            identifier_parser=parse_identifier,
+            sql_generation_notes="custom notes",
+        )
+
+        assert ConnectorRegistry.get_parser_dialect("maxcompute") == "odps"
+        assert ConnectorRegistry.get_identifier_parser("maxcompute") is parse_identifier
+        assert ConnectorRegistry.get_sql_generation_notes("maxcompute") == "custom notes"
+    finally:
+        ConnectorRegistry._connectors = saved_connectors
+        ConnectorRegistry._metadata = saved_metadata
+        ConnectorRegistry._capabilities = saved_capabilities
+        ConnectorRegistry._uri_builders = saved_uri_builders
+        ConnectorRegistry._context_resolvers = saved_context_resolvers

--- a/datus-maxcompute/tests/unit/test_registration.py
+++ b/datus-maxcompute/tests/unit/test_registration.py
@@ -1,0 +1,27 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+from datus_db_core.registry import ConnectorRegistry
+from datus_maxcompute import register
+
+
+def test_registration_exposes_generic_hooks():
+    saved_connectors = ConnectorRegistry._connectors.copy()
+    saved_metadata = ConnectorRegistry._metadata.copy()
+    saved_capabilities = ConnectorRegistry._capabilities.copy()
+    saved_uri_builders = ConnectorRegistry._uri_builders.copy()
+    saved_context_resolvers = ConnectorRegistry._context_resolvers.copy()
+    try:
+        register()
+        assert ConnectorRegistry.get_capabilities("maxcompute") == {"database", "schema"}
+        assert ConnectorRegistry.get_parser_dialect("maxcompute") == "hive"
+        assert ConnectorRegistry.get_identifier_parser("maxcompute") is not None
+        assert "project.schema.table" in ConnectorRegistry.get_sql_generation_notes("maxcompute")
+        assert ConnectorRegistry.get_uri_builder("maxcompute") is not None
+        assert ConnectorRegistry.get_context_resolver("maxcompute") is not None
+    finally:
+        ConnectorRegistry._connectors = saved_connectors
+        ConnectorRegistry._metadata = saved_metadata
+        ConnectorRegistry._capabilities = saved_capabilities
+        ConnectorRegistry._uri_builders = saved_uri_builders
+        ConnectorRegistry._context_resolvers = saved_context_resolvers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.12"
 license = {file = "LICENSE"}
 
 [tool.uv.workspace]
-members = ["datus-db-core", "datus-mysql", "datus-postgresql", "datus-sqlalchemy", "datus-starrocks", "datus-snowflake", "datus-clickzetta", "datus-clickhouse", "datus-hive", "datus-redshift", "datus-spark", "datus-trino", "datus-greenplum"]
+members = ["datus-db-core", "datus-mysql", "datus-postgresql", "datus-sqlalchemy", "datus-starrocks", "datus-snowflake", "datus-clickzetta", "datus-clickhouse", "datus-hive", "datus-redshift", "datus-spark", "datus-trino", "datus-greenplum", "datus-maxcompute"]
 
 [dependency-groups]
 
@@ -62,4 +62,9 @@ ignore = [
 max-complexity = 10
 
 [tool.ruff.lint.isort]
-known-first-party = ["datus_db_core", "datus_sqlalchemy", "datus_mysql", "datus_postgresql", "datus_redshift", "datus_snowflake", "datus_clickhouse", "datus_clickzetta", "datus_starrocks", "datus_trino", "datus_spark", "datus_hive", "datus_greenplum"]
+known-first-party = ["datus_db_core", "datus_sqlalchemy", "datus_mysql", "datus_postgresql", "datus_redshift", "datus_snowflake", "datus_clickhouse", "datus_clickzetta", "datus_starrocks", "datus_trino", "datus_spark", "datus_hive", "datus_greenplum", "datus_maxcompute"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that require external database services",
+]


### PR DESCRIPTION
## Why

MaxCompute supports both legacy `project.table` projects and schema-enabled
`project.schema.table` projects. Datus needs one adapter that can detect and
handle both models without database-specific branches in consumers.

## What changed

- add the `datus-maxcompute` adapter backed by the official PyODPS SDK
- detect two-level and three-level projects from the schema API and cache the result per connector
- apply the correct `odps.namespace.schema` hint to every SQL job
- support query and DDL execution, Arrow/Pandas/list/CSV results, tables, views, materialized views, DDL, columns, partitions, and samples
- add connector-local REST request timeouts and bounded Tunnel reads for `execute_csv_iterator`
- extend `datus-db-core` with backward-compatible adapter hooks for parser dialects, identifier parsing, SQL-generation notes, and instance-level capabilities
- add unit-test, release-workflow, and scheduled/manual cloud-test integration

## Compatibility

Existing adapters keep their registered static capability behavior. Only
connectors that override `get_effective_capabilities()` expose
configuration-dependent namespace support.

`datus-db-core` is bumped to `0.1.5`; `datus-maxcompute 0.1.0` depends on that
version or newer.

## Validation

- `290 passed` — MaxCompute and db-core unit tests
- `2 passed` — live cloud integration against:
  - two-level project `datus_maxcompute_ci_0725`
  - three-level project `datus_maxcompute_ci_3_layer`
- cloud coverage includes namespace detection, create/insert/query, bounded Tunnel preview reads, metadata/DDL, and cleanup
- Ruff check and format passed
- wheel and sdist builds passed for `datus-db-core 0.1.5` and `datus-maxcompute 0.1.0`
- no test tables remained in either cloud project

## Release order

1. publish `datus-db-core 0.1.5`
2. publish `datus-maxcompute 0.1.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Datus MaxCompute adapter with MaxCompute URI handling, namespace auto-detection, SQL execution, metadata discovery, sampling, and DDL support.
  * Extended release workflows to include the MaxCompute adapter as a selectable package.
* **Documentation**
  * Documented the Datus MaxCompute adapter setup, configuration, and namespace behavior.
* **Bug Fixes**
  * Improved dialect parsing and capability resolution to respect adapter registrations.
* **Tests**
  * Added unit tests for registry, dialect parsing, and MaxCompute behavior, plus cloud integration tests for end-to-end CRUD and metadata.
* **Chores**
  * Added scheduled cloud CI coverage and updated test/package CI to include MaxCompute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->