### PR TITLE
[Feature] GaussDB: pure-Python pg8000 driver with native SHA256 auth, full sslmode support, tolerant bool decoding

### DIFF
--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -52,7 +52,7 @@ identifiers.
 | Driver | Authentication methods | When to use |
 |--------|-----------------------|-------------|
 | `gaussdb` (Linux default) | sha256, md5, sm3 | Any GaussDB / openGauss server, including a stock installation |
-| `pg8000` (macOS default) | sha256, md5 | Pure Python, no libpq — any platform, any stock server |
+| `pg8000` (macOS default) | sha256, md5 | Pure Python, no libpq — any platform; SHA256/MD5-stored accounts (not SM3) |
 | `psycopg2` | md5 only | Escape hatch when neither of the above can be installed |
 
 GaussDB defaults to `sha256` password authentication, which vanilla PostgreSQL

--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -52,25 +52,42 @@ identifiers.
 | Driver | Authentication methods | When to use |
 |--------|-----------------------|-------------|
 | `gaussdb` (Linux default) | sha256, md5, sm3 | Any GaussDB / openGauss server, including a stock installation |
-| `psycopg2` (macOS default) | md5 only | PostgreSQL wire-compatible connection when official libpq is unavailable |
+| `pg8000` (macOS default) | sha256, md5 | Pure Python, no libpq — any platform, any stock server |
+| `psycopg2` | md5 only | Escape hatch when neither of the above can be installed |
 
 GaussDB defaults to `sha256` password authentication, which vanilla PostgreSQL
-drivers do not implement. The default `gaussdb` driver speaks it, so a stock
-server works with no server-side changes.
+drivers do not implement. The default `gaussdb` driver speaks it natively, so a
+stock server works with no server-side changes.
 
