### PR TITLE
[Enhancement] Test Oracle adapter against Database 19c

### DIFF
--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -264,9 +264,12 @@ export_adapter_env() {
       export ORACLE_PORT="$ORACLE_HOST_PORT"
       export ORACLE_USER="datus_test"
       export ORACLE_PASSWORD="test_password"
-      export ORACLE_SERVICE_NAME="FREEPDB1"
+      export ORACLE_SID="${ORACLE_SID:-ORCLCDB}"
+      export ORACLE_PDB="${ORACLE_PDB:-ORCLPDB1}"
+      export ORACLE_SERVICE_NAME="${ORACLE_SERVICE_NAME:-$ORACLE_PDB}"
       export ORACLE_SCHEMA="DATUS_TEST"
       export ORACLE_SYS_PASSWORD="${ORACLE_SYS_PASSWORD:-test_sys_password}"
+      export ORACLE_READY_TIMEOUT="${ORACLE_READY_TIMEOUT:-1200}"
       ;;
     gaussdb)
       export GAUSSDB_HOST_PORT="${GAUSSDB_HOST_PORT:-25434}"
@@ -657,7 +660,7 @@ elif adapter == "oracle":
         port=int(os.getenv("ORACLE_PORT", "1521")),
         username=os.getenv("ORACLE_USER", "datus_test"),
         password=os.getenv("ORACLE_PASSWORD", "test_password"),
-        service_name=os.getenv("ORACLE_SERVICE_NAME", "FREEPDB1"),
+        service_name=os.getenv("ORACLE_SERVICE_NAME", "ORCLPDB1"),
         schema_name=os.getenv("ORACLE_SCHEMA", "DATUS_TEST"),
         timeout_seconds=5,
     )

--- a/datus-oracle/README.md
+++ b/datus-oracle/README.md
@@ -21,7 +21,7 @@ services:
       port: 1521
       username: datus_test
       password: ${ORACLE_PASSWORD}
-      service_name: FREEPDB1
+      service_name: ORCLPDB1
       schema: DATUS_TEST
       default: true
 ```
@@ -47,6 +47,9 @@ cd datus-oracle && python -m pytest tests/unit/ -v
 
 # Start the local integration database. Both passwords are required; choose
 # values that are not reused outside this disposable development environment.
+# The default Oracle 19c Enterprise Edition image requires accepting its license
+# in Oracle Container Registry and logging Docker in to that registry first.
+docker login container-registry.oracle.com
 export ORACLE_SYS_PASSWORD='<strong-sys-password>'
 export ORACLE_PASSWORD='<app-password-starting-with-a-letter>'
 docker compose up -d
@@ -54,6 +57,11 @@ docker compose up -d
 # Integration tests
 cd datus-oracle && python -m pytest tests/integration/ -v
 ```
+
+The compose environment pins Oracle Database 19c `19.3.0.0`, uses
+`ORCLCDB`/`ORCLPDB1`, and stores its data in a dedicated 19c volume. The first
+database creation is substantially slower than restarting an initialized
+volume; the CI readiness probe allows up to 20 minutes by default.
 
 ### Sample schemas
 

--- a/datus-oracle/docker-compose.yml
+++ b/datus-oracle/docker-compose.yml
@@ -1,19 +1,23 @@
 services:
   oracle:
-    # Official Oracle Database Free image; pin the tag (no floating latest)
-    image: container-registry.oracle.com/database/free:23.8.0.0
+    # Official Oracle Database 19c Enterprise Edition; pin the tag (no floating latest).
+    # Pulling this image requires accepting the Oracle Container Registry license and logging in.
+    image: ${ORACLE_IMAGE:-container-registry.oracle.com/database/enterprise:19.3.0.0}
     environment:
+      ORACLE_SID: ${ORACLE_SID:-ORCLCDB}
+      ORACLE_PDB: ${ORACLE_PDB:-ORCLPDB1}
       ORACLE_PWD: ${ORACLE_SYS_PASSWORD:?Set ORACLE_SYS_PASSWORD}
       ORACLE_APP_PASSWORD: ${ORACLE_PASSWORD:?Set ORACLE_PASSWORD}
     ports:
       - "127.0.0.1:${ORACLE_HOST_PORT:-1521}:1521"
     volumes:
-      # The Free image ships a prebuilt database, so setup scripts are skipped.
+      # Startup scripts run after the 19c database is created and after every restart.
       - ./docker/init:/opt/oracle/scripts/startup:ro
       # Vendored Oracle sample schemas, installed by docker/init/02_install_hr_schema.sh.
       # Kept out of the startup directory so the runner does not execute them directly.
       - ./docker/sample-schemas:/opt/oracle/sample-schemas:ro
-      - oracle_data:/opt/oracle/oradata
+      # Keep 19c files separate from the previous 23ai Free volume; they are not compatible.
+      - oracle19c_data:/opt/oracle/oradata
 
 volumes:
-  oracle_data:
+  oracle19c_data:

