### PR TITLE
[BugFix] Preserve adapter SQL failure details

### DIFF
--- a/datus-clickzetta/datus_clickzetta/connector.py
+++ b/datus-clickzetta/datus_clickzetta/connector.py
@@ -35,6 +35,7 @@ else:
 
 logger = get_logger(__name__)
 
+_SQL_PREVIEW_CHARS = 50
 _DEFAULT_HINTS: Dict[str, Any] = {
     "sdk.job.timeout": 300,
     "query_tag": "Query from Datus Agent",
@@ -47,6 +48,30 @@ _DEFAULT_HINTS: Dict[str, Any] = {
     "cz.sql.index.prewhere.enabled": "true",
     "cz.storage.parquet.enable.io.prefetch": "false",
 }
+
+
+def _log_sql_exception(event: str, sql: str, exc: Exception) -> None:
+    """Log a SQL failure with a bounded preview instead of the full statement."""
+    statement = sql or ""
+    normalized_sql = " ".join(statement.split())
+    sql_preview = normalized_sql[:_SQL_PREVIEW_CHARS]
+    if len(normalized_sql) > _SQL_PREVIEW_CHARS:
+        sql_preview += "..."
+    driver_error = str(getattr(exc, "orig", None) or exc) or type(exc).__name__
+    if statement:
+        driver_error = driver_error.replace(statement, "<sql>")
+    if normalized_sql and normalized_sql != statement:
+        driver_error = driver_error.replace(normalized_sql, "<sql>")
+    safe_exception = RuntimeError(driver_error)
+    logger.error(
+        "%s; sql_preview=%r; sql_chars=%d; error_type=%s; error=%s",
+        event,
+        sql_preview,
+        len(statement),
+        type(exc).__name__,
+        driver_error,
+        exc_info=(type(safe_exception), safe_exception, exc.__traceback__),
+    )
 
 
 def _safe_escape(value: Optional[str]) -> str:
@@ -236,13 +261,7 @@ class ClickZettaConnector:
     ):
         if isinstance(exc, DatusDbException):
             raise exc
-        logger.error(
-            "ClickZetta SQL execution failed; sql=%s; error_type=%s; error=%r",
-            sql,
-            type(exc).__name__,
-            exc,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
+        _log_sql_exception("ClickZetta SQL execution failed", sql, exc)
         raise DatusDbException(error_code, message_args={"error_message": str(exc), "sql": sql}) from exc
 
     def _run_query(self, sql: str) -> pd.DataFrame:
@@ -489,13 +508,7 @@ class ClickZettaConnector:
         except DatusDbException:
             raise
         except Exception as e:
-            logger.error(
-                "ClickZetta DataFrame query failed; sql=%s; error_type=%s; error=%r",
-                sql,
-                type(e).__name__,
-                e,
-                exc_info=(type(e), e, e.__traceback__),
-            )
+            _log_sql_exception("ClickZetta DataFrame query failed", sql, e)
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute query to DataFrame: {str(e)}",
@@ -512,13 +525,7 @@ class ClickZettaConnector:
         except DatusDbException:
             raise
         except Exception as e:
-            logger.error(
-                "ClickZetta dictionary query failed; sql=%s; error_type=%s; error=%r",
-                sql,
-                type(e).__name__,
-                e,
-                exc_info=(type(e), e, e.__traceback__),
-            )
+            _log_sql_exception("ClickZetta dictionary query failed", sql, e)
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute query to dict: {str(e)}",
@@ -565,13 +572,7 @@ class ClickZettaConnector:
         except DatusDbException:
             raise
         except Exception as e:
-            logger.error(
-                "ClickZetta Arrow query failed; sql=%s; error_type=%s; error=%r",
-                sql,
-                type(e).__name__,
-                e,
-                exc_info=(type(e), e, e.__traceback__),
-            )
+            _log_sql_exception("ClickZetta Arrow query failed", sql, e)
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute Arrow query: {str(e)}",

--- a/datus-clickzetta/datus_clickzetta/connector.py
+++ b/datus-clickzetta/datus_clickzetta/connector.py
@@ -236,6 +236,13 @@ class ClickZettaConnector:
     ):
         if isinstance(exc, DatusDbException):
             raise exc
