### PR TITLE
[BugFix] GaussDB: refuse system discovery of a vanilla PostgreSQL libpq

### DIFF
--- a/datus-gaussdb/datus_gaussdb/_libpq.py
+++ b/datus-gaussdb/datus_gaussdb/_libpq.py
@@ -85,6 +85,39 @@ def _patched_find_library(libpq_path: str):
         ctypes.util.find_library = original
 
 
+def _reject_vanilla_postgres_libpq() -> None:
+    """Refuse system discovery when it would bind a vanilla PostgreSQL libpq.
+
+    The gaussdb driver's ctypes struct layouts match only the
+    GaussDB/openGauss build of libpq; against a modern vanilla PostgreSQL
+    libpq the first ``PQconninfoParse`` call segfaults the whole process
+    (source checkouts without ``_vendor`` fall back to system discovery and
+    hit exactly this on hosts with PostgreSQL installed). ``PQlibVersion()``
+    is a safe probe — no arguments, plain int return: the GaussDB/openGauss
+    libpq is a PostgreSQL 9.2 fork and reports 9xxxx, while any vanilla
+    libpq found on a modern host reports >= 100000 (PostgreSQL 10+).
+    """
+    libpq_path = ctypes.util.find_library("pq")
+    if libpq_path is None:
+        # Nothing to probe; let the driver surface its own import error.
+        return
+    try:
+        lib = ctypes.CDLL(libpq_path)
+        version = int(lib.PQlibVersion())
+    except (OSError, AttributeError):
+        # Unloadable or ancient library: the driver's own loading will
+        # produce a regular (non-crashing) error for these.
+        return
+    if version >= 100000:
+        raise ImportError(
+            f"libpq at {libpq_path!r} reports PostgreSQL {version // 10000}.x; the gaussdb "
+            "driver requires the GaussDB/openGauss build of libpq and would crash the "
+            "process against this one. Populate the vendored copy with "
+            "`python scripts/fetch_vendor_libpq.py` (release wheels bundle it) or point "
+            f"{_ENV_VAR} at a GaussDB client libpq."
+        )
+
+
 def import_gaussdb():
     """Import (and return) the ``gaussdb`` module against the right libpq.
 
@@ -96,6 +129,7 @@ def import_gaussdb():
 
     libpq_path = resolve_libpq_path()
     if libpq_path is None:
+        _reject_vanilla_postgres_libpq()
         import gaussdb
 
         return gaussdb

--- a/datus-gaussdb/tests/unit/test_libpq.py
+++ b/datus-gaussdb/tests/unit/test_libpq.py
@@ -195,6 +195,9 @@ def test_import_gaussdb_uses_system_discovery_without_preloading(monkeypatch):
     original_import = builtins.__import__
     monkeypatch.delitem(sys.modules, "gaussdb", raising=False)
     monkeypatch.setattr(_libpq, "resolve_libpq_path", lambda: None)
+    # No discoverable libpq: the vanilla-PostgreSQL probe has nothing to
+    # inspect and must fall through to the driver's own import.
+    monkeypatch.setattr(ctypes.util, "find_library", lambda _name: None)
     monkeypatch.setattr(
         _libpq.ctypes,
         "CDLL",
@@ -259,3 +262,74 @@ def test_import_gaussdb_preloads_openssl_and_patches_libpq_lookup(monkeypatch, t
         ("import", "gaussdb"),
         ("patch-exit", str(tmp_path / "libpq.so.5")),
     ]
+
+
+# ==================== vanilla-libpq guard ====================
+
+
+class _FakeLibpq:
+    def __init__(self, version: int):
+        self._version = version
+
+    def PQlibVersion(self) -> int:  # noqa: N802 - mirrors the C symbol
+        return self._version
+
+
+def _system_discovery(monkeypatch, found: str | None, cdll):
+    """Route import_gaussdb into system discovery with a fake probe target."""
+    monkeypatch.delitem(sys.modules, "gaussdb", raising=False)
+    monkeypatch.setattr(_libpq, "resolve_libpq_path", lambda: None)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda _name: found)
+    monkeypatch.setattr(_libpq.ctypes, "CDLL", cdll)
+
+
+@pytest.mark.acceptance
+def test_import_gaussdb_rejects_vanilla_postgres_libpq(monkeypatch):
+    """A discoverable PostgreSQL 10+ libpq raises instead of segfaulting.
+
+    Regression guard for the nightly crash: a source checkout without
+    `_vendor` falls back to system discovery, finds the host's vanilla
+    libpq, and the driver's first PQconninfoParse call segfaults. The
+    probe must turn that into an actionable ImportError.
+    """
+    _system_discovery(monkeypatch, "libpq.so.5", lambda _path: _FakeLibpq(170005))
+
+    with pytest.raises(ImportError, match="fetch_vendor_libpq"):
+        _libpq.import_gaussdb()
+
+
+@pytest.mark.acceptance
+def test_import_gaussdb_accepts_gaussdb_family_libpq(monkeypatch):
+    """A GaussDB/openGauss libpq (PostgreSQL 9.2 fork) passes the probe."""
+    sentinel = object()
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "gaussdb":
+            return sentinel
+        return original_import(name, *args, **kwargs)
+
+    _system_discovery(monkeypatch, "libpq.so.5", lambda _path: _FakeLibpq(90204))
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert _libpq.import_gaussdb() is sentinel
+
+
+@pytest.mark.acceptance
+def test_import_gaussdb_probe_tolerates_unloadable_library(monkeypatch):
+    """An unloadable probe target falls through to the driver's own error."""
+    sentinel = object()
+    original_import = builtins.__import__
+
+    def raising_cdll(_path):
+        raise OSError("cannot open shared object file")
+
+    def fake_import(name, *args, **kwargs):
+        if name == "gaussdb":
+            return sentinel
+        return original_import(name, *args, **kwargs)
+
+    _system_discovery(monkeypatch, "libpq.so.5", raising_cdll)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert _libpq.import_gaussdb() is sentinel