--- a/datus-oracle/docker/init/01_create_test_user.sh
+++ b/datus-oracle/docker/init/01_create_test_user.sh
@@ -11,10 +11,16 @@ if [[ ! "$ORACLE_APP_PASSWORD" =~ ^[A-Za-z][A-Za-z0-9_]{7,127}$ ]]; then
   exit 1
 fi
 
+ORACLE_PDB="${ORACLE_PDB:-ORCLPDB1}"
+if [[ ! "$ORACLE_PDB" =~ ^[A-Za-z][A-Za-z0-9_]{0,127}$ ]]; then
+  echo "ORACLE_PDB must be an unquoted Oracle identifier." >&2
+  exit 1
+fi
+
 sqlplus -s / as sysdba <<SQL
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 
-ALTER SESSION SET CONTAINER = FREEPDB1;
+ALTER SESSION SET CONTAINER = ${ORACLE_PDB};
 
 DECLARE
     user_count PLS_INTEGER;

--- a/datus-oracle/docker/init/02_install_hr_schema.sh
+++ b/datus-oracle/docker/init/02_install_hr_schema.sh
@@ -30,13 +30,19 @@ if [[ ! "$HR_PASSWORD" =~ ^[A-Za-z][A-Za-z0-9_]{7,127}$ ]]; then
   exit 1
 fi
 
+ORACLE_PDB="${ORACLE_PDB:-ORCLPDB1}"
+if [[ ! "$ORACLE_PDB" =~ ^[A-Za-z][A-Za-z0-9_]{0,127}$ ]]; then
+  echo "ORACLE_PDB must be an unquoted Oracle identifier." >&2
+  exit 1
+fi
+
 # Key the probe on an installed object, not on the HR user: an install that
 # aborted midway leaves the user behind with no tables, and a user-only check
 # would treat that empty schema as complete forever.
 already_installed="$(sqlplus -s / as sysdba <<SQL
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 SET HEADING OFF FEEDBACK OFF PAGESIZE 0
-ALTER SESSION SET CONTAINER = FREEPDB1;
+ALTER SESSION SET CONTAINER = ${ORACLE_PDB};
 SELECT COUNT(*) FROM dba_tables WHERE owner = 'HR' AND table_name = 'EMPLOYEES';
 EXIT;
 SQL
@@ -66,7 +72,7 @@ WHENEVER SQLERROR EXIT SQL.SQLCODE
 WHENEVER OSERROR EXIT FAILURE
 SET ECHO OFF FEEDBACK OFF VERIFY OFF
 
-ALTER SESSION SET CONTAINER = FREEPDB1;
+ALTER SESSION SET CONTAINER = ${ORACLE_PDB};
 
 -- Reaching here means the schema is incomplete, so a leftover HR user is the
 -- remains of a failed install: drop it and start from a clean slate.

--- a/datus-oracle/tests/integration/conftest.py
+++ b/datus-oracle/tests/integration/conftest.py
@@ -311,7 +311,7 @@ def _make_config() -> OracleConfig:
         port=int(os.getenv("ORACLE_PORT", "1521")),
         username=os.getenv("ORACLE_USER", "datus_test"),
         password=os.getenv("ORACLE_PASSWORD", "test_password"),
-        service_name=os.getenv("ORACLE_SERVICE_NAME", "FREEPDB1"),
+        service_name=os.getenv("ORACLE_SERVICE_NAME", "ORCLPDB1"),
         schema_name=os.getenv("ORACLE_SCHEMA", "DATUS_TEST"),
     )
 

--- a/datus-oracle/tests/integration/test_integration.py
+++ b/datus-oracle/tests/integration/test_integration.py
@@ -38,7 +38,7 @@ def test_connection_with_dict():
                 "port": int(os.getenv("ORACLE_PORT", "1521")),
                 "username": os.getenv("ORACLE_USER", "datus_test"),
                 "password": os.getenv("ORACLE_PASSWORD", "test_password"),
-                "database": os.getenv("ORACLE_SERVICE_NAME", "FREEPDB1"),
+                "database": os.getenv("ORACLE_SERVICE_NAME", "ORCLPDB1"),
             }
         )
         assert conn.test_connection()


### PR DESCRIPTION
## Summary

- replace the Oracle 23ai Free integration image with the pinned Oracle Database 19c Enterprise Edition 19.3.0.0 image
- switch the integration service from FREEPDB1 to ORCLCDB/ORCLPDB1 and make startup scripts honor the configured PDB
- isolate 19c data from the previous 23ai volume and allow 20 minutes for first-time database creation
- document the Oracle Container Registry login requirement

## Validation

- `85 passed` in the datus-oracle unit suite
- `33 passed` in the CI tooling suite
- Ruff check and format check
- Bash syntax checks for the integration runner and Oracle startup scripts
- Docker Compose configuration validation

## CI note

The self-hosted Ubuntu runner has the pinned Oracle 19c image pre-pulled from Oracle Container Registry. The merge-queue integration job will perform the live Oracle 19c validation.