### PR TITLE
[Enhancement] Add GaussDB TLS verification coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,12 @@ pip install datus-gaussdb
 ```
 
 **Features**:
-- GaussDB / openGauss (PostgreSQL-compatible), official gaussdb driver with sha256 auth
+- Official `gaussdb` driver on Linux (sha256, md5, and sm3 authentication)
+- Pure-Python `pg8000` driver on macOS and any platform (sha256 and md5 authentication)
 - Optional `psycopg2` driver escape hatch for md5-authenticated servers
+- TLS modes through `verify-full`, with `verify-ca` recommended for production
 - Database and schema namespace support with PostgreSQL-compatible SQL execution
-- Docker integration coverage against an openGauss instance
+- Ephemeral Docker TLS integration coverage against an openGauss instance
 
 ---
 

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -562,6 +562,8 @@ prepare_adapter_test_artifacts() {
       GAUSSDB_TLS_HOST_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-gaussdb-tls.XXXXXX")"
       docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/ca.crt "$GAUSSDB_TLS_HOST_DIR/ca.crt"
       docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/wrong-ca.crt "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"
+      # The native GaussDB/libpq client rejects CA files readable by group or other users.
+      chmod 0600 "$GAUSSDB_TLS_HOST_DIR/ca.crt" "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"
       export GAUSSDB_SSLMODE="verify-ca"
       export GAUSSDB_SSLROOTCERT="$GAUSSDB_TLS_HOST_DIR/ca.crt"
       export GAUSSDB_WRONG_SSLROOTCERT="$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -8,6 +8,7 @@ ALL_ADAPTERS=(postgresql mysql clickhouse starrocks doris trino greenplum hive s
 DOCKER_COMPOSE=()
 STARTED_ADAPTERS=()
 CURRENT_ADAPTER=""
+GAUSSDB_TLS_HOST_DIR=""
 
 usage() {
   cat <<'USAGE'
@@ -294,7 +295,7 @@ adapter_env_summary() {
     hive) echo "env: HIVE_HOST=$HIVE_HOST HIVE_PORT=$HIVE_PORT HIVE_DATABASE=$HIVE_DATABASE" ;;
     spark) echo "env: SPARK_HOST=$SPARK_HOST SPARK_PORT=$SPARK_PORT SPARK_DATABASE=$SPARK_DATABASE SPARK_AUTH_MECHANISM=$SPARK_AUTH_MECHANISM" ;;
     oracle) echo "env: ORACLE_HOST=$ORACLE_HOST ORACLE_PORT=$ORACLE_PORT ORACLE_SERVICE_NAME=$ORACLE_SERVICE_NAME ORACLE_SCHEMA=$ORACLE_SCHEMA" ;;
-    gaussdb) echo "env: GAUSSDB_HOST=$GAUSSDB_HOST GAUSSDB_PORT=$GAUSSDB_PORT GAUSSDB_DATABASE=$GAUSSDB_DATABASE" ;;
+    gaussdb) echo "env: GAUSSDB_HOST=$GAUSSDB_HOST GAUSSDB_PORT=$GAUSSDB_PORT GAUSSDB_DATABASE=$GAUSSDB_DATABASE GAUSSDB_SSLMODE=${GAUSSDB_SSLMODE:-unset}" ;;
   esac
 }
 
@@ -309,7 +310,7 @@ prepare_adapter_dependencies() {
     gaussdb)
       operating_system="$(uname -s)"
       if [ "$operating_system" != "Linux" ]; then
-        echo "GaussDB vendored client libraries are Linux-only; using system library discovery on $operating_system"
+        echo "GaussDB vendored client libraries are Linux-only; using the pure-Python pg8000 driver on $operating_system"
         return 0
       fi
 
@@ -357,6 +358,15 @@ cleanup_started() {
   for adapter in "${STARTED_ADAPTERS[@]}"; do
     compose_down "$adapter"
   done
+}
+
+cleanup_gaussdb_tls_artifacts() {
+  if [ -n "$GAUSSDB_TLS_HOST_DIR" ] && [ -d "$GAUSSDB_TLS_HOST_DIR" ]; then
+    rm -f -- "$GAUSSDB_TLS_HOST_DIR/ca.crt" "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"
+    rmdir "$GAUSSDB_TLS_HOST_DIR" 2>/dev/null || true
+  fi
+  GAUSSDB_TLS_HOST_DIR=""
+  unset GAUSSDB_SSLMODE GAUSSDB_SSLROOTCERT GAUSSDB_WRONG_SSLROOTCERT
 }
 
 dump_adapter_diagnostics() {
@@ -411,6 +421,7 @@ cleanup_on_exit() {
     dump_adapter_diagnostics "$CURRENT_ADAPTER"
   fi
   cleanup_started
+  cleanup_gaussdb_tls_artifacts
   exit "$exit_status"
 }
 
@@ -537,6 +548,23 @@ wait_for_adapter_client_readiness() {
       ;;
     gaussdb)
       wait_for_python_connector_readiness "gaussdb" "datus-gaussdb"
+      ;;
+  esac
+}
+
+prepare_adapter_test_artifacts() {
+  local adapter="$1"
+  local compose_file="$2"
+
+  case "$adapter" in
+    gaussdb)
+      cleanup_gaussdb_tls_artifacts
+      GAUSSDB_TLS_HOST_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-gaussdb-tls.XXXXXX")"
+      docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/ca.crt "$GAUSSDB_TLS_HOST_DIR/ca.crt"
+      docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/wrong-ca.crt "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"
+      export GAUSSDB_SSLMODE="verify-ca"
+      export GAUSSDB_SSLROOTCERT="$GAUSSDB_TLS_HOST_DIR/ca.crt"
+      export GAUSSDB_WRONG_SSLROOTCERT="$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"
       ;;
   esac
 }
@@ -675,6 +703,9 @@ elif adapter == "gaussdb":
         password=os.getenv("GAUSSDB_PASSWORD", "Datus@123"),
         database=os.getenv("GAUSSDB_DATABASE", "postgres"),
         schema_name=os.getenv("GAUSSDB_SCHEMA", "public"),
+        driver=os.getenv("GAUSSDB_DRIVER") or ("pg8000" if sys.platform == "darwin" else "gaussdb"),
+        sslmode=os.getenv("GAUSSDB_SSLMODE", "prefer"),
+        sslrootcert=os.getenv("GAUSSDB_SSLROOTCERT") or None,
         timeout_seconds=5,
     )
     connector = GaussDBConnector(config)
@@ -828,10 +859,14 @@ for adapter in "${selected_adapters[@]}"; do
     timeout_seconds="${spec##*:}"
     wait_for_service_health "$compose_file" "$service_name" "$timeout_seconds"
   done
+  prepare_adapter_test_artifacts "$adapter" "$compose_file"
   wait_for_adapter_client_readiness "$adapter"
 
   uv run --package "$package" --with pytest --with pandas --with pyarrow pytest "$test_path" -m integration --tb=short --verbose
 
   compose_down "$adapter"
+  if [ "$adapter" = "gaussdb" ]; then
+    cleanup_gaussdb_tls_artifacts
+  fi
   CURRENT_ADAPTER=""
 done

--- a/ci/tests/test_run_integration_tests.py
+++ b/ci/tests/test_run_integration_tests.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+RUNNER = Path(__file__).resolve().parents[1] / "run-integration-tests.sh"
+
+
+def test_gaussdb_client_ca_files_are_private_before_export() -> None:
+    source = RUNNER.read_text(encoding="utf-8")
+
+    trusted_copy = source.index(
+        'docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/ca.crt "$GAUSSDB_TLS_HOST_DIR/ca.crt"'
+    )
+    untrusted_copy = source.index(
+        'docker_compose -f "$compose_file" cp gaussdb:/gaussdb-tls/wrong-ca.crt "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"'
+    )
+    private_permissions = source.index('chmod 0600 "$GAUSSDB_TLS_HOST_DIR/ca.crt" "$GAUSSDB_TLS_HOST_DIR/wrong-ca.crt"')
+    trusted_export = source.index('export GAUSSDB_SSLROOTCERT="$GAUSSDB_TLS_HOST_DIR/ca.crt"')
+
+    assert max(trusted_copy, untrusted_copy) < private_permissions < trusted_export

--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -215,7 +215,11 @@ GAUSSDB_SCHEMA=public
 GAUSSDB_DRIVER=pg8000         # platform default when unset
 GAUSSDB_SSLMODE=verify-ca
 GAUSSDB_SSLROOTCERT=/path/to/gaussdb-ca.pem
+GAUSSDB_WRONG_SSLROOTCERT=/path/to/untrusted-ca.pem
 ```
