### PR TITLE
[UT] Trino: regression tests for http_scheme in connect_args (follow-up to #80)

### DIFF
--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -60,7 +60,7 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
         )
 
         self._verify_ssl = config.verify
-
+        self._http_scheme = config.http_scheme
         self.dialect = TRINO_DIALECT
         self._default_catalog = config.catalog
         self._default_schema = config.schema_name
@@ -83,7 +83,7 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
                 pool_timeout=self.timeout_seconds,
                 pool_recycle=3600,
                 pool_pre_ping=True,
-                connect_args={"verify": self._verify_ssl},
+                connect_args={"verify": self._verify_ssl,"http_scheme": self._http_scheme},
             )
             self._owns_engine = True
             return self.engine

--- a/datus-trino/datus_trino/connector.py
+++ b/datus-trino/datus_trino/connector.py
@@ -83,7 +83,7 @@ class TrinoConnector(SQLAlchemyConnector, CatalogSupportMixin, MigrationTargetMi
                 pool_timeout=self.timeout_seconds,
                 pool_recycle=3600,
                 pool_pre_ping=True,
-                connect_args={"verify": self._verify_ssl,"http_scheme": self._http_scheme},
+                connect_args={"verify": self._verify_ssl, "http_scheme": self._http_scheme},
             )
             self._owns_engine = True
             return self.engine

--- a/datus-trino/tests/unit/test_connector_unit.py
+++ b/datus-trino/tests/unit/test_connector_unit.py
@@ -140,6 +140,43 @@ def test_connector_connection_string_without_password():
         assert ":@" not in conn_string or "user:@" not in conn_string
 
 
+# ==================== _ensure_engine() Tests ====================
+
+
+def test_ensure_engine_forwards_http_scheme_and_verify():
+    """Regression: the Trino SQLAlchemy dialect ignores ?http_scheme=... in the URL,
+    so _ensure_engine() must forward the scheme via connect_args (see PR #80)."""
+    config = TrinoConfig(
+        host="localhost",
+        port=8443,  # non-standard TLS port: 443 may infer HTTPS and mask a broken impl
+        username="user",
+        http_scheme="https",
+        verify=False,
+    )
+    connector = TrinoConnector(config)
+
+    with patch("datus_trino.connector.create_engine") as mock_create_engine:
+        engine = connector._ensure_engine()
+
+        mock_create_engine.assert_called_once()
+        connect_args = mock_create_engine.call_args.kwargs["connect_args"]
+        assert connect_args == {"verify": False, "http_scheme": "https"}
+        assert engine is mock_create_engine.return_value
+        assert connector._owns_engine is True
+
+
+def test_ensure_engine_default_http_scheme():
+    """Default config (http, verify=True) is forwarded through connect_args unchanged."""
+    config = TrinoConfig(host="localhost", port=8080, username="user")
+    connector = TrinoConnector(config)
+
+    with patch("datus_trino.connector.create_engine") as mock_create_engine:
+        connector._ensure_engine()
+
+        connect_args = mock_create_engine.call_args.kwargs["connect_args"]
+        assert connect_args == {"verify": True, "http_scheme": "http"}
+
+
 # ==================== Catalog Functionality Unit Tests ====================
 
 


### PR DESCRIPTION
Follow-up to #80, addressing the review comment there:

- Fix `connect_args` dict formatting (missing space after comma, which broke the format-check workflow).
- Add regression tests exercising `_ensure_engine()` with a mocked `create_engine()`, asserting `connect_args == {"verify": False, "http_scheme": "https"}`. Uses non-standard TLS port 8443 so an implementation relying on port-based HTTPS inference cannot pass. Also covers the default `http` / `verify=True` path.

Note: this branch is based on the #80 head; once #80 is merged the diff reduces to the follow-up commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)