+        logger.error(
+            "ClickZetta SQL execution failed; sql=%s; error_type=%s; error=%r",
+            sql,
+            type(exc).__name__,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
         raise DatusDbException(error_code, message_args={"error_message": str(exc), "sql": sql}) from exc
 
     def _run_query(self, sql: str) -> pd.DataFrame:
@@ -479,8 +486,16 @@ class ClickZettaConnector:
             if max_rows is not None and len(df) > max_rows:
                 df = df.head(max_rows)
             return df
+        except DatusDbException:
+            raise
         except Exception as e:
-            logger.error(f"Error executing query to DataFrame: {sql}, error: {str(e)}")
+            logger.error(
+                "ClickZetta DataFrame query failed; sql=%s; error_type=%s; error=%r",
+                sql,
+                type(e).__name__,
+                e,
+                exc_info=(type(e), e, e.__traceback__),
+            )
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute query to DataFrame: {str(e)}",
@@ -494,8 +509,16 @@ class ClickZettaConnector:
                 return []
             # Convert DataFrame to list of dictionaries with records orientation
             return df.to_dict(orient="records")
+        except DatusDbException:
+            raise
         except Exception as e:
-            logger.error(f"Error executing query to dict: {sql}, error: {str(e)}")
+            logger.error(
+                "ClickZetta dictionary query failed; sql=%s; error_type=%s; error=%r",
+                sql,
+                type(e).__name__,
+                e,
+                exc_info=(type(e), e, e.__traceback__),
+            )
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute query to dict: {str(e)}",
@@ -539,8 +562,16 @@ class ClickZettaConnector:
                 row_count=len(df),
                 result_format="arrow",
             )
+        except DatusDbException:
+            raise
         except Exception as e:
