### PR TITLE
[BugFix] StarRocks: fall back to SHOW when information_schema metadata fails

### DIFF
--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -335,6 +335,74 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
                 logger.debug(f"'{statement} {target}' failed: {e}")
         return None
 
+    @override
+    def get_schema(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Column metadata, falling back to SHOW when information_schema fails.
+
+        Column lookups reach the FE through the same thrift call as the object
+        listing above, so they time out under the same conditions.
+        """
+        try:
+            return super().get_schema(
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_name=table_name,
+            )
+        except Exception as e:
+            columns = self._show_columns(
+                self._resolve_catalog(catalog_name), database_name or self.database_name, table_name
+            )
+            if columns is None:
+                raise
+            logger.warning(f"information_schema columns failed ({e}); fell back to SHOW for {table_name}")
+            return columns
+
+    def _show_columns(self, catalog_name: str, database_name: str, table_name: str) -> Optional[List[Dict[str, Any]]]:
+        """Describe one table with SHOW FULL COLUMNS; None when SHOW cannot answer."""
+        if not (database_name and table_name):
+            return None
+
+        quoted_table = self.quote_identifier(table_name)
+        quoted_db = self.quote_identifier(database_name)
+        # The catalog-qualified and `FROM <table> FROM <db>` spellings are both
+        # version-dependent, so try each until one is accepted.
+        targets = [
+            f"{self.quote_identifier(catalog_name)}.{quoted_db}.{quoted_table}",
+            f"{quoted_db}.{quoted_table}",
+            f"{quoted_table} FROM {quoted_db}",
+        ]
+        rows = self._try_show(targets, "SHOW FULL COLUMNS FROM")
+        if rows is None:
+            return None
+
+        by_name = {str(column).lower(): column for column in rows.columns}
+        if "field" not in by_name or "type" not in by_name:
+            return None
+
+        def cell(row: int, key: str, default=None):
+            column = by_name.get(key)
+            return rows[column][row] if column is not None else default
+
+        return [
+            {
+                "cid": i,
+                "name": cell(i, "field"),
+                "type": cell(i, "type"),
+                "nullable": str(cell(i, "null", "YES")).upper() == "YES",
+                "default_value": cell(i, "default"),
+                "pk": str(cell(i, "key", "")).upper() == "PRI",
+                "comment": cell(i, "comment"),
+            }
+            for i in range(len(rows))
+        ]
+
     @staticmethod
     def _pick_name_column(rows) -> List[str]:
         """Extract object names from a SHOW result whose column order is version-dependent."""

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -294,7 +294,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         ]
 
         if table_type == "mv":
-            rows = self._try_show(targets, "SHOW MATERIALIZED VIEWS FROM")
+            rows = self._try_show(targets, "SHOW MATERIALIZED VIEWS FROM", catalog_name)
             if rows is None:
                 return None
             names = self._pick_name_column(rows)
@@ -303,34 +303,29 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
         if table_type not in ("table", "view"):
             return None
 
-        # SHOW FULL TABLES carries a Table_type column, so tables and views stay separable.
-        rows = self._try_show(targets, "SHOW FULL TABLES FROM")
-        if rows is not None and len(rows.columns) >= 2:
-            wanted = "VIEW" if table_type == "view" else "BASE TABLE"
-            name_col, type_col = rows.columns[0], rows.columns[1]
-            return [
-                self._metadata_row(catalog_name, database_name, str(rows[name_col][i]), table_type)
-                for i in range(len(rows))
-                if str(rows[type_col][i]).upper() == wanted
-            ]
+        # Only SHOW FULL TABLES carries a Table_type column. Plain SHOW TABLES lumps views
+        # in with tables, so there is no honest way to answer either request from it.
+        rows = self._try_show(targets, "SHOW FULL TABLES FROM", catalog_name)
+        if rows is None or len(rows.columns) < 2:
+            return None
 
-        # Plain SHOW TABLES cannot distinguish views, so only tables may use it — and it
-        # over-reports by including views, which is still better than reporting nothing.
-        if table_type == "view":
-            return None
-        rows = self._try_show(targets, "SHOW TABLES FROM")
-        if rows is None:
-            return None
+        wanted = "VIEW" if table_type == "view" else "BASE TABLE"
+        name_col, type_col = rows.columns[0], rows.columns[1]
         return [
-            self._metadata_row(catalog_name, database_name, str(rows[rows.columns[0]][i]), "table")
+            self._metadata_row(catalog_name, database_name, str(rows[name_col][i]), table_type)
             for i in range(len(rows))
+            if str(rows[type_col][i]).upper() == wanted
         ]
 
-    def _try_show(self, targets: List[str], statement: str):
-        """Run ``statement`` against each target until one succeeds; None if all fail."""
+    def _try_show(self, targets: List[str], statement: str, catalog_name: str = ""):
+        """Run ``statement`` against each target until one succeeds; None if all fail.
+
+        ``catalog_name`` is applied to the connection, so the unqualified spellings
+        resolve in the requested catalog rather than whatever the session is on.
+        """
         for target in targets:
             try:
-                return self._execute_pandas(f"{statement} {target}")
+                return self._execute_pandas(f"{statement} {target}", catalog_name=catalog_name)
             except Exception as e:
                 logger.debug(f"'{statement} {target}' failed: {e}")
         return None
@@ -378,7 +373,7 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             f"{quoted_db}.{quoted_table}",
             f"{quoted_table} FROM {quoted_db}",
         ]
-        rows = self._try_show(targets, "SHOW FULL COLUMNS FROM")
+        rows = self._try_show(targets, "SHOW FULL COLUMNS FROM", catalog_name)
         if rows is None:
             return None
 
@@ -620,9 +615,10 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
 
         Connectors are cached and shared across callers, so disposing the engine here
         would drop the pool other threads are using. Only an engine this probe itself
-        brought up gets torn down.
+        brought up gets torn down — ownership is deliberately not consulted, since an
+        engine attached from elsewhere is even less ours to dispose.
         """
-        engine_was_live = bool(self.engine and self._owns_engine)
+        engine_was_live = self.engine is not None
         try:
             return super().test_connection()
         finally:

--- a/datus-starrocks/datus_starrocks/connector.py
+++ b/datus-starrocks/datus_starrocks/connector.py
@@ -3,7 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 from contextlib import contextmanager
-from typing import Any, Dict, List, Set, Union, override
+from typing import Any, Dict, List, Optional, Set, Union, override
 
 from sqlalchemy import text
 
@@ -245,25 +245,103 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
             f"WHERE {where} {type_filter}"
         )
 