### PR DESCRIPTION
## Why

Datus nightly has ended with exit 139 (SIGSEGV) in `test_gaussdb.py::test_list_tables_returns_seeded_tables` every night since the GaussDB group was added (e.g. [run 31921897109](https://github.com/Datus-ai/Datus-agent/actions/runs/31921897109)). The crash stack is `gaussdb/pq/pq_ctypes.py` → `conninfo.py` → `PQconninfoParse`.

Root cause: nightly installs this adapter from the git checkout, and source checkouts have no `_vendor` binaries (`.gitignore` excludes `*.so*`; they are generated only at wheel-release time by `fetch_vendor_libpq.py`). `import_gaussdb()` therefore falls back to system discovery, binds the driver against the runner's vanilla PostgreSQL libpq, and the very first `PQconninfoParse` call segfaults — exactly the failure mode `_libpq.py`'s docstring warns about, but until now it took down the whole pytest process instead of failing one import.

## Solution

Before system discovery imports the driver, probe the discoverable libpq with `PQlibVersion()` — no arguments, plain int return, safe to call on any libpq build:

- GaussDB/openGauss libpq (PostgreSQL 9.2 fork) reports `9xxxx` → proceed.
- Vanilla libpq on any modern host reports `>= 100000` (PostgreSQL 10+) → raise an actionable `ImportError` pointing at `scripts/fetch_vendor_libpq.py` and `DATUS_GAUSSDB_LIBPQ`.
- No discoverable libpq / unloadable library → fall through to the driver's own regular error, as before.

The explicit `DATUS_GAUSSDB_LIBPQ=<path>` override and the vendored-wheel path are unchanged.

A companion Datus-agent PR makes nightly populate the vendored libpq so the GaussDB group actually runs; this guard ensures any future environment gap fails as one readable error instead of SIGSEGV.

## Test Cases

`tests/unit/test_libpq.py`: three new cases — vanilla PG 17 libpq raises with the fetch-script hint, GaussDB-family 9.2 libpq passes through to the driver import, unloadable probe target falls through; the existing system-discovery test now pins the no-discoverable-libpq path. Full adapter unit suite: 147 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks when loading system database libraries.
  * PostgreSQL 10+ libraries are now rejected with a clear error when incompatible with the GaussDB driver.
  * Compatible GaussDB libraries continue loading normally.
  * Improved handling when libraries are missing or cannot be probed.

* **Tests**
  * Added coverage for library discovery, version validation, compatible libraries, and unavailable libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->