-On macOS, the adapter selects `psycopg2` automatically because the official
-GaussDB/openGauss libpq is not published for Darwin. It can also be selected
-explicitly on any platform:
+The `pg8000` driver reaches the same result without libpq: it extends the
+pure-Python [pg8000](https://pypi.org/project/pg8000/) driver with GaussDB's
+SHA256 handshake (RFC 5802 over startup protocol 3.51) in
+`datus_gaussdb/_pg8000_gauss.py`. macOS selects it automatically — the
+official libpq has no Darwin build — and it can be chosen explicitly on any
+platform:
 
 ```yaml
-      driver: psycopg2
+      driver: pg8000
 ```
 
-It requires the server to offer md5 authentication for that login: an `md5`
-rule in `pg_hba.conf` **and** a password stored as an md5 digest, which means
-the role's password must have been set while `password_encryption_type = 1`
-(GaussDB's md5-compatible setting). Changing that parameter does not re-encrypt
-existing passwords — the role's password has to be set again afterwards.
+For TLS it maps the full libpq `sslmode` vocabulary onto Python's `ssl`
+module; `verify-ca` / `verify-full` additionally need the CA bundle:
+
+```yaml
+      sslmode: verify-full
+      sslrootcert: /etc/ssl/gauss-ca.pem
+```
+
+The `psycopg2` escape hatch requires the server to offer md5 authentication
+for that login: an `md5` rule in `pg_hba.conf` **and** a password stored as an
+md5 digest, which means the role's password must have been set while
+`password_encryption_type = 1` (GaussDB's md5-compatible setting). Changing
+that parameter does not re-encrypt existing passwords — the role's password
+has to be set again afterwards.
+
+All drivers decode GaussDB booleans tolerantly: databases in `B` (MySQL)
+compatibility mode render `boolean` as `'1'/'0'`, which strict PostgreSQL
+parsers silently read as `False`.
 
 ## Vendored libpq
 
@@ -97,10 +114,10 @@ neither installation shadows the other. Set `DATUS_GAUSSDB_LIBPQ=system` if you
 would rather use the client you installed.
 
 The official `gaussdb` driver is not supported on macOS — no openGauss libpq is
-published for Darwin. The adapter therefore uses its isolated
-`gaussdb+psycopg2` dialect on macOS. This does not replace or monkey-patch
-SQLAlchemy's PostgreSQL dialect, and Linux continues to use the official driver
-by default.
+published for Darwin. The adapter therefore defaults to the pure-Python
+`gaussdb+pg8000` dialect on macOS. None of the GaussDB dialects replace or
+monkey-patch SQLAlchemy's PostgreSQL dialects, and Linux continues to use the
+official driver by default.
 
 ## Compatibility modes and deployment shapes
 
@@ -153,9 +170,10 @@ documents two openGauss container quirks (the mandatory out-of-datadir
 `GAUSSLOG`, and the first post-initdb server start aborting on Docker Desktop
 for macOS) that its entrypoint wrapper works around.
 
-On macOS, integration tests use `psycopg2` by default. To exercise the official
+On macOS, integration tests use `pg8000` by default. To exercise the official
 driver, run them in a Linux container or explicitly set `GAUSSDB_DRIVER=gaussdb`
-on a Linux host.
+on a Linux host; `GAUSSDB_DRIVER=pg8000` selects the pure-Python path on any
+platform.
 
 ## Source checkouts
 

--- a/datus-gaussdb/datus_gaussdb/_pg8000_gauss.py
+++ b/datus-gaussdb/datus_gaussdb/_pg8000_gauss.py
@@ -1,0 +1,161 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""GaussDB/openGauss authentication for the pure-Python ``pg8000`` driver.
+
+GaussDB replaces PostgreSQL's SASL authentication with a private SHA256
+handshake whose auth-code numbers collide with PG's SASL codes, so stock
+PostgreSQL drivers fail before the password is even checked. pg8000 is pure
+Python — no libpq, no C extension — which makes the handshake patchable and
+the driver usable on every platform, including macOS where no GaussDB libpq
+build exists.
+
+Two deltas against stock pg8000, both verified against a live openGauss
+7.0.0-RC2 and a Huawei-cloud managed GaussDB Kernel 505.2.1:
+
+1. **Startup protocol 3.51** (196659) instead of 3.0 (196608). Under 3.0 the
+   server's SHA256 payload omits the PBKDF2 iteration count, so no client can
+   derive the key; under 3.51 (the modern openGauss JDBC default) the
+   iteration count is explicit.
+2. **Auth code 10 means AUTH_REQ_SHA256** on GaussDB, not PG's
+   AuthenticationSASL. The client proof is the RFC 5802 scheme below,
+   verified byte-for-byte against openGauss JDBC's
+   ``MD5Digest.RFC5802Algorithm``.
+
+This module is a self-contained DB-API 2.0 module (SQLAlchemy's
+``import_dbapi`` contract): it re-exports pg8000's DB-API surface and swaps
+in a GaussDB-aware ``Connection``/``connect``.
+"""
+
+import hashlib
+import hmac
+import struct
+import types
+
+import pg8000
+import pg8000.core as _core
+import pg8000.dbapi as _dbapi
+from pg8000.core import NULL_BYTE, PASSWORD, CoreConnection, _flush
+from pg8000.dbapi import InterfaceError
+
+# Re-export the full DB-API surface (exceptions, type constructors, module
+# constants) so this module is a drop-in ``import_dbapi`` target. pg8000's
+# __all__ omits the PEP 249 module globals, so they come from the dbapi
+# module explicitly.
+globals().update({name: getattr(pg8000, name) for name in pg8000.__all__})
+apilevel = _dbapi.apilevel
+threadsafety = _dbapi.threadsafety
+paramstyle = _dbapi.paramstyle
+
+PROTOCOL_3_0 = 196608
+PROTOCOL_3_51 = 196659
+
+# GaussDB password-stored methods (first int32 of the auth code 10 payload).
+_METHOD_PLAIN = 0
+_METHOD_MD5 = 1
+_METHOD_SHA256 = 2
+_METHOD_SM3 = 3
+
+_AUTH_HINT = (
+    "GaussDB accounts must use an MD5- or SHA256-stored password "
+    "(password_encryption_type 0, 1 or 2). If the server's pg_hba method is "
+    "'md5' while the account's password is SHA256-only, or the password uses "
+    "SM3, re-set the account password under password_encryption_type = 1 or "
+    "switch the pg_hba method to 'sha256'."
+)
+
+
+def rfc5802_response(password: bytes, random64_hex: bytes, token_hex: bytes, iteration: int) -> bytes:
+    """GaussDB's RFC 5802 client proof, as lowercase-hex ASCII bytes.
+
+    Matches openGauss JDBC's ``MD5Digest.RFC5802Algorithm``: the PBKDF2 salt
+    and the token are the *decoded* bytes of their hex strings, and the HMAC
+    key direction is K-as-key with the literal strings as data.
+    """
+    k = hashlib.pbkdf2_hmac("sha1", password, bytes.fromhex(random64_hex.decode("ascii")), iteration, 32)
+    client_key = hmac.new(k, b"Client Key", hashlib.sha256).digest()
+    stored_key = hashlib.sha256(client_key).digest()
+    h = hmac.new(stored_key, bytes.fromhex(token_hex.decode("ascii")), hashlib.sha256).digest()
+    return bytes(a ^ b for a, b in zip(h, client_key)).hex().encode("ascii")
+
+
+def _md5_response(user: bytes, password: bytes, salt: bytes) -> bytes:
+    inner = hashlib.md5(password + user).hexdigest().encode("ascii")
+    return b"md5" + hashlib.md5(inner + salt).hexdigest().encode("ascii")
+
+
+def _i_pack_351(value):
+    """``i_pack`` that rewrites the startup protocol constant to 3.51.
+
+    Scoped to the cloned ``__init__`` below; 196608 appears in that function
+    only as the protocol constant (a startup packet can never be 196608 bytes
+    long), so the rewrite is unambiguous.
+    """
+    return _core.i_pack(PROTOCOL_3_51 if value == PROTOCOL_3_0 else value)
+
+
+# ``protocol = 196608`` is a hardcoded local inside CoreConnection.__init__ —
+# there is no subclass hook. Rather than copying the ~140-line method (which
+# would silently drift from upstream), clone the function object with a
+# patched ``i_pack`` in its globals. The clone is thread-safe (no module
+# state is touched) and survives upstream patch releases as long as the
+# ``i_pack(protocol)`` idiom stays; test_pg8000_gauss.py carries a drift
+# guard pinning the upstream source. Tracked for removal once pg8000 grows a
+# ``protocol_version`` parameter (upstream PR planned).
+_init_3_51 = types.FunctionType(
+    CoreConnection.__init__.__code__,
+    {**vars(_core), "i_pack": _i_pack_351},
+    "__init__",
+    CoreConnection.__init__.__defaults__,
+    CoreConnection.__init__.__closure__,
+)
+
+
+class _GaussCore(CoreConnection):
+    """CoreConnection speaking startup 3.51 and the GaussDB SHA256 handshake."""
+
+    __init__ = _init_3_51
+
+    def handle_AUTHENTICATION_REQUEST(self, data, context):
+        auth_code = _core.i_unpack(data)[0]
+        # PG's AuthenticationSASL is also code 10; its payload is a
+        # null-terminated mechanism list ("SCRAM-SHA-256..."), while
+        # GaussDB's starts with a binary method int. Delegate the SASL shape
+        # so this class stays correct against a real PostgreSQL server.
+        if auth_code != 10 or b"SCRAM" in data[4:]:
+            if auth_code == 11:
+                raise InterfaceError(
+                    "GaussDB MD5_SHA256 authentication (code 11) omits the "
+                    "PBKDF2 iteration count, so no client can derive the "
+                    f"key. {_AUTH_HINT}"
+                )
+            return super().handle_AUTHENTICATION_REQUEST(data, context)
+
+        if self.password is None:
+            raise InterfaceError("server requesting GaussDB SHA256 authentication, but no password was provided")
+        payload = data[4:]
+        method = struct.unpack("!I", payload[:4])[0]
+        body = payload[4:]
+        if method in (_METHOD_PLAIN, _METHOD_SHA256):
+            random64, token = body[:64], body[64:72]
+            iteration = struct.unpack("!I", body[72:76])[0]
+            response = rfc5802_response(self.password, random64, token, iteration)
+        elif method == _METHOD_MD5:
+            response = _md5_response(self.user, self.password, body[:4])
+        else:
+            raise InterfaceError(f"GaussDB password-stored method {method} is not supported. {_AUTH_HINT}")
+        self._send_message(PASSWORD, response + NULL_BYTE)
+        _flush(self._sock)
+
+
+class Connection(_dbapi.Connection, _GaussCore):
+    """DB-API 2.0 connection; MRO inserts the GaussDB core under pg8000's.
+
+    ``pg8000.dbapi.Connection.__init__`` delegates straight to
+    ``super().__init__``, which resolves to :class:`_GaussCore` here.
+    """
+
+
+def connect(*args, **kwargs):
+    return Connection(*args, **kwargs)

--- a/datus-gaussdb/datus_gaussdb/_pg8000_gauss.py
+++ b/datus-gaussdb/datus_gaussdb/_pg8000_gauss.py
@@ -51,6 +51,12 @@ paramstyle = _dbapi.paramstyle
 PROTOCOL_3_0 = 196608
 PROTOCOL_3_51 = 196659
 
+# The server names the PBKDF2 iteration count and the client must obey it, so
+# an unauthenticated hostile endpoint could demand arbitrary work before any
+# password check. openGauss/GaussDB default to 10000 (GUC-tunable); two orders
+# of magnitude above that is generously legitimate, anything more is abuse.
+MAX_PBKDF2_ITERATIONS = 1_000_000
+
 # GaussDB password-stored methods (first int32 of the auth code 10 payload).
 _METHOD_PLAIN = 0
 _METHOD_MD5 = 1
@@ -140,6 +146,11 @@ class _GaussCore(CoreConnection):
         if method in (_METHOD_PLAIN, _METHOD_SHA256):
             random64, token = body[:64], body[64:72]
             iteration = struct.unpack("!I", body[72:76])[0]
+            if not 0 < iteration <= MAX_PBKDF2_ITERATIONS:
+                raise InterfaceError(
+                    f"server demanded {iteration} PBKDF2 iterations "
+                    f"(sane range: 1..{MAX_PBKDF2_ITERATIONS}); refusing the handshake"
+                )
             response = rfc5802_response(self.password, random64, token, iteration)
         elif method == _METHOD_MD5:
             response = _md5_response(self.user, self.password, body[:4])

--- a/datus-gaussdb/datus_gaussdb/config.py
+++ b/datus-gaussdb/datus_gaussdb/config.py
@@ -3,16 +3,20 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import sys
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import Field
 
 from datus_postgresql import PostgreSQLConfig
 
 
-def _default_driver() -> Literal["gaussdb", "psycopg2"]:
-    """Use the portable wire-compatible client when Darwin lacks GaussDB libpq."""
-    return "psycopg2" if sys.platform == "darwin" else "gaussdb"
+def _default_driver() -> Literal["gaussdb", "pg8000"]:
+    """The official driver binds the GaussDB libpq, which has no Darwin build.
+
+    macOS therefore defaults to the pure-Python ``pg8000`` path, which speaks
+    the GaussDB SHA256 handshake natively and works against a stock server.
+    """
+    return "pg8000" if sys.platform == "darwin" else "gaussdb"
 
 
 class GaussDBConfig(PostgreSQLConfig):
@@ -22,12 +26,21 @@ class GaussDBConfig(PostgreSQLConfig):
     inherited from PostgreSQLConfig.
     """
 
-    driver: Literal["gaussdb", "psycopg2"] = Field(
+    driver: Literal["gaussdb", "pg8000", "psycopg2"] = Field(
         default_factory=_default_driver,
         description=(
-            "Client driver. 'gaussdb' (official driver, supports sha256/md5/sm3 "
-            "authentication; default outside macOS) or 'psycopg2' (macOS "
-            "default and portable escape hatch; requires md5 authentication "
-            "on the server)"
+            "Client driver. 'gaussdb' (official driver; sha256/md5/sm3 "
+            "authentication; default outside macOS), 'pg8000' (pure Python; "
+            "sha256/md5 authentication on every platform; macOS default) or "
+            "'psycopg2' (escape hatch; requires md5 authentication on the "
+            "server)"
+        ),
+    )
+    sslrootcert: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to the CA certificate for sslmode verify-ca/verify-full. "
+            "Only honored by the pg8000 driver; the libpq-based drivers read "
+            "the standard PGSSLROOTCERT locations instead."
         ),
     )

--- a/datus-gaussdb/datus_gaussdb/connector.py
+++ b/datus-gaussdb/datus_gaussdb/connector.py
@@ -36,8 +36,8 @@ class GaussDBConnector(PostgreSQLConnector):
     all execution and metadata logic from PostgreSQLConnector and connects
     through the official ``gaussdb`` driver (sha256/md5/sm3 authentication)
     via the ``gaussdb+psycopg`` SQLAlchemy dialect. On macOS, where the
-    official libpq is unavailable, it uses the isolated
-    ``gaussdb+psycopg2`` compatibility dialect by default.
+    official libpq is unavailable, it defaults to the pure-Python
+    ``gaussdb+pg8000`` dialect, which speaks the SHA256 handshake natively.
     """
 
     def __init__(self, config: Union[GaussDBConfig, dict]):

--- a/datus-gaussdb/datus_gaussdb/connector.py
+++ b/datus-gaussdb/datus_gaussdb/connector.py
@@ -59,13 +59,16 @@ class GaussDBConnector(PostgreSQLConnector):
 
     @override
     def _build_connection_string(self, database_name: str) -> str:
-        prefix = "gaussdb+psycopg2" if self.config.driver == "psycopg2" else "gaussdb+psycopg"
+        prefix = {
+            "psycopg2": "gaussdb+psycopg2",
+            "pg8000": "gaussdb+pg8000",
+        }.get(self.config.driver, "gaussdb+psycopg")
         encoded_username = quote_plus(self.username) if self.username else ""
         encoded_password = quote_plus(self.password) if self.password else ""
-        return (
-            f"{prefix}://{encoded_username}:{encoded_password}"
-            f"@{self.host}:{self.port}/{database_name}?sslmode={self.config.sslmode}"
-        )
+        query = f"sslmode={self.config.sslmode}"
+        if self.config.sslrootcert:
+            query += f"&sslrootcert={quote_plus(self.config.sslrootcert)}"
+        return f"{prefix}://{encoded_username}:{encoded_password}@{self.host}:{self.port}/{database_name}?{query}"
 
     # ==================== System Resources ====================
 

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -194,6 +194,16 @@ def _build_pg8000_ssl_context(sslmode, sslrootcert):
     negotiates but falls back to plaintext (libpq's prefer), ``True``
     requires TLS without verification, and a custom ``SSLContext`` requires
     TLS with that context's verification rules.
+
+    Two libpq subtleties carried over deliberately:
+
+    * ``allow`` is treated as ``prefer`` (TLS-first with plaintext fallback)
+      rather than libpq's plaintext-first order — the same approximation the
+      Rust executor and most non-libpq drivers make; both spellings end up
+      connected either way.
+    * ``require`` **with** ``sslrootcert`` verifies the chain like
+      ``verify-ca`` — libpq's documented backwards-compatibility behavior.
+      Without a CA file it only encrypts.
     """
     import ssl as ssl_module
 
@@ -203,7 +213,11 @@ def _build_pg8000_ssl_context(sslmode, sslrootcert):
     if mode in ("allow", "prefer"):
         return None
     if mode == "require":
-        return True
+        if not sslrootcert:
+            return True
+        context = ssl_module.create_default_context(cafile=sslrootcert)
+        context.check_hostname = False
+        return context
     if mode in ("verify-ca", "verify-full"):
         if not sslrootcert:
             raise ValueError(f"sslmode={mode} requires sslrootcert to point at the CA certificate")

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -253,6 +253,13 @@ class GaussDBPg8000Dialect(PGDialect_pg8000):
         sslmode = opts.pop("sslmode", None)
         sslrootcert = opts.pop("sslrootcert", None)
         opts["ssl_context"] = _build_pg8000_ssl_context(sslmode, sslrootcert)
+        # Chinese GaussDB deployments often run server_encoding=GBK, and the
+        # server then defaults client_encoding to GBK too. pg8000 does not
+        # negotiate an encoding at startup — it decodes with whatever the
+        # server reports — so pin UTF8 and let the server transcode.
+        startup = dict(opts.get("startup_params") or {})
+        startup.setdefault("client_encoding", "UTF8")
+        opts["startup_params"] = startup
         return args, opts
 
     def on_connect(self):

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -15,20 +15,39 @@ The optional psycopg2 path uses its own GaussDB-named dialect. This keeps the
 stock PostgreSQL dialect untouched while allowing PostgreSQL's macOS libpq to
 connect to servers that expose the compatible wire protocol.
 
+The pure-Python pg8000 path (``datus_gaussdb._pg8000_gauss``) speaks the
+GaussDB SHA256 handshake natively and therefore works on every platform,
+macOS included; it is selected by default there.
+
 URL forms::
 
     gaussdb+psycopg://user:password@host:port/database
     gaussdb+psycopg2://user:password@host:port/database
+    gaussdb+pg8000://user:password@host:port/database
 """
 
 import sys
 import types
 
 from sqlalchemy.dialects import registry
+from sqlalchemy.dialects.postgresql.pg8000 import PGDialect_pg8000
 from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 
 from ._libpq import import_gaussdb
+
+# GaussDB databases in 'B' (MySQL) compatibility mode render booleans as
+# '1'/'0' instead of PostgreSQL's 't'/'f' — the type OID stays BOOL, only
+# the text changes, so strict parsers silently read every True as False.
+# A tolerant parser is correct in every compatibility mode ('t' never means
+# False and '1' never means True elsewhere), so it is registered
+# unconditionally instead of per-mode.
+_BOOL_TRUE_TEXTS = ("t", "true", "1", "y", "yes", "on")
+
+
+def _gaussdb_bool_in(data):
+    return data in _BOOL_TRUE_TEXTS
+
 
 _PSYCOPG_SUBMODULES = (
     "adapt",
@@ -119,6 +138,21 @@ class GaussDBDialect(PGDialect_psycopg):
     def _get_server_version_info(self, connection):
         return _get_server_version_info(connection)
 
+    def on_connect(self):
+        parent = super().on_connect()
+        gaussdb_mod = sys.modules["gaussdb"]
+
+        class _TolerantBoolLoader(gaussdb_mod.adapt.Loader):
+            def load(self, data):
+                return bytes(data).decode("ascii") in _BOOL_TRUE_TEXTS
+
+        def connect(conn):
+            if parent is not None:
+                parent(conn)
+            conn.adapters.register_loader("bool", _TolerantBoolLoader)
+
+        return connect
+
 
 class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
     """GaussDB/openGauss dialect using PostgreSQL's psycopg2 client.
@@ -131,6 +165,91 @@ class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
     name = "gaussdb"
     driver = "psycopg2"
     supports_statement_cache = True
+
+    def _get_server_version_info(self, connection):
+        return _get_server_version_info(connection)
+
+    def on_connect(self):
+        parent = super().on_connect()
+
+        def connect(conn):
+            if parent is not None:
+                parent(conn)
+            import psycopg2.extensions as ext
+
+            tolerant_bool = ext.new_type(
+                (16,),
+                "GAUSSDB_BOOLEAN",
+                lambda value, _cur: None if value is None else value in _BOOL_TRUE_TEXTS,
+            )
+            ext.register_type(tolerant_bool, conn)
+
+        return connect
+
+
+def _build_pg8000_ssl_context(sslmode, sslrootcert):
+    """Map the libpq ``sslmode`` vocabulary onto pg8000's ``ssl_context``.
+
+    pg8000 semantics: ``False`` skips the SSLRequest entirely, ``None``
+    negotiates but falls back to plaintext (libpq's prefer), ``True``
+    requires TLS without verification, and a custom ``SSLContext`` requires
+    TLS with that context's verification rules.
+    """
+    import ssl as ssl_module
+
+    mode = (sslmode or "prefer").strip().lower()
+    if mode == "disable":
+        return False
+    if mode in ("allow", "prefer"):
+        return None
+    if mode == "require":
+        return True
+    if mode in ("verify-ca", "verify-full"):
+        if not sslrootcert:
+            raise ValueError(f"sslmode={mode} requires sslrootcert to point at the CA certificate")
+        context = ssl_module.create_default_context(cafile=sslrootcert)
+        context.check_hostname = mode == "verify-full"
+        return context
+    raise ValueError(
+        f"unknown sslmode {mode!r}: expected one of disable, allow, prefer, require, verify-ca, verify-full"
+    )
+
+
+class GaussDBPg8000Dialect(PGDialect_pg8000):
+    """GaussDB/openGauss dialect over the pure-Python pg8000 driver.
+
+    The DB-API module is :mod:`datus_gaussdb._pg8000_gauss`, which extends
+    pg8000 with the GaussDB SHA256 handshake (startup protocol 3.51). Pure
+    Python end to end — no libpq — so this path works on every platform and
+    is the macOS default.
+    """
+
+    name = "gaussdb"
+    driver = "pg8000"
+    supports_statement_cache = True
+
+    @classmethod
+    def import_dbapi(cls):
+        from . import _pg8000_gauss
+
+        return _pg8000_gauss
+
+    def create_connect_args(self, url):
+        args, opts = super().create_connect_args(url)
+        sslmode = opts.pop("sslmode", None)
+        sslrootcert = opts.pop("sslrootcert", None)
+        opts["ssl_context"] = _build_pg8000_ssl_context(sslmode, sslrootcert)
+        return args, opts
+
+    def on_connect(self):
+        parent = super().on_connect()
+
+        def connect(conn):
+            if parent is not None:
+                parent(conn)
+            conn.register_in_adapter(16, _gaussdb_bool_in)
+
+        return connect
 
     def _get_server_version_info(self, connection):
         return _get_server_version_info(connection)
@@ -157,3 +276,4 @@ def _get_server_version_info(connection):
 registry.register("gaussdb", "datus_gaussdb.sa_dialect", "GaussDBDialect")
 registry.register("gaussdb.psycopg", "datus_gaussdb.sa_dialect", "GaussDBDialect")
 registry.register("gaussdb.psycopg2", "datus_gaussdb.sa_dialect", "GaussDBPsycopg2Dialect")
+registry.register("gaussdb.pg8000", "datus_gaussdb.sa_dialect", "GaussDBPg8000Dialect")

--- a/datus-gaussdb/datus_gaussdb/skills/db-gaussdb-sql/SKILL.md
+++ b/datus-gaussdb/datus_gaussdb/skills/db-gaussdb-sql/SKILL.md
@@ -20,6 +20,10 @@ Generate GaussDB-compatible SQL from metadata-provided object and column names. 
 - In `A` mode, string concatenation follows Oracle semantics: `NULL || 'x'` returns `'x'`, not NULL.
 - Do not use Oracle-only functions or syntax (`nvl`, `decode`, `sysdate`, `add_months`, `(+)` outer joins) even in `A` mode; use PostgreSQL equivalents (`coalesce`, `CASE`, `current_timestamp`, interval arithmetic, ANSI joins).
 - Prefer explicit casts (`CAST(x AS type)` or `x::type`) — `A` mode implicit conversions differ from vanilla PostgreSQL, and `DATE` behaves like a timestamp there.
+- In `B` mode, `date1 - date2` subtracts the dates *as numbers* (`20240315 - 20240101 = 214`), not as a day count. For a portable day difference in every mode use `to_char(d1,'J')::int - to_char(d2,'J')::int`; `DATEDIFF` exists only in `B` mode.
+- In `B` mode, NULLs sort *first* ascending (opposite of PostgreSQL). When NULL placement matters — especially before `LIMIT` — always spell it out: `ORDER BY col NULLS LAST` (or `NULLS FIRST`).
+- In `B` mode, `extract(week ...)` uses MySQL week numbering; use `to_char(d,'IW')` for ISO week in every mode.
+- In `B` mode, boolean values render as `'1'/'0'` and aggregates over an empty set may not be NULL. For text output of booleans compare explicitly (`CASE WHEN flag THEN ...`) instead of relying on the rendering.
 
 ## Queries and types
 

--- a/datus-gaussdb/pyproject.toml
+++ b/datus-gaussdb/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "datus-sqlalchemy>=0.1.8",
     "datus-postgresql>=0.1.8",
     "gaussdb>=1.0.4,<2",
+    "pg8000>=1.31.5,<1.32",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.0.0",
 ]

--- a/datus-gaussdb/tests/integration/conftest.py
+++ b/datus-gaussdb/tests/integration/conftest.py
@@ -15,7 +15,7 @@ Variable                     Default             Meaning
 ``GAUSSDB_PASSWORD``         ``Datus@123``       login password
 ``GAUSSDB_DATABASE``         ``postgres``        default database
 ``GAUSSDB_SCHEMA``           ``public``          default schema
-``GAUSSDB_DRIVER``           platform default    ``gaussdb`` or ``psycopg2``
+``GAUSSDB_DRIVER``           platform default    ``gaussdb``, ``pg8000`` or ``psycopg2``
 ===========================  ==================  =========================
 
 IMPORTANT — platform caveat: the official ``gaussdb`` driver binds the
@@ -50,8 +50,8 @@ from datus_gaussdb.tpch_data import TPCH_DATA, TPCH_DDL, TPCH_TABLES
 
 
 def _require_gaussdb_libpq_platform() -> None:
-    """Skip unsafe official-driver runs while allowing psycopg2 on macOS."""
-    driver = os.getenv("GAUSSDB_DRIVER") or ("psycopg2" if sys.platform == "darwin" else "gaussdb")
+    """Skip unsafe official-driver runs; pg8000/psycopg2 run anywhere."""
+    driver = os.getenv("GAUSSDB_DRIVER") or ("pg8000" if sys.platform == "darwin" else "gaussdb")
     if driver == "gaussdb" and sys.platform != "linux" and os.getenv("GAUSSDB_FORCE_INTEGRATION") != "1":
         pytest.skip(
             f"the gaussdb driver needs the GaussDB/openGauss libpq, which has no {sys.platform} build; "
@@ -73,7 +73,7 @@ def _build_config() -> GaussDBConfig:
         password=os.getenv("GAUSSDB_PASSWORD", "Datus@123"),
         database=os.getenv("GAUSSDB_DATABASE", "postgres"),
         schema_name=os.getenv("GAUSSDB_SCHEMA", "public"),
-        driver=os.getenv("GAUSSDB_DRIVER") or ("psycopg2" if sys.platform == "darwin" else "gaussdb"),
+        driver=os.getenv("GAUSSDB_DRIVER") or ("pg8000" if sys.platform == "darwin" else "gaussdb"),
     )
 
 

--- a/datus-gaussdb/tests/integration/gaussdb-compat-contract.yaml
+++ b/datus-gaussdb/tests/integration/gaussdb-compat-contract.yaml
@@ -1,0 +1,130 @@
+# GaussDB compatibility-mode semantic contract.
+#
+# VENDORED from osi-engine design/gaussdb-compat-contract.yaml — keep the two
+# files byte-identical below this provenance block; update them together.
+#
+# Machine-readable record of how DBCOMPATIBILITY 'PG' / 'A' / 'B' change SQL
+# semantics on GaussDB/openGauss, derived from a 47-construct live scan
+# (openGauss 7.0.0-RC2, 2026-08-14) and re-verified against a managed GaussDB
+# Kernel 505.2.1. Consumed by crates/dosi-exec/tests/gaussdb_compat_contract.rs
+# (env-gated live test); the Datus db-adapters repo vendors a copy so both
+# codebases assert the same expectations — update the two files together.
+#
+# `expect` values are the text rendering (cast to varchar server-side unless
+# the probe already returns text). A probe absent for a mode means the
+# construct errors there — `expect_error` names the substring instead.
+#
+# Fields per entry:
+#   id:       stable slug
+#   verdict:  decode-normalized | portable-rewrite-known | data-semantics |
+#             engine-wide | identical
+#   notes:    what dosi does about it (or why nothing is needed)
+
+version: 1
+probes:
+  - id: bool-text-rendering
+    verdict: decode-normalized
+    sql: "select cast(true as varchar)"
+    expect: { PG: "true", A: "true", B: "1" }
+    notes: >-
+      The BOOL type OID is unchanged in B mode; only the text differs. Both
+      the dosi executor (to_value) and the Datus adapters decode tolerantly
+      ('t'/'true'/'1'), so this never reaches results.
+
+  - id: empty-string-is-null
+    verdict: data-semantics
+    sql: "select cast(('' is null) as int)"
+    expect: { PG: "0", A: "1", B: "0" }
+    notes: >-
+      'A' mode stores '' as NULL at write time — the distinction is destroyed
+      at rest, no query rewrite can recover it. Declared, not rewritten:
+      `col = ''` never matches in A mode. The portable emptiness predicate
+      `col = '' OR col IS NULL` returns the same row count in all modes.
+
+  - id: date-literal-cast
+    verdict: identical-textually
+    sql: "select to_char(cast('2024-01-15' as date), 'YYYY-MM-DD')"
+    expect: { PG: "2024-01-15", A: "2024-01-15", B: "2024-01-15" }
+    notes: >-
+      A mode's DATE is timestamp-shaped (bare cast renders with a time part);
+      to_char normalizes. dosi's compiled SQL compares date values, not their
+      bare text, and the corpus passes on all three modes.
+
+  - id: date-subtraction
+    verdict: portable-rewrite-known
+    sql: "select cast(date '2024-03-15' - date '2024-01-01' as varchar)"
+    expect: { PG: "74", A: "74 days", B: "214" }
+    notes: >-
+      B mode subtracts the dates as numbers (20240315 - 20240101). dosi never
+      emits bare date-date (its DATEDIFF case is a declared corpus skip on the
+      whole Postgres family). Portable form if ever needed:
+      to_char(d,'J')::int - to_char(d2,'J')::int == 74 in every mode.
+
+  - id: null-sort-position
+    verdict: engine-wide
+    sql: >-
+      select coalesce(cast(x as varchar),'NULL') from
+      (select 1 x union all select null) t order by x limit 1
+    expect: { PG: "1", A: "1", B: "NULL" }
+    notes: >-
+      B mode sorts NULLs first ascending — the same semantics MySQL/TiDB
+      already have in the fleet. Not a GaussDB-specific divergence; explicit
+      NULLS LAST/FIRST is the portable spelling and is verified to work in
+      all three modes.
+
+  - id: iso-week-number
+    verdict: portable-rewrite-known
+    sql: "select cast(extract(week from date '2024-03-15') as varchar)"
+    expect: { PG: "11", A: "11", B: "10" }
+    notes: >-
+      B mode uses MySQL week numbering. Portable form: to_char(d,'IW') == 11
+      in every mode. dosi's time-grain lowering does not emit extract(week)
+      for the Postgres family.
+
+  - id: concat-null-absorption
+    verdict: data-semantics
+    sql: "select cast(('a' || null) is null as int)"
+    expect: { PG: "1", A: "0", B: "1" }
+    notes: >-
+      Concat's NULL handling follows each mode's family: PG propagates NULL,
+      A (Oracle) ignores it ('a' || NULL = 'a'), B (MySQL CONCAT) propagates.
+      Portable form: wrap operands in coalesce(x,''). dosi does not emit ||.
+
+  - id: trailing-space-comparison
+    verdict: data-semantics
+    sql: "select cast(('a' = 'a ') as int)"
+    expect: { PG: "0", A: "0", B: "1" }
+    notes: >-
+      B mode compares CHAR-semantics style (MySQL PAD SPACE): trailing
+      spaces are insignificant in equality. Affects predicates and DISTINCT
+      over user data with trailing spaces; declared, not rewritten. Case
+      sensitivity is unaffected ('ABC' = 'abc' is false in every mode).
+
+  - id: empty-sum-is-null
+    verdict: identical
+    sql: "select cast((select sum(x) from (select 1 x where false) t) is null as int)"
+    expect: { PG: "1", A: "1", B: "1" }
+    notes: >-
+      SUM over an empty *grouped* input never reaches this (no groups, no
+      rows); the scalar-subquery shape is NULL in every mode.
+
+  - id: integer-division
+    verdict: engine-wide
+    sql: "select cast(7/2 as varchar)"
+    expect: { PG: "3.5", A: "3.5", B: "3.5000000000000000" }
+    notes: >-
+      GaussDB divides integers as reals in every compatibility mode — a
+      kernel behavior, not a mode behavior (real PostgreSQL truncates to 3).
+      The fleet is already split on this (MySQL/ClickHouse real, PG/Trino
+      truncating); dosi's Ratio metrics carry an explicit double cast
+      (dosi-compiler infer.rs), and bare int/int in expression metrics is a
+      documented fleet-level divergence.
+
+  - id: timestamptz-suffix
+    verdict: decode-normalized
+    sql: "select cast(cast('2024-01-01 10:20:30' as timestamp) as varchar)"
+    expect: { PG: "2024-01-01 10:20:30", A: "2024-01-01 10:20:30", B: "2024-01-01 10:20:30+00" }
+    notes: >-
+      B mode's timestamp is timestamptz-shaped; under the executor's pinned
+      UTC session the +00 suffix is stripped by to_value, so Value rows
+      compare equal.

--- a/datus-gaussdb/tests/integration/test_compat_contract.py
+++ b/datus-gaussdb/tests/integration/test_compat_contract.py
@@ -47,9 +47,16 @@ def _ensure_mode_databases(config: GaussDBConfig) -> None:
         for mode, db in MODE_DBS.items():
             try:
                 cur.execute(f"CREATE DATABASE {db} DBCOMPATIBILITY '{mode}'")
-            except Exception as e:  # noqa: BLE001 - probe for skip decision
-                if "already exists" not in str(e):
-                    pytest.skip(f"cannot create compatibility-mode databases: {e}")
+            except Exception as e:  # noqa: BLE001 - classify for skip-vs-fail
+                message = str(e)
+                if "already exists" in message:
+                    continue
+                # Only the expected insufficient-privilege case skips; any
+                # other failure (server error, driver regression) must fail
+                # the contract loudly, not hide it.
+                if "permission denied" in message.lower():
+                    pytest.skip(f"login lacks CREATEDB: {e}")
+                raise
     finally:
         conn.close()
 

--- a/datus-gaussdb/tests/integration/test_compat_contract.py
+++ b/datus-gaussdb/tests/integration/test_compat_contract.py
@@ -1,0 +1,85 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Live contract test for GaussDB compatibility-mode semantics.
+
+Executes every probe in ``gaussdb-compat-contract.yaml`` (vendored from
+osi-engine, which runs the same table from Rust) against one database per
+DBCOMPATIBILITY mode and asserts the recorded expectations — semantic drift
+on either side turns one shared table red in both repos.
+
+The three mode databases are created on demand (``datus_compat_pg`` / ``_a``
+/ ``_b``); creation needs a role with CREATEDB, so the whole module skips
+when the configured login cannot create databases.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from datus_gaussdb import GaussDBConfig, GaussDBConnector
+
+yaml = pytest.importorskip("yaml", reason="PyYAML is needed to read the vendored contract")
+
+pytestmark = pytest.mark.integration
+
+CONTRACT = Path(__file__).with_name("gaussdb-compat-contract.yaml")
+MODE_DBS = {"PG": "datus_compat_pg", "A": "datus_compat_a", "B": "datus_compat_b"}
+
+
+def _ensure_mode_databases(config: GaussDBConfig) -> None:
+    """CREATE DATABASE refuses transaction blocks, so this goes through a raw
+    autocommit DB-API connection instead of the connector."""
+    from datus_gaussdb import _pg8000_gauss
+
+    conn = _pg8000_gauss.connect(
+        user=config.username,
+        password=config.password,
+        host=config.host,
+        port=config.port,
+        database=config.database,
+        ssl_context=None,
+    )
+    conn.autocommit = True
+    try:
+        cur = conn.cursor()
+        for mode, db in MODE_DBS.items():
+            try:
+                cur.execute(f"CREATE DATABASE {db} DBCOMPATIBILITY '{mode}'")
+            except Exception as e:  # noqa: BLE001 - probe for skip decision
+                if "already exists" not in str(e):
+                    pytest.skip(f"cannot create compatibility-mode databases: {e}")
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def mode_connectors(config: GaussDBConfig):
+    _ensure_mode_databases(config)
+    connectors = {mode: GaussDBConnector(config.model_copy(update={"database": db})) for mode, db in MODE_DBS.items()}
+    yield connectors
+    for connector in connectors.values():
+        connector.close()
+
+
+def _load_probes():
+    doc = yaml.safe_load(CONTRACT.read_text())
+    return [pytest.param(p, id=p["id"]) for p in doc["probes"]]
+
+
+def _render(cell) -> str:
+    if cell is None:
+        return "NULL"
+    if isinstance(cell, bool):
+        return str(cell).lower()
+    return str(cell)
+
+
+@pytest.mark.parametrize("probe", _load_probes())
+def test_contract_probe(mode_connectors, probe):
+    for mode, expected in probe["expect"].items():
+        result = mode_connectors[mode].execute({"sql_query": probe["sql"].replace("\n", " ")}, result_format="list")
+        row = result.sql_return[0]
+        got = _render(next(iter(row.values())))
+        assert got == str(expected), f"{probe['id']} [{mode}]: expected {expected!r}, got {got!r}"

--- a/datus-gaussdb/tests/integration/test_connection.py
+++ b/datus-gaussdb/tests/integration/test_connection.py
@@ -18,7 +18,7 @@ def test_connection_with_config_object(config: GaussDBConfig):
     try:
         assert conn.test_connection()
         assert conn.dialect == "gaussdb"
-        sqlalchemy_driver = "psycopg2" if config.driver == "psycopg2" else "psycopg"
+        sqlalchemy_driver = {"psycopg2": "psycopg2", "pg8000": "pg8000"}.get(config.driver, "psycopg")
         assert conn.connection_string.startswith(f"gaussdb+{sqlalchemy_driver}://")
     finally:
         conn.close()

--- a/datus-gaussdb/tests/integration/test_encoding.py
+++ b/datus-gaussdb/tests/integration/test_encoding.py
@@ -12,6 +12,9 @@ encoding. A GBK database is created on demand (CREATEDB required; the module
 skips gracefully without it).
 """
 
+import os
+import sys
+
 import pytest
 
 from datus_gaussdb import GaussDBConfig, GaussDBConnector
@@ -21,8 +24,15 @@ pytestmark = pytest.mark.integration
 GBK_DB = "datus_enc_gbk"
 
 
-@pytest.fixture
-def gbk_connector(config: GaussDBConfig):
+@pytest.fixture(params=["pg8000", "gaussdb"])
+def gbk_connector(request, config: GaussDBConfig):
+    """Both client drivers, so the GBK behavior of each is asserted: pg8000
+    must pin client_encoding=UTF8, the official driver decodes GBK natively.
+    The official driver needs the GaussDB libpq (linux-only)."""
+    driver = request.param
+    if driver == "gaussdb" and sys.platform != "linux" and os.getenv("GAUSSDB_FORCE_INTEGRATION") != "1":
+        pytest.skip("the official gaussdb driver needs the GaussDB libpq, which has no build here")
+
     from datus_gaussdb import _pg8000_gauss
 
     conn = _pg8000_gauss.connect(
@@ -41,13 +51,18 @@ def gbk_connector(config: GaussDBConfig):
                 f"CREATE DATABASE {GBK_DB} WITH ENCODING 'GBK' "
                 "LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0 DBCOMPATIBILITY 'PG'"
             )
-        except Exception as e:  # noqa: BLE001 - probe for skip decision
-            if "already exists" not in str(e):
-                pytest.skip(f"cannot create a GBK database: {e}")
+        except Exception as e:  # noqa: BLE001 - classify for skip-vs-fail
+            message = str(e)
+            if "already exists" not in message:
+                # Only the expected insufficient-privilege case skips; any
+                # other failure must surface, not hide as a skip.
+                if "permission denied" in message.lower():
+                    pytest.skip(f"login lacks CREATEDB: {e}")
+                raise
     finally:
         conn.close()
 
-    connector = GaussDBConnector(config.model_copy(update={"database": GBK_DB}))
+    connector = GaussDBConnector(config.model_copy(update={"database": GBK_DB, "driver": driver}))
     # Ordinary users have no CREATE on public even in a database they own
     # (openGauss default); a dedicated schema owned by the test user avoids
     # depending on superuser grants.

--- a/datus-gaussdb/tests/integration/test_encoding.py
+++ b/datus-gaussdb/tests/integration/test_encoding.py
@@ -1,0 +1,123 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Server-encoding coverage: GBK databases with Chinese identifiers and data.
+
+Chinese GaussDB deployments frequently run ``server_encoding = GBK`` rather
+than UTF8. The drivers always negotiate ``client_encoding = UTF8`` and the
+server transcodes, so Chinese table/column names, Chinese row data, and
+Chinese predicates must round-trip losslessly regardless of the on-disk
+encoding. A GBK database is created on demand (CREATEDB required; the module
+skips gracefully without it).
+"""
+
+import pytest
+
+from datus_gaussdb import GaussDBConfig, GaussDBConnector
+
+pytestmark = pytest.mark.integration
+
+GBK_DB = "datus_enc_gbk"
+
+
+@pytest.fixture
+def gbk_connector(config: GaussDBConfig):
+    from datus_gaussdb import _pg8000_gauss
+
+    conn = _pg8000_gauss.connect(
+        user=config.username,
+        password=config.password,
+        host=config.host,
+        port=config.port,
+        database=config.database,
+        ssl_context=None,
+    )
+    conn.autocommit = True
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"CREATE DATABASE {GBK_DB} WITH ENCODING 'GBK' "
+                "LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0 DBCOMPATIBILITY 'PG'"
+            )
+        except Exception as e:  # noqa: BLE001 - probe for skip decision
+            if "already exists" not in str(e):
+                pytest.skip(f"cannot create a GBK database: {e}")
+    finally:
+        conn.close()
+
+    connector = GaussDBConnector(config.model_copy(update={"database": GBK_DB}))
+    # Ordinary users have no CREATE on public even in a database they own
+    # (openGauss default); a dedicated schema owned by the test user avoids
+    # depending on superuser grants.
+    connector.execute({"sql_query": "CREATE SCHEMA IF NOT EXISTS enc_test"}, result_format="list")
+    yield connector
+    connector.close()
+
+
+def test_gbk_database_client_encoding(gbk_connector):
+    """pg8000 must pin client_encoding=UTF8 (it has no GBK codec mapping and
+    would silently mis-decode); the official psycopg-family driver carries a
+    full encoding map and decodes a GBK session correctly as-is."""
+    result = gbk_connector.execute(
+        {
+            "sql_query": (
+                "SELECT current_setting('server_encoding') AS server_enc, "
+                "current_setting('client_encoding') AS client_enc"
+            )
+        },
+        result_format="list",
+    )
+    row = list(result.sql_return[0].values())
+    assert row[0] == "GBK"
+    if gbk_connector.config.driver == "pg8000":
+        assert row[1].upper() in ("UTF8", "UTF-8")
+
+
+def test_gbk_chinese_identifiers_and_data_round_trip(gbk_connector):
+    c = gbk_connector
+    c.execute({"sql_query": 'DROP TABLE IF EXISTS "enc_test"."订单表"'}, result_format="list")
+    c.execute(
+        {"sql_query": 'CREATE TABLE "enc_test"."订单表" ("订单号" INT, "客户名" VARCHAR(64), "备注" TEXT)'},
+        result_format="list",
+    )
+    c.execute(
+        {
+            "sql_query": (
+                'INSERT INTO "enc_test"."订单表" VALUES '
+                "(1, '张三', '加急——今天发货（华东仓）'), "
+                "(2, '李四·全角，测试', NULL)"
+            )
+        },
+        result_format="list",
+    )
+
+    # Data round-trip, including a Chinese predicate.
+    result = c.execute(
+        {"sql_query": 'SELECT "客户名", "备注" FROM "enc_test"."订单表" WHERE "客户名" = \'张三\''},
+        result_format="list",
+    )
+    assert result.sql_return == [{"客户名": "张三", "备注": "加急——今天发货（华东仓）"}]
+
+    # Chinese LIKE and length semantics survive transcoding.
+    result = c.execute(
+        {"sql_query": 'SELECT count(*) AS n FROM "enc_test"."订单表" WHERE "客户名" LIKE \'%四%\''},
+        result_format="list",
+    )
+    assert list(result.sql_return[0].values()) == [1]
+    result = c.execute(
+        {"sql_query": "SELECT length('华东仓') AS n"},
+        result_format="list",
+    )
+    assert list(result.sql_return[0].values()) == [3]
+
+    # Metadata reflection sees the Chinese table and columns.
+    tables = c.get_tables(schema_name="enc_test")
+    assert any(t == "订单表" or t.endswith(".订单表") for t in tables), tables
+    ddl_entries = c.get_tables_with_ddl(schema_name="enc_test")
+    entry = next(e for e in ddl_entries if e["table_name"] == "订单表")
+    for column in ("订单号", "客户名", "备注"):
+        assert column in entry["definition"], entry["definition"]
+
+    c.execute({"sql_query": 'DROP TABLE "enc_test"."订单表"'}, result_format="list")