+
+Set both CA paths to run the positive trusted-CA and negative untrusted-CA TLS
+contracts; tests that require a missing path are skipped.
 
 Tear the environment down with `docker compose down -v`. The compose file
 documents two openGauss container quirks (the mandatory out-of-datadir

--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -15,18 +15,31 @@ pip install datus-gaussdb
 ## Configuration
 
 ```yaml
-services:
-  datasources:
-    gaussdb:
-      type: gaussdb
-      host: ${GAUSSDB_HOST}
-      port: ${GAUSSDB_PORT}
-      username: ${GAUSSDB_USER}
-      password: ${GAUSSDB_PASSWORD}
-      database: ${GAUSSDB_DATABASE}
-      schema: public
-      sslmode: prefer
+agent:
+  services:
+    datasources:
+      gaussdb:
+        type: gaussdb
+        host: ${GAUSSDB_HOST}
+        port: ${GAUSSDB_PORT}
+        username: ${GAUSSDB_USER}
+        password: ${GAUSSDB_PASSWORD}
+        database: ${GAUSSDB_DATABASE}
+        schema: public
+        # driver: pg8000  # optional; omit to use the platform default
+        sslmode: verify-ca
+        sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `host`, `port` | yes | GaussDB/openGauss endpoint |
+| `username`, `password` | yes | Login credentials; supported authentication depends on `driver` |
+| `database` | yes | Database to connect to |
+| `schema` | no | Default schema; defaults to `public` |
+| `driver` | no | `gaussdb` on Linux and `pg8000` on macOS by default; `psycopg2` is an md5-only escape hatch |
+| `sslmode` | no | `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, or `verify-full`; use `verify-ca` in production |
+| `sslrootcert` | for explicit verification | CA bundle used by `verify-ca`/`verify-full`; libpq's standard certificate locations are also honored |
 
 ```python
 from datus_gaussdb import GaussDBConfig, GaussDBConnector
@@ -70,13 +83,38 @@ platform:
       driver: pg8000
 ```
 
-For TLS it maps the full libpq `sslmode` vocabulary onto Python's `ssl`
-module; `verify-ca` / `verify-full` additionally need the CA bundle:
+All three drivers support the full libpq `sslmode` vocabulary. `verify-ca` is
+the recommended production setting: it encrypts the connection and rejects a
+server whose certificate is not signed by the configured CA. `verify-full`
+adds hostname verification, so the certificate must also contain the exact
+hostname used in `host`.
 
 ```yaml
-      sslmode: verify-full
-      sslrootcert: /etc/ssl/gauss-ca.pem
+      sslmode: verify-ca
+      sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
+
+| `sslmode` | Encryption | Certificate validation |
+|-----------|------------|------------------------|
+| `disable` | off | none |
+| `allow` | preferred only after a non-TLS connection fails | none |
+| `prefer` | preferred, but permits a non-TLS fallback | none |
+| `require` | required | none |
+| `verify-ca` | required | verifies the server certificate chain against `sslrootcert` |
+| `verify-full` | required | verifies the chain and the server hostname |
+
+The `pg8000` path treats `allow` like `prefer` (TLS first), because its API
+cannot express libpq's plaintext-first retry order.
+
+If the server enables TLS but does not require it, `prefer` can still connect
+without TLS after negotiation failures; it does not authenticate the server.
+If the server requires TLS, `prefer` normally connects with TLS, but explicitly
+select `require`, `verify-ca`, or `verify-full` so the client cannot fall back
+to plaintext against a differently configured endpoint. Only the two
+`verify-*` modes require the server CA to be configured on the client. The
+current adapter supports one-way TLS only: it accepts `sslrootcert`, but does
+not expose client-certificate fields such as `sslcert` or `sslkey` for mutual
+TLS.
 
 The `psycopg2` escape hatch requires the server to offer md5 authentication
 for that login: an `md5` rule in `pg_hba.conf` **and** a password stored as an
@@ -144,12 +182,23 @@ Unit tests need no database:
 cd datus-gaussdb && python -m pytest tests/unit/ -v
 ```
 
-Integration tests need a live server. The bundled compose file starts openGauss
-7.0.0-RC2 and provisions the `datus` login role:
+The repository runner starts an ephemeral openGauss 7.0.0-RC2 server, creates a
+temporary CA and server certificate, requires TLS on the server, and runs the
+positive and negative certificate-verification contracts:
+
+```bash
+ci/run-integration-tests.sh gaussdb
+```
+
+The generated certificates live in the compose volume only for that run and
+are removed by `docker compose down -v`; no Huawei Cloud or other persistent
+instance is required.
+
+To run against an existing GaussDB/openGauss service instead, start the service
+yourself and invoke the integration suite directly:
 
 ```bash
 cd datus-gaussdb
-docker compose up -d          # wait for the container to report healthy
 python scripts/init_tpch_data.py --drop
 python -m pytest tests/integration/ -v -m integration
 ```
@@ -163,6 +212,9 @@ GAUSSDB_USER=datus
 GAUSSDB_PASSWORD=Datus@123
 GAUSSDB_DATABASE=postgres
 GAUSSDB_SCHEMA=public
+GAUSSDB_DRIVER=pg8000         # platform default when unset
+GAUSSDB_SSLMODE=verify-ca
+GAUSSDB_SSLROOTCERT=/path/to/gaussdb-ca.pem
 ```
 
 Tear the environment down with `docker compose down -v`. The compose file
@@ -170,10 +222,10 @@ documents two openGauss container quirks (the mandatory out-of-datadir
 `GAUSSLOG`, and the first post-initdb server start aborting on Docker Desktop
 for macOS) that its entrypoint wrapper works around.
 
-On macOS, integration tests use `pg8000` by default. To exercise the official
-driver, run them in a Linux container or explicitly set `GAUSSDB_DRIVER=gaussdb`
-on a Linux host; `GAUSSDB_DRIVER=pg8000` selects the pure-Python path on any
-platform.
+On macOS, integration tests use `pg8000` by default and also exercise the
+`psycopg2` escape hatch in the dedicated TLS contract. To exercise the official
+driver, run on Linux; `GAUSSDB_DRIVER=pg8000` selects the pure-Python path on
+any platform.
 
 ## Source checkouts
 

--- a/datus-gaussdb/datus_gaussdb/config.py
+++ b/datus-gaussdb/datus_gaussdb/config.py
@@ -36,11 +36,18 @@ class GaussDBConfig(PostgreSQLConfig):
             "server)"
         ),
     )
+    sslmode: Literal["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] = Field(
+        default="prefer",
+        description=(
+            "TLS mode. 'verify-ca' is recommended for production. pg8000 requires "
+            "sslrootcert; the libpq drivers may use their standard certificate locations"
+        ),
+    )
     sslrootcert: Optional[str] = Field(
         default=None,
         description=(
-            "Path to the CA certificate for sslmode verify-ca/verify-full. "
-            "Only honored by the pg8000 driver; the libpq-based drivers read "
-            "the standard PGSSLROOTCERT locations instead."
+            "Path to the CA certificate used to verify the server for sslmode "
+            "verify-ca/verify-full. Forwarded to every supported driver; the "
+            "libpq-based drivers can also use their standard certificate locations"
         ),
     )

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -158,8 +158,9 @@ class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
     """GaussDB/openGauss dialect using PostgreSQL's psycopg2 client.
 
     Linux continues to use the official ``gaussdb`` driver unless
-    ``driver: psycopg2`` is configured explicitly. macOS selects this path by
-    default because no compatible native GaussDB/openGauss libpq is available.
+    ``driver: psycopg2`` is configured explicitly. macOS defaults to the
+    pure-Python ``pg8000`` path because no compatible native
+    GaussDB/openGauss libpq is available.
     """
 
     name = "gaussdb"

--- a/datus-gaussdb/docker-compose.yml
+++ b/datus-gaussdb/docker-compose.yml
@@ -23,8 +23,19 @@
 # Comment that catch-all out to exercise sha256 authentication exclusively.
 
 services:
+  tls-setup:
+    image: opengauss/opengauss:7.0.0-RC2.B015
+    volumes:
+      - ./scripts/generate-test-tls.sh:/generate-test-tls.sh:ro
+      - gaussdb_tls:/gaussdb-tls
+    entrypoint: ["bash", "/generate-test-tls.sh", "/gaussdb-tls"]
+    restart: "no"
+
   gaussdb:
     image: opengauss/opengauss:7.0.0-RC2.B015
+    depends_on:
+      tls-setup:
+        condition: service_completed_successfully
     ports:
       - "${GAUSSDB_HOST_PORT:-25434}:5432"
     environment:
@@ -34,6 +45,8 @@ services:
       GAUSSLOG: /gausslog
     volumes:
       - ./scripts/docker-entrypoint-wrapper.sh:/docker-entrypoint-wrapper.sh:ro
+      - ./scripts/configure-test-tls.sh:/docker-entrypoint-initdb.d/10-configure-test-tls.sh:ro
+      - gaussdb_tls:/gaussdb-tls:ro
     entrypoint: ["bash", "/docker-entrypoint-wrapper.sh"]
     healthcheck:
       test: ["CMD-SHELL", "bash /docker-entrypoint-wrapper.sh healthcheck"]
@@ -41,3 +54,6 @@ services:
       timeout: 10s
       retries: 40
       start_period: 60s
+
+volumes:
+  gaussdb_tls:

--- a/datus-gaussdb/scripts/configure-test-tls.sh
+++ b/datus-gaussdb/scripts/configure-test-tls.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Executed by the upstream image during first-time init, after its temporary
+# server starts and before the final server start. This guarantees that the
+# final TCP listener requires TLS without adding a restart race to the wrapper.
+set -euo pipefail
+
+install -m 0600 /gaussdb-tls/server.key "$PGDATA/server.key"
+# openGauss rejects both the private key and the server certificate when
+# either is group/world-accessible.
+install -m 0600 /gaussdb-tls/server.crt "$PGDATA/server.crt"
+
+gs_guc set -D "$PGDATA" -c "ssl=on"
+gs_guc set -D "$PGDATA" -c "require_ssl=on"

--- a/datus-gaussdb/scripts/generate-test-tls.sh
+++ b/datus-gaussdb/scripts/generate-test-tls.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Generate an ephemeral CA, a server certificate signed by it, and an unrelated
+# CA used by the negative verification test. The named Docker volume that holds
+# these files is removed by `docker compose down -v`.
+set -euo pipefail
+
+tls_output_dir=${1:-/gaussdb-tls}
+umask 077
+mkdir -p "$tls_output_dir"
+
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -days 2 \
+  -subj "/CN=Datus GaussDB Integration CA" \
+  -keyout "$tls_output_dir/ca.key" \
+  -out "$tls_output_dir/ca.crt"
+
+openssl req \
+  -newkey rsa:2048 \
+  -nodes \
+  -subj "/CN=localhost" \
+  -keyout "$tls_output_dir/server.key" \
+  -out "$tls_output_dir/server.csr"
+
+printf '%s\n' 'subjectAltName=DNS:localhost' >"$tls_output_dir/server.ext"
+
+openssl x509 \
+  -req \
+  -days 2 \
+  -in "$tls_output_dir/server.csr" \
+  -CA "$tls_output_dir/ca.crt" \
+  -CAkey "$tls_output_dir/ca.key" \
+  -CAcreateserial \
+  -extfile "$tls_output_dir/server.ext" \
+  -out "$tls_output_dir/server.crt"
+
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -days 2 \
+  -subj "/CN=Datus GaussDB Untrusted CA" \
+  -keyout "$tls_output_dir/wrong-ca.key" \
+  -out "$tls_output_dir/wrong-ca.crt"
+
+chmod 0600 "$tls_output_dir/ca.key" "$tls_output_dir/server.key" "$tls_output_dir/wrong-ca.key"
+chmod 0644 "$tls_output_dir/ca.crt" "$tls_output_dir/server.crt" "$tls_output_dir/wrong-ca.crt"
+# The database image runs initdb as uid/gid 70 (omm). The named volume is
+# populated by this root-owned setup service, so hand the server pair to omm.
+chown 70:70 "$tls_output_dir/server.key" "$tls_output_dir/server.crt"
+rm -f "$tls_output_dir/server.csr" "$tls_output_dir/server.ext" "$tls_output_dir/ca.srl"

--- a/datus-gaussdb/tests/integration/conftest.py
+++ b/datus-gaussdb/tests/integration/conftest.py
@@ -16,12 +16,14 @@ Variable                     Default             Meaning
 ``GAUSSDB_DATABASE``         ``postgres``        default database
 ``GAUSSDB_SCHEMA``           ``public``          default schema
 ``GAUSSDB_DRIVER``           platform default    ``gaussdb``, ``pg8000`` or ``psycopg2``
+``GAUSSDB_SSLMODE``          ``prefer``           TLS mode
+``GAUSSDB_SSLROOTCERT``      unset                CA certificate used to verify the server
 ===========================  ==================  =========================
 
 IMPORTANT — platform caveat: the official ``gaussdb`` driver binds the
 GaussDB/openGauss build of libpq via ctypes, and only that build; there is no
-macOS distribution of it. Run this suite inside a Linux container (the same
-one that runs the openGauss server is fine)::
+macOS distribution of it. macOS therefore defaults to ``pg8000``. To exercise
+the official driver, run this suite inside a Linux container::
 
     docker run --rm -v "$PWD:/w" -w /w --network host python:3.12 \\
         bash -c "pip install -e datus-db-core -e datus-sqlalchemy \\
@@ -34,7 +36,7 @@ is inert on developer machines without a GaussDB instance.
 Off Linux, tests using the official driver are skipped up front: the driver
 binds whatever libpq it can find, and a vanilla PostgreSQL libpq makes it
 *segfault* on connect rather than raise — a crash no fixture can catch. The
-``psycopg2`` path is safe on macOS and is selected there by default. Set
+``pg8000`` path is safe on macOS and is selected there by default. Set
 ``GAUSSDB_FORCE_INTEGRATION=1`` only to run the official driver on a host that
 really does have the GaussDB client libraries.
 """
@@ -74,6 +76,8 @@ def _build_config() -> GaussDBConfig:
         database=os.getenv("GAUSSDB_DATABASE", "postgres"),
         schema_name=os.getenv("GAUSSDB_SCHEMA", "public"),
         driver=os.getenv("GAUSSDB_DRIVER") or ("pg8000" if sys.platform == "darwin" else "gaussdb"),
+        sslmode=os.getenv("GAUSSDB_SSLMODE", "prefer"),
+        sslrootcert=os.getenv("GAUSSDB_SSLROOTCERT") or None,
     )
 
 

--- a/datus-gaussdb/tests/integration/test_ssl.py
+++ b/datus-gaussdb/tests/integration/test_ssl.py
@@ -1,0 +1,122 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Live TLS verification against the Docker-backed openGauss server."""
+
+import os
+import sys
+
+import pytest
+
+from datus_db_core import DatusDbException
+from datus_gaussdb import GaussDBConnector
+
+pytestmark = pytest.mark.integration
+
+
+def _tls_file(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        pytest.skip(f"{name} is required for the TLS integration contract")
+    return value
+
+
+def _supported_drivers() -> list[str]:
+    drivers = ["pg8000", "psycopg2"]
+    if sys.platform == "linux" or os.getenv("GAUSSDB_FORCE_INTEGRATION") == "1":
+        drivers.insert(0, "gaussdb")
+    return drivers
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+def test_verify_ca_accepts_the_trusted_server(config, driver):
+    connector = GaussDBConnector(
+        config.model_copy(
+            update={
+                "driver": driver,
+                "sslmode": "verify-ca",
+                "sslrootcert": _tls_file("GAUSSDB_SSLROOTCERT"),
+            }
+        )
+    )
+    try:
+        assert connector.test_connection() is True
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+def test_verify_ca_rejects_an_untrusted_server(config, driver):
+    connector = GaussDBConnector(
+        config.model_copy(
+            update={
+                "driver": driver,
+                "sslmode": "verify-ca",
+                "sslrootcert": _tls_file("GAUSSDB_WRONG_SSLROOTCERT"),
+            }
+        )
+    )
+    try:
+        with pytest.raises(DatusDbException):
+            connector.test_connection()
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+def test_verify_full_accepts_a_matching_hostname(config, driver):
+    connector = GaussDBConnector(
+        config.model_copy(
+            update={
+                "host": "localhost",
+                "driver": driver,
+                "sslmode": "verify-full",
+                "sslrootcert": _tls_file("GAUSSDB_SSLROOTCERT"),
+            }
+        )
+    )
+    try:
+        assert connector.test_connection() is True
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+def test_verify_full_rejects_a_hostname_mismatch(config, driver):
+    connector = GaussDBConnector(
+        config.model_copy(
+            update={
+                "driver": driver,
+                "sslmode": "verify-full",
+                "sslrootcert": _tls_file("GAUSSDB_SSLROOTCERT"),
+            }
+        )
+    )
+    try:
+        with pytest.raises(DatusDbException):
+            connector.test_connection()
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+@pytest.mark.parametrize("sslmode", ["prefer", "require"])
+def test_non_verifying_modes_negotiate_tls_without_a_ca(config, driver, sslmode):
+    connector = GaussDBConnector(config.model_copy(update={"driver": driver, "sslmode": sslmode, "sslrootcert": None}))
+    try:
+        assert connector.test_connection() is True
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("driver", _supported_drivers())
+def test_disable_fails_when_the_server_requires_tls(config, driver):
+    connector = GaussDBConnector(
+        config.model_copy(update={"driver": driver, "sslmode": "disable", "sslrootcert": None})
+    )
+    try:
+        with pytest.raises(DatusDbException):
+            connector.test_connection()
+    finally:
+        connector.close()

--- a/datus-gaussdb/tests/unit/test_config.py
+++ b/datus-gaussdb/tests/unit/test_config.py
@@ -128,6 +128,23 @@ def test_config_sslrootcert_default_none_and_roundtrip():
 
 
 @pytest.mark.acceptance
+@pytest.mark.parametrize(
+    "sslmode",
+    ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+)
+def test_config_accepts_supported_ssl_modes(sslmode):
+    assert GaussDBConfig(username="datus", sslmode=sslmode).sslmode == sslmode
+
+
+@pytest.mark.acceptance
+def test_config_rejects_unknown_ssl_mode():
+    with pytest.raises(ValidationError) as exc_info:
+        GaussDBConfig(username="datus", sslmode="verify-sometimes")
+
+    assert any(error["loc"] == ("sslmode",) for error in exc_info.value.errors())
+
+
+@pytest.mark.acceptance
 def test_config_driver_invalid_rejected():
     """Any other driver value is rejected by the Literal type."""
     with pytest.raises(ValidationError) as exc_info:

--- a/datus-gaussdb/tests/unit/test_connector_unit.py
+++ b/datus-gaussdb/tests/unit/test_connector_unit.py
@@ -152,16 +152,17 @@ def test_connection_string_uses_pg8000_dialect():
 
 
 @pytest.mark.acceptance
-def test_connection_string_carries_sslrootcert():
-    """verify-ca/verify-full need the CA path forwarded to the dialect."""
+@pytest.mark.parametrize("driver", ["gaussdb", "pg8000", "psycopg2"])
+def test_connection_string_carries_sslrootcert_for_every_driver(driver):
+    """Every supported driver receives the explicit CA path."""
     connector = _make_connector(
-        driver="pg8000",
+        driver=driver,
         password="pass",
-        sslmode="verify-full",
+        sslmode="verify-ca",
         sslrootcert="/etc/ssl/gauss-ca.pem",
     )
 
-    assert "sslmode=verify-full" in connector.connection_string
+    assert "sslmode=verify-ca" in connector.connection_string
     assert "sslrootcert=%2Fetc%2Fssl%2Fgauss-ca.pem" in connector.connection_string
 
 


### PR DESCRIPTION
## Summary

- validate the full GaussDB `sslmode` vocabulary and forward `sslrootcert` to every supported driver
- generate an ephemeral CA and server certificate for the Docker-backed openGauss fixture, enable `require_ssl`, and remove the certificate volume after each run
- add live positive and negative TLS contracts for `verify-ca`, `verify-full`, `prefer`, `require`, and `disable` across the supported platform drivers
- document driver authentication, A/B/PG compatibility modes, production `verify-ca` configuration, and the current one-way TLS boundary

## Why

The adapter already forwarded `sslmode` and `sslrootcert`, but the behavior was not constrained by typed configuration, deterministic real-TLS coverage, or complete user documentation. This left certificate verification and server-required TLS vulnerable to regressions and made a persistent cloud instance appear necessary for testing.

The new fixture uses the existing disposable openGauss container, so CI exercises real TLS without external infrastructure or committed certificates.

## Validation

- `uv run --package datus-gaussdb --with pytest pytest datus-gaussdb/tests/unit -q` — 157 passed
- `ci/run-integration-tests.sh gaussdb` — 55 passed, 3 platform skips on macOS
- `uv run ruff check datus-gaussdb`
- `uv run ruff format --check datus-gaussdb`
- `bash -n ci/run-integration-tests.sh datus-gaussdb/scripts/generate-test-tls.sh datus-gaussdb/scripts/configure-test-tls.sh`
- `docker compose -f datus-gaussdb/docker-compose.yml config --quiet`
- `git diff --check`

Linux CI additionally exercises the official `gaussdb` native driver; the local macOS run exercised `pg8000` and `psycopg2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive TLS configuration for GaussDB/openGauss connections, including SSL modes, CA certificates, and hostname verification.
  - Added platform-aware driver guidance, with `pg8000` as the default path on macOS.
  - Added automated ephemeral TLS integration coverage for trusted, untrusted, and mismatched certificates.

- **Documentation**
  - Expanded setup, authentication, TLS, and integration-testing guidance.
  - Clarified certificate validation, fallback behavior, and production recommendations.

- **Tests**
  - Added validation for supported SSL modes and invalid configuration values.
  - Extended connection coverage across supported drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->