### PR TITLE
[BugFix] Snowflake fallback for non-Arrow results

### DIFF
--- a/datus-snowflake/datus_snowflake/connector.py
+++ b/datus-snowflake/datus_snowflake/connector.py
@@ -265,7 +265,22 @@ class SnowflakeConnector(BaseSqlConnector, SchemaNamespaceMixin, MaterializedVie
             with self.connection.cursor() as cursor:
                 cursor.execute("ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT='ARROW'")
                 cursor.execute(sql_query, params)
-                return cursor.fetch_arrow_all(force_return_table=True), cursor.rowcount
+                try:
+                    arrow_table = cursor.fetch_arrow_all(force_return_table=True)
+                except NotSupportedError:
+                    # Snowflake can return JSON for statements such as EXPLAIN
+                    # even when Arrow is requested for the session. In that case
+                    # fetch_arrow_all() rejects the result before consuming it,
+                    # so fetch the rows normally and materialize the requested
+                    # Arrow result locally.
+                    rows = cursor.fetchall()
+                    column_names = [getattr(column, "name", None) or column[0] for column in (cursor.description or [])]
+                    arrays = [
+                        pa.array([row.get(column_name) if isinstance(row, dict) else row[index] for row in rows])
+                        for index, column_name in enumerate(column_names)
+                    ]
+                    arrow_table = pa.Table.from_arrays(arrays, names=column_names)
+                return arrow_table, cursor.rowcount
         except Exception as e:
             raise _handle_snowflake_exception(e, sql_query)
 

--- a/datus-snowflake/tests/test_result_fetching.py
+++ b/datus-snowflake/tests/test_result_fetching.py
@@ -1,0 +1,79 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from dataclasses import dataclass
+
+import pyarrow as pa
+import pytest
+from snowflake.connector.errors import NotSupportedError
+
+from datus_snowflake import SnowflakeConnector
+
+
+@dataclass
+class ResultColumn:
+    name: str
+
+
+class JsonResultCursor:
+    def __init__(self):
+        self.description = [ResultColumn("plan")]
+        self.rowcount = 2
+        self.executed = []
+        self.fetch_arrow_calls = 0
+        self.fetchall_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetch_arrow_all(self, *, force_return_table):
+        assert force_return_table is True
+        self.fetch_arrow_calls += 1
+        raise NotSupportedError
+
+    def fetchall(self):
+        self.fetchall_calls += 1
+        return [("GlobalStats",), ("Result",)]
+
+
+class JsonResultConnection:
+    def __init__(self):
+        self.cursor_obj = JsonResultCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+@pytest.fixture
+def connector() -> SnowflakeConnector:
+    instance = SnowflakeConnector.__new__(SnowflakeConnector)
+    instance.connection = JsonResultConnection()
+    instance.dialect = "snowflake"
+    return instance
+
+
+def test_execute_query_arrow_falls_back_to_rows_for_json_result(connector: SnowflakeConnector):
+    result = connector.execute_query("EXPLAIN SELECT 1", result_format="arrow")
+
+    assert result.success
+    assert result.result_format == "arrow"
+    assert isinstance(result.sql_return, pa.Table)
+    assert result.sql_return.to_pylist() == [{"plan": "GlobalStats"}, {"plan": "Result"}]
+    assert result.row_count == 2
+    assert connector.connection.cursor_obj.fetch_arrow_calls == 1
+    assert connector.connection.cursor_obj.fetchall_calls == 1
+
+
+def test_execute_query_list_falls_back_to_rows_for_json_result(connector: SnowflakeConnector):
+    result = connector.execute_query("EXPLAIN SELECT 1", result_format="list")
+
+    assert result.success
+    assert result.result_format == "list"
+    assert result.sql_return == [{"plan": "GlobalStats"}, {"plan": "Result"}]


### PR DESCRIPTION
## Summary

- fall back to regular row fetching when Snowflake returns a non-Arrow result
- materialize fallback rows as an Arrow table so existing Arrow and list callers keep their result contract
- add regression coverage for `EXPLAIN` results returned as JSON

## Root cause

Snowflake can return `queryResultFormat=json` for statements such as `EXPLAIN`, even when the session requests Arrow. The Python connector then raises `NotSupportedError` from `fetch_arrow_all()` after the SQL has executed successfully. The adapter treated that fetch error as a query failure, which caused metric publication preflight to fail.

## Impact

Snowflake `EXPLAIN` queries, including metric publication preflight checks, now succeed without requiring Agent-side Snowflake special cases. Normal Arrow-backed query results keep the existing fast path.

## Validation

- `uv run pytest datus-snowflake/tests -m 'not integration' -q` (`42 passed`, `23 deselected`)
- `uv run ruff check datus-snowflake`
- `uv run ruff format --check datus-snowflake`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake query result handling when Arrow-format retrieval is unavailable.
  * Automatically falls back to standard row fetching and converts results into the expected table format.
  * Preserves support for list-format results, including dictionary-based rows.

* **Tests**
  * Added coverage for Arrow fallback behavior, row counts, and alternate result formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->