--- a/datus-gaussdb/tests/unit/test_config.py
+++ b/datus-gaussdb/tests/unit/test_config.py
@@ -98,9 +98,10 @@ def test_config_schema_name_still_accepted():
 
 
 @pytest.mark.acceptance
-@pytest.mark.parametrize(("platform_name", "expected"), [("linux", "gaussdb"), ("darwin", "psycopg2")])
+@pytest.mark.parametrize(("platform_name", "expected"), [("linux", "gaussdb"), ("darwin", "pg8000")])
 def test_config_driver_default_is_platform_safe(monkeypatch, platform_name, expected):
-    """Linux keeps the official driver while macOS avoids its unavailable libpq."""
+    """Linux keeps the official driver; macOS uses the pure-Python pg8000
+    path, which speaks GaussDB SHA256 without the unavailable libpq."""
     monkeypatch.setattr("datus_gaussdb.config.sys.platform", platform_name)
     config = GaussDBConfig(username="datus")
     assert config.driver == expected
@@ -111,6 +112,19 @@ def test_config_driver_psycopg2_accepted():
     """psycopg2 stays available as an escape hatch."""
     config = GaussDBConfig(username="datus", driver="psycopg2")
     assert config.driver == "psycopg2"
+
+
+@pytest.mark.acceptance
+def test_config_driver_pg8000_accepted():
+    config = GaussDBConfig(username="datus", driver="pg8000")
+    assert config.driver == "pg8000"
+
+
+@pytest.mark.acceptance
+def test_config_sslrootcert_default_none_and_roundtrip():
+    assert GaussDBConfig(username="datus").sslrootcert is None
+    config = GaussDBConfig(username="datus", sslrootcert="/etc/ssl/gauss-ca.pem")
+    assert config.model_dump()["sslrootcert"] == "/etc/ssl/gauss-ca.pem"
 
 
 @pytest.mark.acceptance

