### PR TITLE
[BugFix] Support GaussDB psycopg2 connections on macOS

### DIFF
--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -51,14 +51,16 @@ identifiers.
 
 | Driver | Authentication methods | When to use |
 |--------|-----------------------|-------------|
-| `gaussdb` (default) | sha256, md5, sm3 | Any GaussDB / openGauss server, including a stock installation |
-| `psycopg2` | md5 only | Escape hatch when the official driver cannot be installed |
+| `gaussdb` (Linux default) | sha256, md5, sm3 | Any GaussDB / openGauss server, including a stock installation |
+| `psycopg2` (macOS default) | md5 only | PostgreSQL wire-compatible connection when official libpq is unavailable |
 
 GaussDB defaults to `sha256` password authentication, which vanilla PostgreSQL
 drivers do not implement. The default `gaussdb` driver speaks it, so a stock
 server works with no server-side changes.
 
-The `psycopg2` escape hatch is selected in the datasource config:
+On macOS, the adapter selects `psycopg2` automatically because the official
+GaussDB/openGauss libpq is not published for Darwin. It can also be selected
+explicitly on any platform:
 
 ```yaml
       driver: psycopg2
@@ -94,9 +96,11 @@ loaded by absolute path and nothing is added to the loader search path, so
 neither installation shadows the other. Set `DATUS_GAUSSDB_LIBPQ=system` if you
 would rather use the client you installed.
 
-macOS is not supported by the driver natively — no openGauss libpq is published
-for Darwin. Run the adapter (and its integration tests) inside a Linux
-container on macOS hosts.
+The official `gaussdb` driver is not supported on macOS — no openGauss libpq is
+published for Darwin. The adapter therefore uses its isolated
+`gaussdb+psycopg2` dialect on macOS. This does not replace or monkey-patch
+SQLAlchemy's PostgreSQL dialect, and Linux continues to use the official driver
+by default.
 
 ## Compatibility modes and deployment shapes
 
@@ -149,8 +153,9 @@ documents two openGauss container quirks (the mandatory out-of-datadir
 `GAUSSLOG`, and the first post-initdb server start aborting on Docker Desktop
 for macOS) that its entrypoint wrapper works around.
 
-On macOS the tests themselves must also run inside a Linux container, because
-the driver's libpq is Linux-only.
+On macOS, integration tests use `psycopg2` by default. To exercise the official
+driver, run them in a Linux container or explicitly set `GAUSSDB_DRIVER=gaussdb`
+on a Linux host.
 
 ## Source checkouts
 

--- a/datus-gaussdb/datus_gaussdb/config.py
+++ b/datus-gaussdb/datus_gaussdb/config.py
@@ -2,11 +2,17 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import sys
 from typing import Literal
 
 from pydantic import Field
 
 from datus_postgresql import PostgreSQLConfig
+
+
+def _default_driver() -> Literal["gaussdb", "psycopg2"]:
+    """Use the portable wire-compatible client when Darwin lacks GaussDB libpq."""
+    return "psycopg2" if sys.platform == "darwin" else "gaussdb"
 
 
 class GaussDBConfig(PostgreSQLConfig):
@@ -17,10 +23,11 @@ class GaussDBConfig(PostgreSQLConfig):
     """
 
     driver: Literal["gaussdb", "psycopg2"] = Field(
-        default="gaussdb",
+        default_factory=_default_driver,
         description=(
             "Client driver. 'gaussdb' (official driver, supports sha256/md5/sm3 "
-            "authentication) or 'psycopg2' (escape hatch; requires md5 "
-            "authentication on the server)"
+            "authentication; default outside macOS) or 'psycopg2' (macOS "
+            "default and portable escape hatch; requires md5 authentication "
+            "on the server)"
         ),
     )

--- a/datus-gaussdb/datus_gaussdb/connector.py
+++ b/datus-gaussdb/datus_gaussdb/connector.py
@@ -35,7 +35,9 @@ class GaussDBConnector(PostgreSQLConnector):
     GaussDB is PostgreSQL-compatible on the wire; this connector inherits
     all execution and metadata logic from PostgreSQLConnector and connects
     through the official ``gaussdb`` driver (sha256/md5/sm3 authentication)
-    via the ``gaussdb+psycopg`` SQLAlchemy dialect.
+    via the ``gaussdb+psycopg`` SQLAlchemy dialect. On macOS, where the
+    official libpq is unavailable, it uses the isolated
+    ``gaussdb+psycopg2`` compatibility dialect by default.
     """
 
     def __init__(self, config: Union[GaussDBConfig, dict]):
@@ -46,7 +48,7 @@ class GaussDBConnector(PostgreSQLConnector):
 
         super().__init__(config)
         # PostgreSQLConnector fixes dialect="postgresql" and a psycopg2
-        # connection string; both must be re-pointed at the gaussdb driver.
+        # connection string; both must be re-pointed at a GaussDB dialect.
         # The engine is created lazily, so nothing has connected yet.
         self.dialect = "gaussdb"
         self.config = config
@@ -57,7 +59,7 @@ class GaussDBConnector(PostgreSQLConnector):
 
     @override
     def _build_connection_string(self, database_name: str) -> str:
-        prefix = "postgresql+psycopg2" if self.config.driver == "psycopg2" else "gaussdb+psycopg"
+        prefix = "gaussdb+psycopg2" if self.config.driver == "psycopg2" else "gaussdb+psycopg"
         encoded_username = quote_plus(self.username) if self.username else ""
         encoded_password = quote_plus(self.password) if self.password else ""
         return (

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -2,15 +2,23 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""SQLAlchemy dialect for GaussDB on top of the official ``gaussdb`` driver.
+"""SQLAlchemy dialects for GaussDB/openGauss client drivers.
 
-The driver is a psycopg3 fork with the module tree renamed psycopg->gaussdb.
-SQLAlchemy's built-in ``postgresql+psycopg`` dialect hard-imports ``psycopg``
-submodules in ~15 places; rather than reimplementing the dialect, the
-(API-identical) ``gaussdb`` module tree is aliased into ``sys.modules`` under
-the ``psycopg`` names before the dialect first touches them.
+The official ``gaussdb`` driver is a psycopg3 fork with the module tree renamed
+psycopg->gaussdb. SQLAlchemy's built-in ``postgresql+psycopg`` dialect
+hard-imports ``psycopg`` submodules in ~15 places; rather than reimplementing
+the dialect, the (API-identical) ``gaussdb`` module tree is aliased into
+``sys.modules`` under the ``psycopg`` names before the dialect first touches
+them.
 
-URL form: ``gaussdb+psycopg://user:password@host:port/database``
+The optional psycopg2 path uses its own GaussDB-named dialect. This keeps the
+stock PostgreSQL dialect untouched while allowing PostgreSQL's macOS libpq to
+connect to servers that expose the compatible wire protocol.
+
+URL forms::
+
+    gaussdb+psycopg://user:password@host:port/database
+    gaussdb+psycopg2://user:password@host:port/database
 """
 
 import sys
@@ -18,6 +26,7 @@ import types
 
 from sqlalchemy.dialects import registry
 from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 
 from ._libpq import import_gaussdb
 
@@ -108,19 +117,43 @@ class GaussDBDialect(PGDialect_psycopg):
         return args, kwargs
 
     def _get_server_version_info(self, connection):
-        # GaussDB's version() returns "gaussdb (GaussDB Kernel 503...)" /
-        # "(openGauss 7.0...)", which the parent regex (expects
-        # "PostgreSQL X.Y") cannot parse. The PG compatibility level is
-        # reported via server_version instead (typically 9.2.x).
-        val = connection.exec_driver_sql("SHOW server_version").scalar()
-        parts = []
-        for token in str(val).replace("-", ".").split("."):
-            if token.isdigit():
-                parts.append(int(token))
-            else:
-                break
-        return tuple(parts) if parts else (9, 2)
+        return _get_server_version_info(connection)
+
+
+class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
+    """GaussDB/openGauss dialect using PostgreSQL's psycopg2 client.
+
+    Linux continues to use the official ``gaussdb`` driver unless
+    ``driver: psycopg2`` is configured explicitly. macOS selects this path by
+    default because no compatible native GaussDB/openGauss libpq is available.
+    """
+
+    name = "gaussdb"
+    driver = "psycopg2"
+    supports_statement_cache = True
+
+    def _get_server_version_info(self, connection):
+        return _get_server_version_info(connection)
+
+
+def _get_server_version_info(connection):
+    """Read the PostgreSQL compatibility level without parsing ``version()``.
+
+    GaussDB's ``version()`` returns ``gaussdb (GaussDB Kernel 503...)`` and
+    openGauss returns ``(openGauss 7.0...)``. Neither matches SQLAlchemy's
+    PostgreSQL-only regular expression. Both server families report their
+    PostgreSQL compatibility level through ``server_version`` instead.
+    """
+    val = connection.exec_driver_sql("SHOW server_version").scalar()
+    parts = []
+    for token in str(val).replace("-", ".").split("."):
+        if token.isdigit():
+            parts.append(int(token))
+        else:
+            break
+    return tuple(parts) if parts else (9, 2)
 
 
 registry.register("gaussdb", "datus_gaussdb.sa_dialect", "GaussDBDialect")
 registry.register("gaussdb.psycopg", "datus_gaussdb.sa_dialect", "GaussDBDialect")
+registry.register("gaussdb.psycopg2", "datus_gaussdb.sa_dialect", "GaussDBPsycopg2Dialect")

--- a/datus-gaussdb/pyproject.toml
+++ b/datus-gaussdb/pyproject.toml
@@ -23,6 +23,7 @@ gaussdb = "datus_gaussdb.skills:get_skills_dir"
 [project.entry-points."sqlalchemy.dialects"]
 gaussdb = "datus_gaussdb.sa_dialect:GaussDBDialect"
 "gaussdb.psycopg" = "datus_gaussdb.sa_dialect:GaussDBDialect"
+"gaussdb.psycopg2" = "datus_gaussdb.sa_dialect:GaussDBPsycopg2Dialect"
 
 [build-system]
 requires = ["hatchling"]

--- a/datus-gaussdb/tests/integration/conftest.py
+++ b/datus-gaussdb/tests/integration/conftest.py
@@ -15,6 +15,7 @@ Variable                     Default             Meaning
 ``GAUSSDB_PASSWORD``         ``Datus@123``       login password
 ``GAUSSDB_DATABASE``         ``postgres``        default database
 ``GAUSSDB_SCHEMA``           ``public``          default schema
+``GAUSSDB_DRIVER``           platform default    ``gaussdb`` or ``psycopg2``
 ===========================  ==================  =========================
 
 IMPORTANT — platform caveat: the official ``gaussdb`` driver binds the
@@ -30,11 +31,12 @@ one that runs the openGauss server is fine)::
 Every fixture skips (never fails) when the server is unreachable, so the suite
 is inert on developer machines without a GaussDB instance.
 
-Off Linux the whole suite is skipped up front: the driver binds whatever libpq
-it can find, and a vanilla PostgreSQL libpq makes it *segfault* on connect
-rather than raise — a crash no fixture can catch. Set
-``GAUSSDB_FORCE_INTEGRATION=1`` to override on a host that really does have the
-GaussDB client libraries.
+Off Linux, tests using the official driver are skipped up front: the driver
+binds whatever libpq it can find, and a vanilla PostgreSQL libpq makes it
+*segfault* on connect rather than raise — a crash no fixture can catch. The
+``psycopg2`` path is safe on macOS and is selected there by default. Set
+``GAUSSDB_FORCE_INTEGRATION=1`` only to run the official driver on a host that
+really does have the GaussDB client libraries.
 """
 
 import os
@@ -48,8 +50,9 @@ from datus_gaussdb.tpch_data import TPCH_DATA, TPCH_DDL, TPCH_TABLES
 
 
 def _require_gaussdb_libpq_platform() -> None:
-    """Skip rather than let the driver segfault against a non-GaussDB libpq."""
-    if sys.platform != "linux" and os.getenv("GAUSSDB_FORCE_INTEGRATION") != "1":
+    """Skip unsafe official-driver runs while allowing psycopg2 on macOS."""
+    driver = os.getenv("GAUSSDB_DRIVER") or ("psycopg2" if sys.platform == "darwin" else "gaussdb")
+    if driver == "gaussdb" and sys.platform != "linux" and os.getenv("GAUSSDB_FORCE_INTEGRATION") != "1":
         pytest.skip(
             f"the gaussdb driver needs the GaussDB/openGauss libpq, which has no {sys.platform} build; "
             "run this suite in a Linux container (or set GAUSSDB_FORCE_INTEGRATION=1)"
@@ -70,6 +73,7 @@ def _build_config() -> GaussDBConfig:
         password=os.getenv("GAUSSDB_PASSWORD", "Datus@123"),
         database=os.getenv("GAUSSDB_DATABASE", "postgres"),
         schema_name=os.getenv("GAUSSDB_SCHEMA", "public"),
+        driver=os.getenv("GAUSSDB_DRIVER") or ("psycopg2" if sys.platform == "darwin" else "gaussdb"),
     )
 
 

--- a/datus-gaussdb/tests/integration/test_connection.py
+++ b/datus-gaussdb/tests/integration/test_connection.py
@@ -18,7 +18,8 @@ def test_connection_with_config_object(config: GaussDBConfig):
     try:
         assert conn.test_connection()
         assert conn.dialect == "gaussdb"
-        assert conn.connection_string.startswith(f"gaussdb+{config.driver}://")
+        sqlalchemy_driver = "psycopg2" if config.driver == "psycopg2" else "psycopg"
+        assert conn.connection_string.startswith(f"gaussdb+{sqlalchemy_driver}://")
     finally:
         conn.close()
 

--- a/datus-gaussdb/tests/integration/test_connection.py
+++ b/datus-gaussdb/tests/integration/test_connection.py
@@ -13,12 +13,12 @@ from datus_gaussdb import GaussDBConfig, GaussDBConnector
 @pytest.mark.integration
 @pytest.mark.acceptance
 def test_connection_with_config_object(config: GaussDBConfig):
-    """Connect through the official gaussdb driver using a config object."""
+    """Connect through the platform-selected driver using a config object."""
     conn = GaussDBConnector(config)
     try:
         assert conn.test_connection()
         assert conn.dialect == "gaussdb"
-        assert conn.connection_string.startswith("gaussdb+psycopg://")
+        assert conn.connection_string.startswith(f"gaussdb+{config.driver}://")
     finally:
         conn.close()
 

--- a/datus-gaussdb/tests/unit/test_config.py
+++ b/datus-gaussdb/tests/unit/test_config.py
@@ -98,10 +98,12 @@ def test_config_schema_name_still_accepted():
 
 
 @pytest.mark.acceptance
-def test_config_driver_defaults_to_gaussdb():
-    """The official driver is the default (sha256/md5/sm3 authentication)."""
+@pytest.mark.parametrize(("platform_name", "expected"), [("linux", "gaussdb"), ("darwin", "psycopg2")])
+def test_config_driver_default_is_platform_safe(monkeypatch, platform_name, expected):
+    """Linux keeps the official driver while macOS avoids its unavailable libpq."""
+    monkeypatch.setattr("datus_gaussdb.config.sys.platform", platform_name)
     config = GaussDBConfig(username="datus")
-    assert config.driver == "gaussdb"
+    assert config.driver == expected
 
 
 @pytest.mark.acceptance

--- a/datus-gaussdb/tests/unit/test_connector_unit.py
+++ b/datus-gaussdb/tests/unit/test_connector_unit.py
@@ -25,7 +25,13 @@ _SA_INIT = "datus_sqlalchemy.SQLAlchemyConnector.__init__"
 
 def _make_connector(**overrides) -> GaussDBConnector:
     """Build a connector whose SQLAlchemy layer is inert."""
-    kwargs = {"username": "datus", "host": "gauss.internal", "port": 25434, "database": "postgres"}
+    kwargs = {
+        "username": "datus",
+        "host": "gauss.internal",
+        "port": 25434,
+        "database": "postgres",
+        "driver": "gaussdb",
+    }
     kwargs.update(overrides)
     with patch(_SA_INIT, return_value=None):
         return GaussDBConnector(GaussDBConfig(**kwargs))
@@ -126,12 +132,12 @@ def test_connection_string_uses_gaussdb_driver_by_default():
 
 
 @pytest.mark.acceptance
-def test_connection_string_uses_postgresql_dialect_for_psycopg2():
-    """The psycopg2 escape hatch falls back to the stock PostgreSQL dialect."""
+def test_connection_string_uses_gaussdb_dialect_for_psycopg2():
+    """The psycopg2 escape hatch keeps GaussDB-specific dialect behavior."""
     connector = _make_connector(driver="psycopg2", password="pass", database="analyticsdb")
 
     assert connector.connection_string == (
-        "postgresql+psycopg2://datus:pass@gauss.internal:25434/analyticsdb?sslmode=prefer"
+        "gaussdb+psycopg2://datus:pass@gauss.internal:25434/analyticsdb?sslmode=prefer"
     )
 
 

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -16,9 +16,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.dialects import registry
 from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 
 from datus_gaussdb import sa_dialect
-from datus_gaussdb.sa_dialect import GaussDBDialect, _GaussDBDbapiProxy
+from datus_gaussdb.sa_dialect import GaussDBDialect, GaussDBPsycopg2Dialect, _GaussDBDbapiProxy
 
 
 def _stub_gaussdb_module() -> types.ModuleType:
@@ -132,6 +133,19 @@ def test_server_version_info_falls_back_when_unparseable():
     assert _version_info("GaussDB Kernel V500R002") == (9, 2)
 
 
+@pytest.mark.acceptance
+def test_psycopg2_server_version_info_uses_gaussdb_parser():
+    """The macOS-compatible path does not invoke PostgreSQL's version regex."""
+    dialect = GaussDBPsycopg2Dialect.__new__(GaussDBPsycopg2Dialect)
+    connection = MagicMock()
+    connection.exec_driver_sql.return_value.scalar.return_value = "9.2.4-openGauss"
+
+    result = dialect._get_server_version_info(connection)
+
+    assert result == (9, 2, 4)
+    connection.exec_driver_sql.assert_called_once_with("SHOW server_version")
+
+
 # ==================== create_connect_args ====================
 
 
@@ -175,9 +189,21 @@ def test_dialect_identity():
     assert GaussDBDialect.supports_statement_cache is True
     assert issubclass(GaussDBDialect, PGDialect_psycopg)
 
+    assert GaussDBPsycopg2Dialect.name == "gaussdb"
+    assert GaussDBPsycopg2Dialect.driver == "psycopg2"
+    assert GaussDBPsycopg2Dialect.supports_statement_cache is True
+    assert issubclass(GaussDBPsycopg2Dialect, PGDialect_psycopg2)
+
 
 @pytest.mark.acceptance
 def test_dialect_registered_in_sqlalchemy_registry():
-    """Both public registry names resolve without touching the native driver."""
+    """All public registry names resolve without touching a native driver."""
     assert registry.load("gaussdb") is GaussDBDialect
     assert registry.load("gaussdb.psycopg") is GaussDBDialect
+    assert registry.load("gaussdb.psycopg2") is GaussDBPsycopg2Dialect
+
+
+@pytest.mark.acceptance
+def test_stock_postgresql_psycopg2_dialect_is_unchanged():
+    """Registering GaussDB's dialect does not replace PostgreSQL behavior."""
+    assert registry.load("postgresql.psycopg2") is PGDialect_psycopg2


### PR DESCRIPTION
## Summary

- add an isolated `gaussdb+psycopg2` SQLAlchemy dialect that parses GaussDB/openGauss server versions without modifying the stock PostgreSQL dialect
- select psycopg2 by default on macOS while preserving the official `gaussdb` driver as the Linux default and honoring explicit driver configuration
- enable macOS integration coverage for the psycopg2 path and document the authentication and platform boundaries

## Validation

- `uv run --group dev python -m pytest datus-gaussdb/tests/unit -q` — 112 passed
- macOS live openGauss integration suite excluding the destructive TPC-H fixture — 30 passed
- Datus Agent `check-db --datasource gaussdb_tpch` — passed
- macOS default-driver query against the existing TPC-H fixture — passed
- Ruff, format check, `git diff --check`, package build, and SQLAlchemy entry-point inspection — passed

## Compatibility

Linux continues to use the official `gaussdb+psycopg` path by default. The psycopg2 compatibility path is isolated under `gaussdb+psycopg2`, so PostgreSQL datasource behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-aware database driver selection: macOS defaults to `psycopg2`, while Linux defaults to `gaussdb`.
  * Added GaussDB-specific SQLAlchemy support for `psycopg2`, including the `gaussdb+psycopg2` connection dialect.
  * Added connection-string support and documentation for both supported drivers.

* **Documentation**
  * Updated authentication, driver selection, dialect, and integration-testing guidance for macOS and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->