-            logger.error(f"Error executing Arrow query: {sql}, error: {str(e)}")
+            logger.error(
+                "ClickZetta Arrow query failed; sql=%s; error_type=%s; error=%r",
+                sql,
+                type(e).__name__,
+                e,
+                exc_info=(type(e), e, e.__traceback__),
+            )
             raise DatusDbException(
                 code=ErrorCode.DB_EXECUTION_ERROR,
                 message=f"Failed to execute Arrow query: {str(e)}",

--- a/datus-clickzetta/tests/unit/test_utils.py
+++ b/datus-clickzetta/tests/unit/test_utils.py
@@ -98,8 +98,9 @@ class TestUtilityFunctions:
             with pytest.raises(DatusDbException):
                 connector._wrap_exception(exc, "SELECT bad")
 
-        assert "ClickZetta SQL execution failed; sql=SELECT bad" in caplog.text
-        assert caplog.records[-1].exc_info[1] is error
+        assert "ClickZetta SQL execution failed; sql_preview='SELECT bad'; sql_chars=10" in caplog.text
+        assert "query failed" in caplog.text
+        assert caplog.records[-1].exc_info[2] is error.__traceback__
 
     def test_normalize_volume_uri(self):
         """Test volume URI normalization."""

--- a/datus-clickzetta/tests/unit/test_utils.py
+++ b/datus-clickzetta/tests/unit/test_utils.py
@@ -85,6 +85,22 @@ class TestUtilityFunctions:
         count = ClickZettaConnector._extract_row_count(None)
         assert count == 0
 
+    def test_sql_execution_error_logs_original_exception(self, caplog):
+        from datus_clickzetta.connector import ClickZettaConnector
+        from datus_db_core import DatusDbException
+
+        connector = object.__new__(ClickZettaConnector)
+        error = RuntimeError("query failed")
+
+        try:
+            raise error
+        except RuntimeError as exc:
+            with pytest.raises(DatusDbException):
+                connector._wrap_exception(exc, "SELECT bad")
+
+        assert "ClickZetta SQL execution failed; sql=SELECT bad" in caplog.text
+        assert caplog.records[-1].exc_info[1] is error
+
     def test_normalize_volume_uri(self):
         """Test volume URI normalization."""
         from datus_clickzetta.connector import ClickZettaConnector

--- a/datus-maxcompute/datus_maxcompute/connector.py
+++ b/datus-maxcompute/datus_maxcompute/connector.py
@@ -338,6 +338,13 @@ class MaxComputeConnector(BaseSqlConnector):
             table = self._query_arrow(sql, catalog_name, database_name, schema_name)
             return self._query_result(sql, table, result_format)
         except Exception as exc:
+            logger.error(
+                "MaxCompute query execution failed; sql=%s; error_type=%s; error=%r",
+                sql,
+                type(exc).__name__,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
             return ExecuteSQLResult(
                 success=False,
                 error=str(exc),
@@ -384,6 +391,13 @@ class MaxComputeConnector(BaseSqlConnector):
                 result_format="",
             )
         except Exception as exc:
+            logger.error(
+                "MaxCompute SQL execution failed; sql=%s; error_type=%s; error=%r",
+                sql,
+                type(exc).__name__,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
             return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql, result_format="")
 
     @override
@@ -430,6 +444,13 @@ class MaxComputeConnector(BaseSqlConnector):
         try:
             table = self._query_arrow(query, max_rows=max(0, int(max_rows)))
         except Exception as exc:
+            logger.error(
+                "MaxCompute query execution failed; sql=%s; error_type=%s; error=%r",
+                query,
+                type(exc).__name__,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
             raise DatusDbException(ErrorCode.DB_EXECUTION_ERROR, message=str(exc)) from exc
         if with_header:
             yield tuple(table.column_names)

--- a/datus-maxcompute/datus_maxcompute/connector.py
+++ b/datus-maxcompute/datus_maxcompute/connector.py
@@ -39,11 +39,36 @@ else:
 
 logger = get_logger(__name__)
 
+_SQL_PREVIEW_CHARS = 50
 _NOT_THREE_LEVEL_MARKER = "is not 3-tier model project"
 _UNSUPPORTED_SQL_RE = re.compile(
     r"^\s*(?:begin(?:\s+transaction)?|start\s+transaction|commit|rollback|grant|revoke)\b",
     flags=re.IGNORECASE,
 )
+
+
+def _log_sql_exception(event: str, sql: str, exc: Exception) -> None:
+    """Log a SQL failure with a bounded preview instead of the full statement."""
+    statement = sql or ""
+    normalized_sql = " ".join(statement.split())
+    sql_preview = normalized_sql[:_SQL_PREVIEW_CHARS]
+    if len(normalized_sql) > _SQL_PREVIEW_CHARS:
+        sql_preview += "..."
+    driver_error = str(getattr(exc, "orig", None) or exc) or type(exc).__name__
+    if statement:
+        driver_error = driver_error.replace(statement, "<sql>")
+    if normalized_sql and normalized_sql != statement:
+        driver_error = driver_error.replace(normalized_sql, "<sql>")
+    safe_exception = RuntimeError(driver_error)
+    logger.error(
+        "%s; sql_preview=%r; sql_chars=%d; error_type=%s; error=%s",
+        event,
+        sql_preview,
+        len(statement),
+        type(exc).__name__,
+        driver_error,
+        exc_info=(type(safe_exception), safe_exception, exc.__traceback__),
+    )
 
 
 def _secret_value(value: Union[SecretStr, str]) -> str:
@@ -338,13 +363,7 @@ class MaxComputeConnector(BaseSqlConnector):
             table = self._query_arrow(sql, catalog_name, database_name, schema_name)
             return self._query_result(sql, table, result_format)
         except Exception as exc:
-            logger.error(
-                "MaxCompute query execution failed; sql=%s; error_type=%s; error=%r",
-                sql,
-                type(exc).__name__,
-                exc,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+            _log_sql_exception("MaxCompute query execution failed", sql, exc)
             return ExecuteSQLResult(
                 success=False,
                 error=str(exc),
@@ -391,13 +410,7 @@ class MaxComputeConnector(BaseSqlConnector):
                 result_format="",
             )
         except Exception as exc:
-            logger.error(
-                "MaxCompute SQL execution failed; sql=%s; error_type=%s; error=%r",
-                sql,
-                type(exc).__name__,
-                exc,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+            _log_sql_exception("MaxCompute SQL execution failed", sql, exc)
             return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql, result_format="")
 
     @override
@@ -444,13 +457,7 @@ class MaxComputeConnector(BaseSqlConnector):
         try:
             table = self._query_arrow(query, max_rows=max(0, int(max_rows)))
         except Exception as exc:
-            logger.error(
-                "MaxCompute query execution failed; sql=%s; error_type=%s; error=%r",
-                query,
-                type(exc).__name__,
-                exc,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+            _log_sql_exception("MaxCompute query execution failed", query, exc)
             raise DatusDbException(ErrorCode.DB_EXECUTION_ERROR, message=str(exc)) from exc
         if with_header:
             yield tuple(table.column_names)

--- a/datus-maxcompute/tests/unit/test_connector.py
+++ b/datus-maxcompute/tests/unit/test_connector.py
@@ -47,6 +47,18 @@ def make_instance(table=None):
     return instance, reader
 
 
+def test_execute_query_logs_original_exception(config, caplog):
+    connector, _ = make_connector(config)
+    error = RuntimeError("query failed")
+
+    with patch.object(connector, "_query_arrow", side_effect=error):
+        result = connector.execute_query("SELECT bad")
+
+    assert result.success is False
+    assert "MaxCompute query execution failed; sql=SELECT bad" in caplog.text
+    assert caplog.records[-1].exc_info[1] is error
+
+
 def test_auto_detects_and_caches_three_level(config):
     connector, odps = make_connector(config)
 

--- a/datus-maxcompute/tests/unit/test_connector.py
+++ b/datus-maxcompute/tests/unit/test_connector.py
@@ -55,8 +55,9 @@ def test_execute_query_logs_original_exception(config, caplog):
         result = connector.execute_query("SELECT bad")
 
     assert result.success is False
-    assert "MaxCompute query execution failed; sql=SELECT bad" in caplog.text
-    assert caplog.records[-1].exc_info[1] is error
+    assert "MaxCompute query execution failed; sql_preview='SELECT bad'; sql_chars=10" in caplog.text
+    assert "query failed" in caplog.text
+    assert caplog.records[-1].exc_info[2] is error.__traceback__
 
 
 def test_auto_detects_and_caches_three_level(config):

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -62,6 +62,13 @@ def _handle_redshift_exception(e: Exception, sql: str = "") -> DatusDbException:
     Returns:
         DatusDbException with appropriate error code and message
     """
+    logger.error(
+        "Redshift SQL execution failed; sql=%s; error_type=%s; error=%r",
+        sql,
+        type(e).__name__,
+        e,
+        exc_info=(type(e), e, e.__traceback__),
+    )
 
     # Check subclasses before parent classes to ensure correct error mapping.
     # IntegrityError, InternalError, DataError are all subclasses of DatabaseError,

--- a/datus-redshift/datus_redshift/connector.py
+++ b/datus-redshift/datus_redshift/connector.py
@@ -47,6 +47,32 @@ from .config import RedshiftConfig
 # Get a logger instance for this module (for debugging and error messages)
 logger = get_logger(__name__)
 
+_SQL_PREVIEW_CHARS = 50
+
+
+def _log_sql_exception(event: str, sql: str, exc: Exception) -> None:
+    """Log a SQL failure with a bounded preview instead of the full statement."""
+    statement = sql or ""
+    normalized_sql = " ".join(statement.split())
+    sql_preview = normalized_sql[:_SQL_PREVIEW_CHARS]
+    if len(normalized_sql) > _SQL_PREVIEW_CHARS:
+        sql_preview += "..."
+    driver_error = str(getattr(exc, "orig", None) or exc) or type(exc).__name__
+    if statement:
+        driver_error = driver_error.replace(statement, "<sql>")
+    if normalized_sql and normalized_sql != statement:
+        driver_error = driver_error.replace(normalized_sql, "<sql>")
+    safe_exception = RuntimeError(driver_error)
+    logger.error(
+        "%s; sql_preview=%r; sql_chars=%d; error_type=%s; error=%s",
+        event,
+        sql_preview,
+        len(statement),
+        type(exc).__name__,
+        driver_error,
+        exc_info=(type(safe_exception), safe_exception, exc.__traceback__),
+    )
+
 
 def _handle_redshift_exception(e: Exception, sql: str = "") -> DatusDbException:
     """
@@ -62,13 +88,7 @@ def _handle_redshift_exception(e: Exception, sql: str = "") -> DatusDbException:
     Returns:
         DatusDbException with appropriate error code and message
     """
-    logger.error(
-        "Redshift SQL execution failed; sql=%s; error_type=%s; error=%r",
-        sql,
-        type(e).__name__,
-        e,
-        exc_info=(type(e), e, e.__traceback__),
-    )
+    _log_sql_exception("Redshift SQL execution failed", sql, e)
 
     # Check subclasses before parent classes to ensure correct error mapping.
     # IntegrityError, InternalError, DataError are all subclasses of DatabaseError,

--- a/datus-redshift/tests/unit/test_connector_unit.py
+++ b/datus-redshift/tests/unit/test_connector_unit.py
@@ -360,8 +360,8 @@ def test_handle_programming_error(caplog):
     ex = _handle_redshift_exception(error, "SELECT bad")
     assert isinstance(ex, DatusDbException)
     assert ex.code == ErrorCode.DB_EXECUTION_SYNTAX_ERROR
-    assert "Redshift SQL execution failed; sql=SELECT bad" in caplog.text
-    assert caplog.records[-1].exc_info[1] is error
+    assert "Redshift SQL execution failed; sql_preview='SELECT bad'; sql_chars=10" in caplog.text
+    assert "syntax error" in caplog.text
 
 
 def test_handle_operational_error():

--- a/datus-redshift/tests/unit/test_connector_unit.py
+++ b/datus-redshift/tests/unit/test_connector_unit.py
@@ -354,11 +354,14 @@ def test_validate_starts_with_digit():
 
 
 @pytest.mark.acceptance
-def test_handle_programming_error():
+def test_handle_programming_error(caplog):
     """Test ProgrammingError maps to DB_EXECUTION_SYNTAX_ERROR."""
-    ex = _handle_redshift_exception(ProgrammingError("syntax error"), "SELECT bad")
+    error = ProgrammingError("syntax error")
+    ex = _handle_redshift_exception(error, "SELECT bad")
     assert isinstance(ex, DatusDbException)
     assert ex.code == ErrorCode.DB_EXECUTION_SYNTAX_ERROR
+    assert "Redshift SQL execution failed; sql=SELECT bad" in caplog.text
+    assert caplog.records[-1].exc_info[1] is error
 
 
 def test_handle_operational_error():

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -43,6 +43,32 @@ from .config import SnowflakeConfig
 
 logger = get_logger(__name__)
 
+_SQL_PREVIEW_CHARS = 50
+
+
+def _log_sql_exception(event: str, sql: str, exc: Exception) -> None:
+    """Log a SQL failure with a bounded preview instead of the full statement."""
+    statement = sql or ""
+    normalized_sql = " ".join(statement.split())
+    sql_preview = normalized_sql[:_SQL_PREVIEW_CHARS]
+    if len(normalized_sql) > _SQL_PREVIEW_CHARS:
+        sql_preview += "..."
+    driver_error = str(getattr(exc, "orig", None) or exc) or type(exc).__name__
+    if statement:
+        driver_error = driver_error.replace(statement, "<sql>")
+    if normalized_sql and normalized_sql != statement:
+        driver_error = driver_error.replace(normalized_sql, "<sql>")
+    safe_exception = RuntimeError(driver_error)
+    logger.error(
+        "%s; sql_preview=%r; sql_chars=%d; error_type=%s; error=%s",
+        event,
+        sql_preview,
+        len(statement),
+        type(exc).__name__,
+        driver_error,
+        exc_info=(type(safe_exception), safe_exception, exc.__traceback__),
+    )
+
 
 def _private_key_to_der(private_key: str, private_key_file_pwd: Optional[str] = None) -> bytes:
     """Convert a PEM private key string into DER bytes accepted by Snowflake."""
@@ -67,13 +93,7 @@ def _private_key_to_der(private_key: str, private_key_file_pwd: Optional[str] = 
 def _handle_snowflake_exception(e: Exception, sql: str = "") -> DatusDbException:
     """Handle Snowflake exceptions and map to appropriate Datus ErrorCode."""
     error_message = getattr(e, "raw_msg", None) or getattr(e, "msg", None) or str(e)
-    logger.error(
-        "Snowflake SQL execution failed; sql=%s; error_type=%s; error=%r",
-        sql,
-        type(e).__name__,
-        e,
-        exc_info=(type(e), e, e.__traceback__),
-    )
+    _log_sql_exception("Snowflake SQL execution failed", sql, e)
 
     if isinstance(e, ProgrammingError):
         return DatusDbException(
@@ -115,7 +135,7 @@ def _handle_snowflake_exception(e: Exception, sql: str = "") -> DatusDbException
         )
 
     else:
-        return DatusDbException(ErrorCode.DB_FAILED, message_args={"error_message": str(e)})
+        return DatusDbException(ErrorCode.DB_FAILED, message_args={"error_message": error_message})
 
 
 class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedViewSupportMixin, MigrationTargetMixin):

--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -66,44 +66,52 @@ def _private_key_to_der(private_key: str, private_key_file_pwd: Optional[str] = 
 
 def _handle_snowflake_exception(e: Exception, sql: str = "") -> DatusDbException:
     """Handle Snowflake exceptions and map to appropriate Datus ErrorCode."""
+    error_message = getattr(e, "raw_msg", None) or getattr(e, "msg", None) or str(e)
+    logger.error(
+        "Snowflake SQL execution failed; sql=%s; error_type=%s; error=%r",
+        sql,
+        type(e).__name__,
+        e,
+        exc_info=(type(e), e, e.__traceback__),
+    )
 
     if isinstance(e, ProgrammingError):
         return DatusDbException(
             ErrorCode.DB_EXECUTION_SYNTAX_ERROR,
-            message_args={"sql": sql, "error_message": e.raw_msg},
+            message_args={"sql": sql, "error_message": error_message},
         )
 
     elif isinstance(e, (OperationalError, DatabaseError)):
         return DatusDbException(
             ErrorCode.DB_EXECUTION_ERROR,
-            message_args={"sql": sql, "error_message": e.raw_msg},
+            message_args={"sql": sql, "error_message": error_message},
         )
 
     elif isinstance(e, IntegrityError):
         return DatusDbException(
             ErrorCode.DB_CONSTRAINT_VIOLATION,
-            message_args={"sql": sql, "error_message": e.raw_msg},
+            message_args={"sql": sql, "error_message": error_message},
         )
 
     elif isinstance(e, (RequestTimeoutError, ServiceUnavailableError)):
         return DatusDbException(
             ErrorCode.DB_EXECUTION_TIMEOUT,
-            message_args={"sql": sql, "error_message": e.raw_msg},
+            message_args={"sql": sql, "error_message": error_message},
         )
 
     elif isinstance(e, (InterfaceError, InternalError)):
-        return DatusDbException(ErrorCode.DB_CONNECTION_FAILED, message_args={"error_message": e.raw_msg})
+        return DatusDbException(ErrorCode.DB_CONNECTION_FAILED, message_args={"error_message": error_message})
 
     elif isinstance(e, ForbiddenError):
         return DatusDbException(
             ErrorCode.DB_PERMISSION_DENIED,
-            message_args={"operation": "query execution", "error_message": e.raw_msg},
+            message_args={"operation": "query execution", "error_message": error_message},
         )
 
     elif isinstance(e, (DataError, NotSupportedError)):
         return DatusDbException(
             ErrorCode.DB_EXECUTION_ERROR,
-            message_args={"sql": sql, "error_message": e.raw_msg},
+            message_args={"sql": sql, "error_message": error_message},
         )
 
     else:
@@ -247,24 +255,30 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
         params: Sequence[Any] | dict[Any, Any] | None = None,
     ) -> DataFrame:
         """Execute query and return pandas DataFrame."""
-        with self.connection.cursor() as cursor:
-            cursor.execute(sql, params)
-            return cursor.fetch_pandas_all()
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql, params)
+                return cursor.fetch_pandas_all()
+        except Exception as e:
+            raise _handle_snowflake_exception(e, sql) from e
 
     def execute_query_to_dict(self, sql: str) -> List[Dict[str, Any]]:
         """Execute query and return list of dictionaries."""
-        with self.connection.cursor() as cursor:
-            cursor.execute(sql)
-            query_result = cursor.fetchall()
-            if not query_result or isinstance(query_result[0], dict):
-                return query_result
-            result = []
-            for item in query_result:
-                item_dict = {}
-                for i, col in enumerate(cursor.description):
-                    item_dict[col.name] = item[i]
-                result.append(item_dict)
-        return result
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql)
+                query_result = cursor.fetchall()
+                if not query_result or isinstance(query_result[0], dict):
+                    return query_result
+                result = []
+                for item in query_result:
+                    item_dict = {}
+                    for i, col in enumerate(cursor.description):
+                        item_dict[col.name] = item[i]
+                    result.append(item_dict)
+            return result
+        except Exception as e:
+            raise _handle_snowflake_exception(e, sql) from e
 
     @override
     def execute_ddl(
@@ -470,6 +484,8 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
                 error=None,
                 result_format="pandas",
             )
+        except DatusDbException as e:
+            return ExecuteSQLResult(success=False, sql_query=sql, result_format="pandas", error=str(e))
         except Exception as e:
             ex = _handle_snowflake_exception(e, sql)
             return ExecuteSQLResult(success=False, sql_query=sql, result_format="pandas", error=str(ex))

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from snowflake.connector.errors import ProgrammingError
 
 from datus_snowflake import SnowflakeConfig, SnowflakeConnector
+from datus_snowflake.connector import _handle_snowflake_exception
 
 
 def _private_key_material(encryption_password: bytes | None = None) -> tuple[str, bytes]:
@@ -41,16 +42,29 @@ def test_snowflake_execution_error_logs_original_exception(caplog):
     error.raw_msg = None
     cursor = connector.connection.cursor.return_value.__enter__.return_value
     cursor.execute.side_effect = error
+    sql = "SELECT " + ("x" * 220) + " FROM sensitive_tail"
 
-    result = connector.execute_pandas("SELECT bad")
+    result = connector.execute_pandas(sql)
 
     assert result.success is False
     assert "syntax error" in result.error
     assert "Error details: None" not in result.error
-    assert "Snowflake SQL execution failed; sql=SELECT bad" in caplog.text
+    assert "Snowflake SQL execution failed; sql_preview='SELECT " in caplog.text
+    assert f"sql_chars={len(sql)}" in caplog.text
+    assert "sensitive_tail" not in caplog.text
     matching_records = [record for record in caplog.records if "Snowflake SQL execution failed" in record.message]
     assert len(matching_records) == 1
-    assert matching_records[0].exc_info[1] is error
+    assert matching_records[0].exc_info[2] is error.__traceback__
+
+
+def test_snowflake_unclassified_error_uses_normalized_raw_message():
+    error = RuntimeError("generic fallback")
+    error.raw_msg = "driver raw message"
+
+    result = _handle_snowflake_exception(error)
+
+    assert "driver raw message" in str(result)
+    assert "generic fallback" not in str(result)
 
 
 def test_config_requires_password_or_key():

--- a/datus-snowflake/tests/test_config.py
+++ b/datus-snowflake/tests/test_config.py
@@ -4,11 +4,12 @@
 
 """Pure-Pydantic SnowflakeConfig tests — no live Snowflake required."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from snowflake.connector.errors import ProgrammingError
 
 from datus_snowflake import SnowflakeConfig, SnowflakeConnector
 
@@ -31,6 +32,25 @@ def _private_key_material(encryption_password: bytes | None = None) -> tuple[str
         encryption_algorithm=serialization.NoEncryption(),
     )
     return pem, der
+
+
+def test_snowflake_execution_error_logs_original_exception(caplog):
+    connector = object.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    error = ProgrammingError("syntax error")
+    error.raw_msg = None
+    cursor = connector.connection.cursor.return_value.__enter__.return_value
+    cursor.execute.side_effect = error
+
+    result = connector.execute_pandas("SELECT bad")
+
+    assert result.success is False
+    assert "syntax error" in result.error
+    assert "Error details: None" not in result.error
+    assert "Snowflake SQL execution failed; sql=SELECT bad" in caplog.text
+    matching_records = [record for record in caplog.records if "Snowflake SQL execution failed" in record.message]
+    assert len(matching_records) == 1
+    assert matching_records[0].exc_info[1] is error
 
 
 def test_config_requires_password_or_key():

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -170,6 +170,14 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
         """Map SQLAlchemy exceptions to Datus exceptions."""
         if isinstance(e, DatusDbException):
             return e
+        logger.error(
+            "%s failed; sql=%s; error_type=%s; error=%r",
+            operation,
+            sql,
+            type(e).__name__,
+            e,
+            exc_info=(type(e), e, e.__traceback__),
+        )
 
         # Extract error message
         if hasattr(e, "detail") and e.detail:
@@ -767,7 +775,7 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
                         yield ()
                     yield from []
         except Exception as e:
-            raise self._handle_exception(e) from e
+            raise self._handle_exception(e, sql, "streaming query") from e
 
     # ==================== MigrationTargetMixin (generic fallback) ====================
     #

--- a/datus-sqlalchemy/datus_sqlalchemy/connector.py
+++ b/datus-sqlalchemy/datus_sqlalchemy/connector.py
@@ -40,6 +40,32 @@ from datus_db_core import (
 
 logger = get_logger(__name__)
 
+_SQL_PREVIEW_CHARS = 50
+
+
+def _log_sql_exception(event: str, sql: str, exc: Exception) -> None:
+    """Log a SQL failure with a bounded preview instead of the full statement."""
+    statement = sql or ""
+    normalized_sql = " ".join(statement.split())
+    sql_preview = normalized_sql[:_SQL_PREVIEW_CHARS]
+    if len(normalized_sql) > _SQL_PREVIEW_CHARS:
+        sql_preview += "..."
+    driver_error = str(getattr(exc, "orig", None) or exc) or type(exc).__name__
+    if statement:
+        driver_error = driver_error.replace(statement, "<sql>")
+    if normalized_sql and normalized_sql != statement:
+        driver_error = driver_error.replace(normalized_sql, "<sql>")
+    safe_exception = RuntimeError(driver_error)
+    logger.error(
+        "%s; sql_preview=%r; sql_chars=%d; error_type=%s; error=%s",
+        event,
+        sql_preview,
+        len(statement),
+        type(exc).__name__,
+        driver_error,
+        exc_info=(type(safe_exception), safe_exception, exc.__traceback__),
+    )
+
 
 class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
     """
@@ -170,14 +196,7 @@ class SQLAlchemyConnector(BaseSqlConnector, MigrationTargetMixin):
         """Map SQLAlchemy exceptions to Datus exceptions."""
         if isinstance(e, DatusDbException):
             return e
-        logger.error(
-            "%s failed; sql=%s; error_type=%s; error=%r",
-            operation,
-            sql,
-            type(e).__name__,
-            e,
-            exc_info=(type(e), e, e.__traceback__),
-        )
+        _log_sql_exception(f"{operation} failed", sql, e)
 
         # Extract error message
         if hasattr(e, "detail") and e.detail:

--- a/datus-sqlalchemy/tests/unit/test_connector_unit.py
+++ b/datus-sqlalchemy/tests/unit/test_connector_unit.py
@@ -255,13 +255,15 @@ def test_execute_ddl_with_context_params():
         ),
     ],
 )
-def test_handle_exception_classifies_common_failures(exception, expected_code):
+def test_handle_exception_classifies_and_logs_common_failures(exception, expected_code, caplog):
     """SQLAlchemy failures should map to stable Datus error categories."""
     connector = DummySQLAlchemyConnector("sqlite://", dialect="sqlite")
 
     classified = connector._handle_exception(exception, "SELECT 1", "query")
 
     assert classified.code == expected_code
+    assert "query failed; sql=SELECT 1" in caplog.text
+    assert caplog.records[-1].exc_info[1] is exception
 
 
 def test_ensure_engine_classifies_connection_creation_failure():

--- a/datus-sqlalchemy/tests/unit/test_connector_unit.py
+++ b/datus-sqlalchemy/tests/unit/test_connector_unit.py
@@ -262,8 +262,9 @@ def test_handle_exception_classifies_and_logs_common_failures(exception, expecte
     classified = connector._handle_exception(exception, "SELECT 1", "query")
 
     assert classified.code == expected_code
-    assert "query failed; sql=SELECT 1" in caplog.text
-    assert caplog.records[-1].exc_info[1] is exception
+    assert "query failed; sql_preview='SELECT 1'; sql_chars=8" in caplog.text
+    assert caplog.text.count("SELECT 1") == 1
+    assert caplog.records[-1].exc_info[2] is exception.__traceback__
 
 
 def test_ensure_engine_classifies_connection_creation_failure():


### PR DESCRIPTION
## Summary

- log SQL execution failures with the original exception and traceback in ClickZetta, MaxCompute, Redshift, Snowflake, and SQLAlchemy connectors
- preserve concrete Snowflake driver messages when `raw_msg` is missing, and consistently classify pandas/dictionary query failures
- add regression coverage that verifies the original exception is present in log records

## Root cause

Several connector error paths converted exceptions into `DatusDbException` or `ExecuteSQLResult` without logging the original traceback. Snowflake additionally relied directly on `raw_msg`, which can be `None`, so callers could receive `Error details: None` instead of the warehouse error.

## Impact

SQL execution failures now produce actionable logs for CloudWatch/Loki while preserving the concrete warehouse error for upper layers.

## Related

- Agent tool error propagation: https://github.com/Datus-ai/Datus-agent/pull/1227

## Validation

- ClickZetta: `11 passed`
- MaxCompute: `22 passed`
- Redshift: `33 passed`
- Snowflake: `14 passed`
- SQLAlchemy: `20 passed`
- Ruff passed for all changed files
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error handling across ClickZetta, MaxCompute, Redshift, Snowflake, and SQLAlchemy integrations.
  * Failures now preserve the original exception details while maintaining existing error responses and mappings.
  * Snowflake query helpers provide more consistent error messages.

* **Tests**
  * Added and updated regression tests to verify exception preservation and detailed failure logging across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->