--- a/datus-gaussdb/tests/unit/test_connector_unit.py
+++ b/datus-gaussdb/tests/unit/test_connector_unit.py
@@ -142,6 +142,30 @@ def test_connection_string_uses_gaussdb_dialect_for_psycopg2():
 
 
 @pytest.mark.acceptance
+def test_connection_string_uses_pg8000_dialect():
+    """The pure-Python pg8000 path routes through gaussdb+pg8000."""
+    connector = _make_connector(driver="pg8000", password="pass", database="analyticsdb")
+
+    assert connector.connection_string == (
+        "gaussdb+pg8000://datus:pass@gauss.internal:25434/analyticsdb?sslmode=prefer"
+    )
+
+
+@pytest.mark.acceptance
+def test_connection_string_carries_sslrootcert():
+    """verify-ca/verify-full need the CA path forwarded to the dialect."""
+    connector = _make_connector(
+        driver="pg8000",
+        password="pass",
+        sslmode="verify-full",
+        sslrootcert="/etc/ssl/gauss-ca.pem",
+    )
+
+    assert "sslmode=verify-full" in connector.connection_string
+    assert "sslrootcert=%2Fetc%2Fssl%2Fgauss-ca.pem" in connector.connection_string
+
+
+@pytest.mark.acceptance
 def test_connection_string_encodes_special_characters():
     """Credentials with URL-significant characters are percent-encoded."""
     connector = _make_connector(username="user@corp", password="p@ss!w0rd#$%")