-        query_result = self._execute_pandas(query)
+        try:
+            query_result = self._execute_pandas(query)
+        except Exception as e:
+            # information_schema is scanned by the BE through a thrift call back to the FE,
+            # which times out (THRIFT_EAGAIN) once a database holds enough objects. SHOW is
+            # answered by the FE directly, so it still works when this query does not.
+            fallback = self._show_metadata(table_type, current_catalog, database_name)
+            if fallback is None:
+                raise
+            logger.warning(f"information_schema listing failed ({e}); fell back to SHOW for {table_type}")
+            return fallback
 
         result = []
         for i in range(len(query_result)):
             db_name = query_result["TABLE_SCHEMA"][i]
             tb_name = query_result["TABLE_NAME"][i]
-            result.append(
-                {
-                    "identifier": self.identifier(
-                        catalog_name=current_catalog, database_name=db_name, table_name=tb_name
-                    ),
-                    "catalog_name": current_catalog,
-                    "schema_name": "",
-                    "database_name": db_name,
-                    "table_name": tb_name,
-                    "table_type": table_type,
-                }
-            )
+            result.append(self._metadata_row(current_catalog, db_name, tb_name, table_type))
         return result
+
+    def _metadata_row(self, catalog_name: str, database_name: str, table_name: str, table_type: str) -> Dict[str, str]:
+        """Build one metadata entry in the shape callers of ``_get_metadata`` expect."""
+        return {
+            "identifier": self.identifier(
+                catalog_name=catalog_name, database_name=database_name, table_name=table_name
+            ),
+            "catalog_name": catalog_name,
+            "schema_name": "",
+            "database_name": database_name,
+            "table_name": table_name,
+            "table_type": table_type,
+        }
+
+    def _show_metadata(self, table_type: str, catalog_name: str, database_name: str) -> Optional[List[Dict[str, str]]]:
+        """Enumerate objects with SHOW as a fallback for a failing information_schema query.
+
+        Returns None when SHOW cannot answer the request — a database-less listing, an
+        unsupported object type, or a cluster that rejects every SHOW variant — so the
+        caller re-raises the original error instead of reporting an empty database.
+        """
+        if not database_name:
+            return None
+
+        # Catalog-qualified SHOW is only understood by newer versions; retry bare.
+        targets = [
+            f"{self.quote_identifier(catalog_name)}.{self.quote_identifier(database_name)}",
+            self.quote_identifier(database_name),
+        ]
+
+        if table_type == "mv":
+            rows = self._try_show(targets, "SHOW MATERIALIZED VIEWS FROM")
+            if rows is None:
+                return None
+            names = self._pick_name_column(rows)
+            return [self._metadata_row(catalog_name, database_name, name, "mv") for name in names]
+
+        if table_type not in ("table", "view"):
+            return None
+
+        # SHOW FULL TABLES carries a Table_type column, so tables and views stay separable.
+        rows = self._try_show(targets, "SHOW FULL TABLES FROM")
+        if rows is not None and len(rows.columns) >= 2:
+            wanted = "VIEW" if table_type == "view" else "BASE TABLE"
+            name_col, type_col = rows.columns[0], rows.columns[1]
+            return [
+                self._metadata_row(catalog_name, database_name, str(rows[name_col][i]), table_type)
+                for i in range(len(rows))
+                if str(rows[type_col][i]).upper() == wanted
+            ]
+
+        # Plain SHOW TABLES cannot distinguish views, so only tables may use it — and it
+        # over-reports by including views, which is still better than reporting nothing.
+        if table_type == "view":
+            return None
+        rows = self._try_show(targets, "SHOW TABLES FROM")
+        if rows is None:
+            return None
+        return [
+            self._metadata_row(catalog_name, database_name, str(rows[rows.columns[0]][i]), "table")
+            for i in range(len(rows))
+        ]
+
+    def _try_show(self, targets: List[str], statement: str):
+        """Run ``statement`` against each target until one succeeds; None if all fail."""
+        for target in targets:
+            try:
+                return self._execute_pandas(f"{statement} {target}")
+            except Exception as e:
+                logger.debug(f"'{statement} {target}' failed: {e}")
+        return None
+
+    @staticmethod
+    def _pick_name_column(rows) -> List[str]:
+        """Extract object names from a SHOW result whose column order is version-dependent."""
+        for column in rows.columns:
+            if str(column).lower() in ("name", "table_name"):
+                return [str(v) for v in rows[column].tolist()]
+        return [str(v) for v in rows.iloc[:, 0].tolist()] if len(rows.columns) else []
 
     @override
     @staticmethod