@@ -178,7 +202,14 @@ def test_sys_schemas_extends_postgresql():
 
     assert pg_schemas.issubset(sys_schemas)
     assert "pg_catalog" in sys_schemas
-    assert {"dbe_perf", "db4ai", "snapshot", "cstore", "blockchain", "sqladvisor"}.issubset(sys_schemas)
+    assert {
+        "dbe_perf",
+        "db4ai",
+        "snapshot",
+        "cstore",
+        "blockchain",
+        "sqladvisor",
+    }.issubset(sys_schemas)
 
 
 @pytest.mark.acceptance
@@ -194,7 +225,12 @@ def test_get_schemas_uses_pg_namespace_and_filters_internal_prefixes():
     """Schema discovery uses pg_namespace and hides system and temporary schemas."""
     connector = _make_connector()
     result = MagicMock()
-    result.__getitem__.return_value.tolist.return_value = ["public", "pg_catalog", "dbe_perf", "pg_temp_3"]
+    result.__getitem__.return_value.tolist.return_value = [
+        "public",
+        "pg_catalog",
+        "dbe_perf",
+        "pg_temp_3",
+    ]
     connector._execute_pandas = MagicMock(return_value=result)
 
     schemas = connector.get_schemas(database_name="analytics")
@@ -418,7 +454,11 @@ def test_attribute_names_map_attnums_in_order():
     """Distribution columns follow the attnum order recorded in the catalog."""
     connector = _make_connector()
     conn = MagicMock()
-    conn.execute.return_value.fetchall.return_value = [(1, "id"), (2, "region"), (3, "name")]
+    conn.execute.return_value.fetchall.return_value = [
+        (1, "id"),
+        (2, "region"),
+        (3, "name"),
+    ]
     connector._conn = _conn_returning(conn)
 
     assert connector._get_attribute_names("public", "orders", "3 1") == ["name", "id"]
@@ -519,7 +559,11 @@ def test_get_ddl_untouched_on_centralized_deployment():
     connector._get_traits = MagicMock(return_value=DbTraits(is_distributed=False))
     connector._get_distribution_clause = MagicMock()
 
-    with patch.object(PostgreSQLConnector, "_get_ddl", return_value='CREATE TABLE "public"."t" ("id" integer);'):
+    with patch.object(
+        PostgreSQLConnector,
+        "_get_ddl",
+        return_value='CREATE TABLE "public"."t" ("id" integer);',
+    ):
         ddl = connector._get_ddl("public", "t", "TABLE")
 
     assert ddl == 'CREATE TABLE "public"."t" ("id" integer);'
@@ -533,7 +577,11 @@ def test_get_ddl_skips_distribution_for_views():
     connector._get_traits = MagicMock(return_value=DbTraits(is_distributed=True))
     connector._get_distribution_clause = MagicMock()
 
-    with patch.object(PostgreSQLConnector, "_get_ddl", return_value='CREATE VIEW "public"."v" AS\nSELECT 1'):
+    with patch.object(
+        PostgreSQLConnector,
+        "_get_ddl",
+        return_value='CREATE VIEW "public"."v" AS\nSELECT 1',
+    ):
         ddl = connector._get_ddl("public", "v", "VIEW")
 
     assert "DISTRIBUTE" not in ddl