@@ -470,15 +548,21 @@ class StarRocksConnector(MySQLConnector, CatalogSupportMixin, MaterializedViewSu
 
     @override
     def test_connection(self) -> bool:
-        """Test the database connection with proper cleanup."""
+        """Test the database connection, leaving an existing engine untouched.
+
+        Connectors are cached and shared across callers, so disposing the engine here
+        would drop the pool other threads are using. Only an engine this probe itself
+        brought up gets torn down.
+        """
+        engine_was_live = bool(self.engine and self._owns_engine)
         try:
             return super().test_connection()
         finally:
-            # Ensure connection is closed after test
-            try:
-                self.close()
-            except Exception as e:
-                logger.debug(f"Ignoring cleanup error during test: {e}")
+            if not engine_was_live:
+                try:
+                    self.close()
+                except Exception as e:
+                    logger.debug(f"Ignoring cleanup error during test: {e}")
 
     # ==================== MigrationTargetMixin ====================
 

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -660,7 +660,7 @@ def test_get_tables_falls_back_to_show_when_information_schema_fails():
     """information_schema can time out server-side; SHOW still answers."""
     connector = _connector_for_metadata()
 
-    def fake_execute(sql):
+    def fake_execute(sql, **kwargs):
         if "information_schema" in sql:
             raise RuntimeError("call frontend service failed: THRIFT_EAGAIN (timed out)")
         if sql.startswith("SHOW FULL TABLES"):
@@ -674,18 +674,19 @@ def test_get_tables_falls_back_to_show_when_information_schema_fails():
 
 
 @pytest.mark.acceptance
-def test_get_tables_falls_back_to_plain_show_tables():
-    """Older clusters reject SHOW FULL TABLES; plain SHOW TABLES still lists tables."""
+def test_get_tables_reraises_when_show_full_tables_is_rejected():
+    """Plain SHOW TABLES cannot tell a view from a table, so it is not an answer."""
     connector = _connector_for_metadata()
 
-    def fake_execute(sql):
+    def fake_execute(sql, **kwargs):
         if sql.startswith("SHOW TABLES"):
-            return pd.DataFrame({"Tables_in_testdb": ["orders", "items"]})
-        raise RuntimeError("unsupported")
+            return pd.DataFrame({"Tables_in_testdb": ["orders", "v_orders"]})
+        raise RuntimeError("thrift timeout")
 
     connector._execute_pandas = MagicMock(side_effect=fake_execute)
 
-    assert connector.get_tables(database_name="testdb") == ["orders", "items"]
+    with pytest.raises(RuntimeError, match="thrift timeout"):
+        connector.get_tables(database_name="testdb")
 
 
 @pytest.mark.acceptance
@@ -714,7 +715,7 @@ def test_show_fallback_retries_without_catalog_qualifier():
     connector = _connector_for_metadata()
     seen = []
 
-    def fake_execute(sql):
+    def fake_execute(sql, **kwargs):
         seen.append(sql)
         if "information_schema" in sql or "`default_catalog`." in sql:
             raise RuntimeError("rejected")
@@ -764,7 +765,7 @@ def test_get_schema_falls_back_to_show_full_columns():
     """Column lookups hit the same FE thrift path; SHOW answers when it times out."""
     connector = _connector_for_metadata()
 
-    def fake_execute(sql):
+    def fake_execute(sql, **kwargs):
         if "INFORMATION_SCHEMA" in sql.upper():
             raise RuntimeError("call frontend service failed: THRIFT_EAGAIN (timed out)")
         if sql.startswith("SHOW FULL COLUMNS FROM `default_catalog`.`testdb`.`orders`"):
@@ -800,3 +801,52 @@ def test_get_schema_reraises_when_show_also_fails():
 
     with pytest.raises(RuntimeError, match="connection reset"):
         connector.get_schema(database_name="testdb", table_name="orders")
+
+
+@pytest.mark.acceptance
+def test_show_fallback_stays_inside_the_requested_catalog():
+    """Two catalogs can hold a same-named database; the fallback must not cross over."""
+    connector = _connector_for_metadata(database="dbx", catalog="catalog_a")
+    tables_by_catalog = {
+        "catalog_a": ["orders_a"],
+        "catalog_b": ["orders_b"],
+    }
+
+    def fake_execute(sql, catalog_name="", **kwargs):
+        if "information_schema" in sql:
+            raise RuntimeError("thrift timeout")
+        if not sql.startswith("SHOW FULL TABLES"):
+            raise AssertionError(f"unexpected query: {sql}")
+        # A qualified name wins; otherwise the session catalog decides, and that is
+        # exactly what catalog_name has to carry.
+        for catalog in tables_by_catalog:
+            if f"`{catalog}`." in sql:
+                effective = catalog
+                break
+        else:
+            effective = catalog_name
+        if effective not in tables_by_catalog:
+            raise AssertionError(f"query ran without a catalog: {sql!r} catalog_name={catalog_name!r}")
+        names = tables_by_catalog[effective]
+        return pd.DataFrame({"Tables_in_dbx": names, "Table_type": ["BASE TABLE"] * len(names)})
+
+    connector._execute_pandas = MagicMock(side_effect=fake_execute)
+
+    assert connector.get_tables(catalog_name="catalog_b", database_name="dbx") == ["orders_b"]
+    assert connector.get_tables(catalog_name="catalog_a", database_name="dbx") == ["orders_a"]
+    show_calls = [c for c in connector._execute_pandas.call_args_list if c.args[0].startswith("SHOW")]
+    assert show_calls and all(c.kwargs.get("catalog_name") for c in show_calls)
+
+
+@pytest.mark.acceptance
+def test_test_connection_keeps_an_engine_it_does_not_own():
+    """An engine attached from elsewhere is even less ours to dispose."""
+    connector = _connector_for_metadata()
+    connector.engine = MagicMock()
+    connector._owns_engine = False
+    connector.close = MagicMock()
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.test_connection", return_value=True):
+        assert connector.test_connection() is True
+
+    connector.close.assert_not_called()

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from datus_db_core import CatalogSupportMixin, MaterializedViewSupportMixin
@@ -637,3 +638,122 @@ def test_implements_materialized_view_support_mixin():
         connector = StarRocksConnector(config)
 
         assert isinstance(connector, MaterializedViewSupportMixin)
+
+
+# ==================== Metadata Fallback Tests ====================
+
+
+def _connector_for_metadata(database="testdb", catalog="default_catalog"):
+    """Build a connector whose SQL execution is fully mocked."""
+    config = StarRocksConfig(username="test_user", catalog=catalog, database=database)
+    with patch("datus_mysql.MySQLConnector.__init__", return_value=None):
+        connector = StarRocksConnector(config)
+    connector.dialect = "starrocks"
+    connector.catalog_name = catalog
+    connector.database_name = database
+    connector.connect = MagicMock()
+    return connector
+
+
+@pytest.mark.acceptance
+def test_get_tables_falls_back_to_show_when_information_schema_fails():
+    """information_schema can time out server-side; SHOW still answers."""
+    connector = _connector_for_metadata()
+
+    def fake_execute(sql):
+        if "information_schema" in sql:
+            raise RuntimeError("call frontend service failed: THRIFT_EAGAIN (timed out)")
+        if sql.startswith("SHOW FULL TABLES"):
+            return pd.DataFrame({"Tables_in_testdb": ["orders", "v_orders"], "Table_type": ["BASE TABLE", "VIEW"]})
+        raise AssertionError(f"unexpected query: {sql}")
+
+    connector._execute_pandas = MagicMock(side_effect=fake_execute)
+
+    assert connector.get_tables(database_name="testdb") == ["orders"]
+    assert connector.get_views(database_name="testdb") == ["v_orders"]
+
+
+@pytest.mark.acceptance
+def test_get_tables_falls_back_to_plain_show_tables():
+    """Older clusters reject SHOW FULL TABLES; plain SHOW TABLES still lists tables."""
+    connector = _connector_for_metadata()
+
+    def fake_execute(sql):
+        if sql.startswith("SHOW TABLES"):
+            return pd.DataFrame({"Tables_in_testdb": ["orders", "items"]})
+        raise RuntimeError("unsupported")
+
+    connector._execute_pandas = MagicMock(side_effect=fake_execute)
+
+    assert connector.get_tables(database_name="testdb") == ["orders", "items"]
+
+
+@pytest.mark.acceptance
+def test_get_tables_reraises_when_show_also_fails():
+    """A blanket failure must surface, not masquerade as an empty database."""
+    connector = _connector_for_metadata()
+    connector._execute_pandas = MagicMock(side_effect=RuntimeError("connection reset"))
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        connector.get_tables(database_name="testdb")
+
+
+@pytest.mark.acceptance
+def test_get_tables_reraises_without_database_to_show():
+    """SHOW needs a database; without one the original error is the only truth."""
+    connector = _connector_for_metadata(database="")
+    connector._execute_pandas = MagicMock(side_effect=RuntimeError("thrift timeout"))
+
+    with pytest.raises(RuntimeError, match="thrift timeout"):
+        connector.get_tables()
+
+
+@pytest.mark.acceptance
+def test_show_fallback_retries_without_catalog_qualifier():
+    """Catalog-qualified SHOW is version-dependent; the bare form is retried."""
+    connector = _connector_for_metadata()
+    seen = []
+
+    def fake_execute(sql):
+        seen.append(sql)
+        if "information_schema" in sql or "`default_catalog`." in sql:
+            raise RuntimeError("rejected")
+        if sql == "SHOW FULL TABLES FROM `testdb`":
+            return pd.DataFrame({"Tables_in_testdb": ["orders"], "Table_type": ["BASE TABLE"]})
+        raise AssertionError(f"unexpected query: {sql}")
+
+    connector._execute_pandas = MagicMock(side_effect=fake_execute)
+
+    assert connector.get_tables(database_name="testdb") == ["orders"]
+    assert "SHOW FULL TABLES FROM `default_catalog`.`testdb`" in seen
+
+
+# ==================== Connection Reuse Tests ====================
+
+
+@pytest.mark.acceptance
+def test_test_connection_keeps_a_shared_engine_alive():
+    """Connectors are cached and shared — the probe must not dispose the engine."""
+    connector = _connector_for_metadata()
+    connector.engine = MagicMock()
+    connector._owns_engine = True
+    connector.close = MagicMock()
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.test_connection", return_value=True):
+        assert connector.test_connection() is True
+
+    connector.close.assert_not_called()
+
+
+@pytest.mark.acceptance
+def test_test_connection_closes_an_engine_it_opened():
+    """A probe that brought the engine up itself still cleans up after."""
+    connector = _connector_for_metadata()
+    connector.engine = None
+    connector._owns_engine = False
+    connector.close = MagicMock()
+
+    with patch("datus_sqlalchemy.SQLAlchemyConnector.test_connection", return_value=True):
+        assert connector.test_connection() is True
+
+    connector.close.assert_called_once()

--- a/datus-starrocks/tests/unit/test_connector_unit.py
+++ b/datus-starrocks/tests/unit/test_connector_unit.py
@@ -757,3 +757,46 @@ def test_test_connection_closes_an_engine_it_opened():
         assert connector.test_connection() is True
 
     connector.close.assert_called_once()
+
+
+@pytest.mark.acceptance
+def test_get_schema_falls_back_to_show_full_columns():
+    """Column lookups hit the same FE thrift path; SHOW answers when it times out."""
+    connector = _connector_for_metadata()
+
+    def fake_execute(sql):
+        if "INFORMATION_SCHEMA" in sql.upper():
+            raise RuntimeError("call frontend service failed: THRIFT_EAGAIN (timed out)")
+        if sql.startswith("SHOW FULL COLUMNS FROM `default_catalog`.`testdb`.`orders`"):
+            return pd.DataFrame(
+                {
+                    "Field": ["id", "amount"],
+                    "Type": ["bigint(20)", "decimal(10,2)"],
+                    "Null": ["NO", "YES"],
+                    "Key": ["PRI", ""],
+                    "Default": [None, "0.00"],
+                    "Comment": ["primary key", ""],
+                }
+            )
+        raise AssertionError(f"unexpected query: {sql}")
+
+    connector._execute_pandas = MagicMock(side_effect=fake_execute)
+
+    columns = connector.get_schema(database_name="testdb", table_name="orders")
+
+    assert [c["name"] for c in columns] == ["id", "amount"]
+    assert columns[0]["pk"] is True
+    assert columns[0]["nullable"] is False
+    assert columns[1]["nullable"] is True
+    assert columns[1]["default_value"] == "0.00"
+    assert columns[0]["comment"] == "primary key"
+
+
+@pytest.mark.acceptance
+def test_get_schema_reraises_when_show_also_fails():
+    """A blanket failure must surface, not masquerade as a column-less table."""
+    connector = _connector_for_metadata()
+    connector._execute_pandas = MagicMock(side_effect=RuntimeError("connection reset"))
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        connector.get_schema(database_name="testdb", table_name="orders")


### PR DESCRIPTION
## Why

Metadata reads go through `information_schema`, which StarRocks serves by having the BE call back into the FE over thrift. On a database with enough objects that RPC times out:

```
(1064, 'call frontend service failed, address=TNetworkAddress(hostname=..., port=9020),
 reason=THRIFT_EAGAIN (timed out): BE:11003')
```

The equivalent `SHOW` statements answer instantly — they are served by the FE directly. A user's 1110-table database was therefore unlistable through the adapter while every `SHOW`-based path — including what the agent fell back to on its own — worked fine.

Two entry points were affected:

- `get_tables()` / `get_views()` / `get_materialized_views()` via `catalog.information_schema.TABLES`;
- `get_schema()`, inherited from the MySQL connector, via `INFORMATION_SCHEMA.COLUMNS`. This one had no fallback at all, so a table's columns were unreachable whenever the FE was slow — `/table/columns` silently drops the table and `/table/detail` fails outright.

## Solution

- `_get_metadata()` catches a failing `information_schema` query and retries via `SHOW FULL TABLES` (tables/views) or `SHOW MATERIALIZED VIEWS` (MVs). Only `SHOW FULL TABLES` carries a `Table_type` column; plain `SHOW TABLES` lumps views in with tables, so it is deliberately *not* used — a listing that misreports object types would be worse than the error it replaces.
- `get_schema()` is overridden to retry through `SHOW FULL COLUMNS`, mapping `Field/Type/Null/Key/Default/Comment` onto the same dict shape the information_schema path returns.
- Every fallback tries the catalog-qualified spelling first and then unqualified ones, since both `SHOW ... FROM catalog.db` and `SHOW FULL COLUMNS FROM <table> FROM <db>` are version-dependent. The requested catalog is applied to the connection for all of them, so an unqualified spelling can never resolve against whatever catalog the session happened to be on.
- When `SHOW` cannot answer — no database to scope it to, an unsupported object type, or every variant rejected — the original exception is re-raised. A real outage must never be reported as an empty database or a column-less table.
- Row construction moved into `_metadata_row()` so both paths return the identical shape.

Also: `test_connection()` unconditionally called `close()`, disposing the engine even when it did not create it. Connectors are cached and shared across callers, so a health probe was dropping the pool other threads were using. It now only tears down an engine that did not exist before the probe.

## Test Cases

`datus-starrocks/tests/unit/test_connector_unit.py`:

- `information_schema` failure falls back to `SHOW FULL TABLES`, with tables and views correctly separated;
- a cluster that rejects `SHOW FULL TABLES` re-raises rather than answering from the untyped `SHOW TABLES`;
- a blanket listing failure re-raises instead of returning an empty list;
- a listing with no database to scope `SHOW` to re-raises;
- the catalog-qualified `SHOW` is attempted before the bare form;
- two catalogs holding a same-named database never leak each other's tables through the fallback, and every `SHOW` carries the requested catalog;
- `get_schema()` falls back to `SHOW FULL COLUMNS`, mapping nullability, PK, default and comment correctly;
- a blanket column failure re-raises;
- `test_connection()` leaves a pre-existing engine alive — owned or not — and still closes one it opened itself.

`ci/run-unit-tests.sh datus-starrocks` → 98 passed. `ruff format --check` / `ruff check` clean.