--- a/datus-gaussdb/tests/unit/test_pg8000_gauss.py
+++ b/datus-gaussdb/tests/unit/test_pg8000_gauss.py
@@ -1,0 +1,183 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the pg8000-based GaussDB authentication path.
+
+The handshake tests run a fake GaussDB server on a socketpair — no real
+database, no network — and drive the full ``Connection.__init__`` against
+it, proving the startup packet carries protocol 3.51 and the SHA256
+response matches the RFC 5802 scheme.
+"""
+
+import hashlib
+import inspect
+import socket
+import struct
+import threading
+
+import pytest
+from pg8000.core import CoreConnection, i_pack
+
+from datus_gaussdb._pg8000_gauss import PROTOCOL_3_51, Connection, InterfaceError, _GaussCore, rfc5802_response
+
+# Vector cross-checked against py_opengauss's independent implementation of
+# the same algorithm (openGauss's official pure-Python driver).
+VECTOR_PASSWORD = b"Datus@123"
+VECTOR_RANDOM64 = b"a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+VECTOR_TOKEN = b"1a2b3c4d"
+VECTOR_ITERATION = 10000
+VECTOR_RESPONSE = b"9db5944272406c1a698e95e009064beb5a7a9de9a2c7a9faf5574a853056a2a3"
+
+
+def test_rfc5802_known_answer():
+    assert rfc5802_response(VECTOR_PASSWORD, VECTOR_RANDOM64, VECTOR_TOKEN, VECTOR_ITERATION) == VECTOR_RESPONSE
+
+
+def test_rfc5802_iteration_changes_response():
+    other = rfc5802_response(VECTOR_PASSWORD, VECTOR_RANDOM64, VECTOR_TOKEN, VECTOR_ITERATION + 1)
+    assert other != VECTOR_RESPONSE
+
+
+class FakeGaussServer(threading.Thread):
+    """Minimal server side of the GaussDB handshake over a socketpair."""
+
+    def __init__(self, sock, auth_payload):
+        super().__init__(daemon=True)
+        self.sock = sock
+        self.auth_payload = auth_payload
+        self.startup_protocol = None
+        self.auth_response = None
+
+    def _read(self, n):
+        buf = b""
+        while len(buf) < n:
+            chunk = self.sock.recv(n - len(buf))
+            if not chunk:
+                raise EOFError
+            buf += chunk
+        return buf
+
+    def run(self):
+        try:
+            (length,) = struct.unpack("!i", self._read(4))
+            startup = self._read(length - 4)
+            (self.startup_protocol,) = struct.unpack("!i", startup[:4])
+
+            # AuthenticationRequest code 10 with the configured payload.
+            body = struct.pack("!i", 10) + self.auth_payload
+            self.sock.sendall(b"R" + i_pack(len(body) + 4) + body)
+
+            # PasswordMessage: 'p' + length + response + NUL.
+            tag = self._read(1)
+            assert tag == b"p"
+            (plen,) = struct.unpack("!i", self._read(4))
+            self.auth_response = self._read(plen - 4).rstrip(b"\x00")
+
+            # AuthenticationOk + ReadyForQuery.
+            self.sock.sendall(b"R" + i_pack(8) + struct.pack("!i", 0))
+            self.sock.sendall(b"Z" + i_pack(5) + b"I")
+        except Exception:  # pragma: no cover - surfaces as client-side failure
+            self.sock.close()
+
+
+def _handshake(auth_payload, password="Datus@123"):
+    client_sock, server_sock = socket.socketpair()
+    server = FakeGaussServer(server_sock, auth_payload)
+    server.start()
+    conn = Connection("datus", password=password, sock=client_sock, ssl_context=False)
+    server.join(timeout=5)
+    conn.close()
+    server_sock.close()
+    return server
+
+
+def _sha256_payload():
+    return struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", VECTOR_ITERATION)
+
+
+def test_startup_packet_carries_protocol_351():
+    server = _handshake(_sha256_payload())
+    assert server.startup_protocol == PROTOCOL_3_51
+
+
+def test_sha256_handshake_sends_rfc5802_response():
+    server = _handshake(_sha256_payload())
+    assert server.auth_response == VECTOR_RESPONSE
+
+
+def test_md5_method_under_code_10():
+    salt = b"\x01\x02\x03\x04"
+    server = _handshake(struct.pack("!I", 1) + salt)
+    inner = hashlib.md5(b"Datus@123" + b"datus").hexdigest().encode("ascii")
+    expected = b"md5" + hashlib.md5(inner + salt).hexdigest().encode("ascii")
+    assert server.auth_response == expected
+
+
+def _core_stub():
+    """A bare _GaussCore carrying just the state the auth handler touches."""
+    stub = _GaussCore.__new__(_GaussCore)
+    stub.user = b"datus"
+    stub.password = b"pw"
+    return stub
+
+
+def test_sm3_method_raises_actionable_error():
+    payload = struct.pack("!i", 10) + struct.pack("!I", 3) + b"\x00" * 76
+    with pytest.raises(InterfaceError, match="method 3.*password_encryption_type"):
+        _core_stub().handle_AUTHENTICATION_REQUEST(payload, None)
+
+
+def test_code_11_raises_actionable_error():
+    payload = struct.pack("!i", 11) + b"\x00" * 8
+    with pytest.raises(InterfaceError, match="MD5_SHA256.*iteration"):
+        _core_stub().handle_AUTHENTICATION_REQUEST(payload, None)
+
+
+def test_missing_password_raises():
+    stub = _core_stub()
+    stub.password = None
+    payload = struct.pack("!i", 10) + _sha256_payload()
+    with pytest.raises(InterfaceError, match="no password"):
+        stub.handle_AUTHENTICATION_REQUEST(payload, None)
+
+
+def test_scram_payload_delegates_to_stock_pg8000(monkeypatch):
+    """PG's AuthenticationSASL is also code 10; the SCRAM shape must reach
+    the stock handler so this class stays usable against real PostgreSQL."""
+    seen = {}
+
+    def fake_parent(self, data, context):
+        seen["delegated"] = True
+
+    monkeypatch.setattr(CoreConnection, "handle_AUTHENTICATION_REQUEST", fake_parent)
+    payload = struct.pack("!i", 10) + b"SCRAM-SHA-256\x00\x00"
+    _core_stub().handle_AUTHENTICATION_REQUEST(payload, None)
+    assert seen.get("delegated") is True
+
+
+def test_upstream_init_drift_guard():
+    """The 3.51 startup rides on a clone of CoreConnection.__init__ whose
+    only assumption is the ``i_pack(protocol)`` idiom. If upstream rewrites
+    __init__, re-verify _pg8000_gauss against the new source and update the
+    pinned hash."""
+    src = inspect.getsource(CoreConnection.__init__)
+    assert (
+        hashlib.sha256(src.encode()).hexdigest() == "3354661aa84d010a910d697e7893edd0a321fc5a9c7a49c9b54efdf5a1cca291"
+    ), "pg8000 CoreConnection.__init__ changed upstream; re-verify the protocol-3.51 clone"
+
+
+def test_dbapi_module_surface():
+    """SQLAlchemy's import_dbapi contract: the module must expose the DB-API
+    names the dialect touches."""
+    from datus_gaussdb import _pg8000_gauss as mod
+
+    for name in (
+        "connect",
+        "Connection",
+        "InterfaceError",
+        "DatabaseError",
+        "paramstyle",
+    ):
+        assert hasattr(mod, name), name
+    assert issubclass(mod.Connection, CoreConnection)

--- a/datus-gaussdb/tests/unit/test_pg8000_gauss.py
+++ b/datus-gaussdb/tests/unit/test_pg8000_gauss.py
@@ -106,6 +106,28 @@ def test_sha256_handshake_sends_rfc5802_response():
     assert server.auth_response == VECTOR_RESPONSE
 
 
+def test_excessive_iteration_count_is_refused():
+    """A hostile server naming an absurd PBKDF2 iteration count must be
+    rejected before any key derivation work happens."""
+    payload = struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", 2**31)
+    client_sock, server_sock = socket.socketpair()
+    server = FakeGaussServer(server_sock, payload)
+    server.start()
+    with pytest.raises(InterfaceError, match="PBKDF2 iterations"):
+        Connection("datus", password="Datus@123", sock=client_sock, ssl_context=False)
+    server_sock.close()
+
+
+def test_zero_iteration_count_is_refused():
+    payload = struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", 0)
+    client_sock, server_sock = socket.socketpair()
+    server = FakeGaussServer(server_sock, payload)
+    server.start()
+    with pytest.raises(InterfaceError, match="PBKDF2 iterations"):
+        Connection("datus", password="Datus@123", sock=client_sock, ssl_context=False)
+    server_sock.close()
+
+
 def test_md5_method_under_code_10():
     salt = b"\x01\x02\x03\x04"
     server = _handshake(struct.pack("!I", 1) + salt)

--- a/datus-gaussdb/tests/unit/test_pg8000_gauss.py
+++ b/datus-gaussdb/tests/unit/test_pg8000_gauss.py
@@ -85,10 +85,13 @@ def _handshake(auth_payload, password="Datus@123"):
     client_sock, server_sock = socket.socketpair()
     server = FakeGaussServer(server_sock, auth_payload)
     server.start()
-    conn = Connection("datus", password=password, sock=client_sock, ssl_context=False)
-    server.join(timeout=5)
-    conn.close()
-    server_sock.close()
+    try:
+        conn = Connection("datus", password=password, sock=client_sock, ssl_context=False)
+        conn.close()
+    finally:
+        server.join(timeout=5)
+        server_sock.close()
+    assert not server.is_alive()
     return server
 
 
@@ -106,26 +109,32 @@ def test_sha256_handshake_sends_rfc5802_response():
     assert server.auth_response == VECTOR_RESPONSE
 
 
+def _assert_iteration_refused(iteration: int):
+    """Drive the handshake against a server naming ``iteration`` and assert
+    the client refuses before any key-derivation work; both socket ends and
+    the server thread are cleaned up whichever way the assertion goes."""
+    payload = struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", iteration)
+    client_sock, server_sock = socket.socketpair()
+    server = FakeGaussServer(server_sock, payload)
+    server.start()
+    try:
+        with pytest.raises(InterfaceError, match="PBKDF2 iterations"):
+            Connection("datus", password="Datus@123", sock=client_sock, ssl_context=False)
+    finally:
+        client_sock.close()
+        server_sock.close()
+        server.join(timeout=5)
+    assert not server.is_alive()
+
+
 def test_excessive_iteration_count_is_refused():
     """A hostile server naming an absurd PBKDF2 iteration count must be
     rejected before any key derivation work happens."""
-    payload = struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", 2**31)
-    client_sock, server_sock = socket.socketpair()
-    server = FakeGaussServer(server_sock, payload)
-    server.start()
-    with pytest.raises(InterfaceError, match="PBKDF2 iterations"):
-        Connection("datus", password="Datus@123", sock=client_sock, ssl_context=False)
-    server_sock.close()
+    _assert_iteration_refused(2**31)
 
 
 def test_zero_iteration_count_is_refused():
-    payload = struct.pack("!I", 2) + VECTOR_RANDOM64 + VECTOR_TOKEN + struct.pack("!I", 0)
-    client_sock, server_sock = socket.socketpair()
-    server = FakeGaussServer(server_sock, payload)
-    server.start()
-    with pytest.raises(InterfaceError, match="PBKDF2 iterations"):
-        Connection("datus", password="Datus@123", sock=client_sock, ssl_context=False)
-    server_sock.close()
+    _assert_iteration_refused(0)
 
 
 def test_md5_method_under_code_10():

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -156,7 +156,11 @@ def test_create_connect_args_injects_client_cursor(monkeypatch):
     monkeypatch.setitem(sys.modules, "gaussdb", module)
     dialect = GaussDBDialect.__new__(GaussDBDialect)
 
-    with patch.object(PGDialect_psycopg, "create_connect_args", return_value=([], {"dbname": "postgres"})):
+    with patch.object(
+        PGDialect_psycopg,
+        "create_connect_args",
+        return_value=([], {"dbname": "postgres"}),
+    ):
         args, kwargs = dialect.create_connect_args(MagicMock())
 
     assert args == []
@@ -172,7 +176,11 @@ def test_create_connect_args_keeps_explicit_cursor_factory(monkeypatch):
     custom_cursor = type("CustomCursor", (), {})
     dialect = GaussDBDialect.__new__(GaussDBDialect)
 
-    with patch.object(PGDialect_psycopg, "create_connect_args", return_value=([], {"cursor_factory": custom_cursor})):
+    with patch.object(
+        PGDialect_psycopg,
+        "create_connect_args",
+        return_value=([], {"cursor_factory": custom_cursor}),
+    ):
         _, kwargs = dialect.create_connect_args(MagicMock())
 
     assert kwargs["cursor_factory"] is custom_cursor
@@ -207,3 +215,140 @@ def test_dialect_registered_in_sqlalchemy_registry():
 def test_stock_postgresql_psycopg2_dialect_is_unchanged():
     """Registering GaussDB's dialect does not replace PostgreSQL behavior."""
     assert registry.load("postgresql.psycopg2") is PGDialect_psycopg2
+
+
+# ==================== pg8000 dialect ====================
+
+
+def test_pg8000_dialect_identity_and_registration():
+    from sqlalchemy.dialects.postgresql.pg8000 import PGDialect_pg8000
+
+    from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect
+
+    assert GaussDBPg8000Dialect.name == "gaussdb"
+    assert GaussDBPg8000Dialect.driver == "pg8000"
+    assert GaussDBPg8000Dialect.supports_statement_cache is True
+    assert issubclass(GaussDBPg8000Dialect, PGDialect_pg8000)
+    assert registry.load("gaussdb.pg8000") is GaussDBPg8000Dialect
+
+
+def test_pg8000_import_dbapi_is_gauss_module():
+    from datus_gaussdb import _pg8000_gauss
+    from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect
+
+    assert GaussDBPg8000Dialect.import_dbapi() is _pg8000_gauss
+
+
+@pytest.mark.parametrize(
+    ("sslmode", "expected"),
+    [
+        ("disable", False),
+        ("allow", None),
+        ("prefer", None),
+        (None, None),
+        ("require", True),
+    ],
+)
+def test_pg8000_ssl_context_simple_modes(sslmode, expected):
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    assert _build_pg8000_ssl_context(sslmode, None) is expected
+
+
+def test_pg8000_ssl_context_verify_modes(tmp_path):
+    import ssl
+
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    # A self-signed cert generated on the fly is overkill; an empty CA file
+    # is enough for context construction (load failure = ssl.SSLError).
+    ca = tmp_path / "ca.pem"
+    ca.write_text(
+        "-----BEGIN CERTIFICATE-----\n"
+        "MIIBhTCCASugAwIBAgIUQ2FsbGVkIGZvciB0ZXN0aW5nIQwwCgYIKoZIzj0EAwIw\n"
+        "-----END CERTIFICATE-----\n"
+    )
+    try:
+        ctx = _build_pg8000_ssl_context("verify-ca", str(ca))
+    except ssl.SSLError:
+        pytest.skip("stub certificate rejected by this OpenSSL build")
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_pg8000_ssl_context_verify_requires_rootcert():
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    for mode in ("verify-ca", "verify-full"):
+        with pytest.raises(ValueError, match="sslrootcert"):
+            _build_pg8000_ssl_context(mode, None)
+
+
+def test_pg8000_ssl_context_unknown_mode_rejected():
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    with pytest.raises(ValueError, match="unknown sslmode"):
+        _build_pg8000_ssl_context("mystery", None)
+
+
+def test_pg8000_create_connect_args_moves_ssl_params():
+    from sqlalchemy.engine import make_url
+
+    from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect
+
+    dialect = GaussDBPg8000Dialect()
+    url = make_url("gaussdb+pg8000://u:p@h:25434/db?sslmode=disable")
+    _, opts = dialect.create_connect_args(url)
+
+    assert opts["ssl_context"] is False
+    assert "sslmode" not in opts
+    assert "sslrootcert" not in opts
+    assert opts["port"] == 25434
+
+
+# ==================== compatibility-mode bool decoding ====================
+
+
+def test_tolerant_bool_parser_covers_all_compat_modes():
+    """'t'/'f' (PG and A modes) and '1'/'0' (B mode) must both decode
+    correctly; B mode's '1' silently reads as False with a strict parser."""
+    from datus_gaussdb.sa_dialect import _gaussdb_bool_in
+
+    assert _gaussdb_bool_in("t") is True
+    assert _gaussdb_bool_in("true") is True
+    assert _gaussdb_bool_in("1") is True
+    assert _gaussdb_bool_in("f") is False
+    assert _gaussdb_bool_in("false") is False
+    assert _gaussdb_bool_in("0") is False
+
+
+def test_pg8000_on_connect_registers_bool_adapter():
+    from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect, _gaussdb_bool_in
+
+    dialect = GaussDBPg8000Dialect()
+    conn = MagicMock()
+    hook = dialect.on_connect()
+    hook(conn)
+    conn.register_in_adapter.assert_called_once_with(16, _gaussdb_bool_in)
+
+
+def test_psycopg2_on_connect_registers_bool_caster():
+    from datus_gaussdb.sa_dialect import GaussDBPsycopg2Dialect
+
+    dialect = GaussDBPsycopg2Dialect()
+    conn = MagicMock()
+    with (
+        patch("psycopg2.extensions.new_type") as new_type,
+        patch("psycopg2.extensions.register_type") as reg,
+    ):
+        new_type.return_value = "caster"
+        hook = dialect.on_connect()
+        hook(conn)
+
+    (oids, name, parse), _ = new_type.call_args
+    assert oids == (16,)
+    assert parse("1", None) is True
+    assert parse("t", None) is True
+    assert parse("0", None) is False
+    assert parse(None, None) is None
+    reg.assert_called_once_with("caster", conn)

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -324,6 +324,19 @@ def test_pg8000_ssl_context_unknown_mode_rejected():
         _build_pg8000_ssl_context("mystery", None)
 
 
+def test_pg8000_create_connect_args_pins_utf8_client_encoding():
+    """GBK-encoded databases default client_encoding to GBK; pg8000 has no
+    GBK codec mapping and would silently mis-decode, so UTF8 is pinned."""
+    from sqlalchemy.engine import make_url
+
+    from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect
+
+    dialect = GaussDBPg8000Dialect()
+    url = make_url("gaussdb+pg8000://u:p@h:25434/db")
+    _, opts = dialect.create_connect_args(url)
+    assert opts["startup_params"]["client_encoding"] == "UTF8"
+
+
 def test_pg8000_create_connect_args_moves_ssl_params():
     from sqlalchemy.engine import make_url
 

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -241,6 +241,8 @@ def test_pg8000_import_dbapi_is_gauss_module():
 
 @pytest.mark.parametrize(
     ("sslmode", "expected"),
+    # `allow` is deliberately treated as `prefer` (TLS-first with plaintext
+    # fallback) — the same approximation the Rust executor makes.
     [
         ("disable", False),
         ("allow", None),
@@ -255,25 +257,56 @@ def test_pg8000_ssl_context_simple_modes(sslmode, expected):
     assert _build_pg8000_ssl_context(sslmode, None) is expected
 
 
+# A real (EC self-signed, 10-year) certificate so ssl actually loads it and
+# the CERT_REQUIRED assertions below genuinely execute; a truncated stub gets
+# rejected by some OpenSSL builds, silently skipping the tests.
+_STUB_CERT = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBhjCCASugAwIBAgIUKYy4YU1TuNflu3n4/hhvaCxV+dswCgYIKoZIzj0EAwIw\n"
+    "GDEWMBQGA1UEAwwNZGF0dXMtdGVzdC1jYTAeFw0yNjA4MTUwODMyMThaFw0zNjA4\n"
+    "MTIwODMyMThaMBgxFjAUBgNVBAMMDWRhdHVzLXRlc3QtY2EwWTATBgcqhkjOPQIB\n"
+    "BggqhkjOPQMBBwNCAAQgcvgmKbaVP7SSMOn580Uv1Jy5GEoaVsFjdzF5wX1o+jPy\n"
+    "6D3hUeLoB95uA3Po1sOpp0xr6AcBwrZXvwU6ngOEo1MwUTAdBgNVHQ4EFgQU/8U6\n"
+    "FzlhBpXz2fMHuCl02FR9wtkwHwYDVR0jBBgwFoAU/8U6FzlhBpXz2fMHuCl02FR9\n"
+    "wtkwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNJADBGAiEAqLXrwfHKkwR3\n"
+    "8QaKlb+w/uMxfVr9wBQ6i4wZjk+tT70CIQDzLUGn2oBEo9QSqt9G8JLkBZUfa8Lv\n"
+    "sRlAkeTWs5ocPg==\n"
+    "-----END CERTIFICATE-----\n"
+)
+
+
 def test_pg8000_ssl_context_verify_modes(tmp_path):
     import ssl
 
     from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
 
-    # A self-signed cert generated on the fly is overkill; an empty CA file
-    # is enough for context construction (load failure = ssl.SSLError).
+    # A self-signed cert generated on the fly is overkill; a stub CA file is
+    # enough for context construction (load failure = ssl.SSLError).
     ca = tmp_path / "ca.pem"
-    ca.write_text(
-        "-----BEGIN CERTIFICATE-----\n"
-        "MIIBhTCCASugAwIBAgIUQ2FsbGVkIGZvciB0ZXN0aW5nIQwwCgYIKoZIzj0EAwIw\n"
-        "-----END CERTIFICATE-----\n"
-    )
+    ca.write_text(_STUB_CERT)
     try:
         ctx = _build_pg8000_ssl_context("verify-ca", str(ca))
     except ssl.SSLError:
         pytest.skip("stub certificate rejected by this OpenSSL build")
     assert ctx.check_hostname is False
     assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_pg8000_require_with_rootcert_verifies_like_verify_ca(tmp_path):
+    """libpq back-compat: `require` + a CA file validates the chain."""
+    import ssl
+
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    ca = tmp_path / "ca.pem"
+    ca.write_text(_STUB_CERT)
+    try:
+        ctx = _build_pg8000_ssl_context("require", str(ca))
+    except ssl.SSLError:
+        pytest.skip("stub certificate rejected by this OpenSSL build")
+    assert ctx is not True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is False
 
 
 def test_pg8000_ssl_context_verify_requires_rootcert():


### PR DESCRIPTION
## Why

The official `gaussdb` driver binds the GaussDB libpq, which has no Darwin build, so macOS could previously only use the md5-limited `psycopg2` escape hatch. Managed GaussDB instances default to sha256 password storage (`password_encryption_type=2`), which md5 clients cannot authenticate against at all — meaning the adapter simply could not reach a stock managed instance from macOS. Separately, databases created in `B` (MySQL) compatibility mode render booleans as `'1'/'0'`, which every strict PostgreSQL parser silently decodes as `False` — a data-corruption-class bug affecting all three driver paths.

## Solution

**New `gaussdb+pg8000` dialect (macOS default).** Extends the pure-Python [pg8000](https://pypi.org/project/pg8000/) driver with GaussDB's private SHA256 handshake: RFC 5802 client proof over startup protocol 3.51 (the payload carries the PBKDF2 iteration count only under 3.51). Key decisions:

- The 3.51 startup rides on a *clone* of `CoreConnection.__init__` with a patched `i_pack` in its globals rather than a ~140-line copy — thread-safe, no module state touched, survives upstream patch releases; a drift-guard test pins the upstream source hash. Planned upstream PR (`protocol_version` parameter) removes the clone entirely.
- Auth code 10 dispatch: sha256/md5/plain handled; SM3 and code-11 (MD5_SHA256, unrecoverable — server omits iteration count) rejected with actionable hints; SCRAM-shaped payloads delegate to stock pg8000 so the class stays correct against real PostgreSQL.
- Full libpq `sslmode` vocabulary mapped onto Python `ssl` (`disable`/`allow`/`prefer`/`require`/`verify-ca`/`verify-full`); new `sslrootcert` config field for the verify modes.
- RFC 5802 implementation cross-checked byte-for-byte against py_opengauss's independent implementation.

**Tolerant boolean decoding on all three dialects** (`pg8000`, `psycopg`, `psycopg2`): a parser accepting both `'t'/'true'` and `'1'` is correct in every compatibility mode, so it is registered unconditionally — no per-connection probe, no failure path.

**SKILL.md**: B-mode SQL rules the skill previously lacked (numeric date subtraction — `date1 - date2` yields 214, not 74; NULLS FIRST ascending sort; MySQL week numbering; bool rendering).

## Test Cases

- `tests/unit/test_pg8000_gauss.py` (new): RFC 5802 known-answer vector (cross-validated against py_opengauss), fake-server socketpair handshake proving protocol 3.51 on the wire and the exact SHA256 response, md5-under-code-10, SM3/code-11/missing-password error paths, SCRAM delegation, upstream drift guard, DB-API module surface.
- `tests/unit/test_sa_dialect.py`: sslmode→ssl_context matrix incl. verify-without-rootcert rejection, bool adapter registration on all three dialects, registry resolution.
- `tests/unit/test_config.py` / `test_connector_unit.py`: pg8000 driver acceptance, macOS default flip, sslrootcert round-trip and URL encoding.
- Integration: all 39 tests pass on macOS over the pg8000 sha256 path (previously impossible) against openGauss 7.0.0-RC2 with sha256-only hba + hostssl; verified end to end against a Huawei-cloud managed GaussDB Kernel 505.2.1 instance (sha256 + TLS + B-mode database), including SQLAlchemy pooling, metadata reflection, and bound-parameter round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pg8000` support for GaussDB, with macOS using it by default.
  * Added SHA256 and MD5 authentication support, including clearer errors for unsupported configurations.
  * Added SSL root certificate configuration through `sslrootcert`.
  * Improved boolean value handling across supported drivers.
  * Added support for GBK database encoding and Chinese identifiers and data.
* **Documentation**
  * Expanded authentication, driver-selection, SSL, platform, and SQL compatibility guidance.
* **Tests**
  * Added coverage for authentication, connection settings, encoding, dialect behavior, driver selection, and SQL compatibility modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->