### PR TITLE
[BugFix] Filter GaussDB's built-in package schemas out of discovery

### DIFF
--- a/datus-gaussdb/datus_gaussdb/connector.py
+++ b/datus-gaussdb/datus_gaussdb/connector.py
@@ -14,6 +14,15 @@ from .config import GaussDBConfig
 
 logger = get_logger(__name__)
 
+# Namespaces GaussDB reserves for its built-in packages. A stock instance ships
+# ~30 of them (dbe_output, dbe_task, pkg_util, prvt_ilm, ...), all holding
+# functions rather than tables, and the roster grows between kernel versions —
+# so they are matched by prefix instead of enumerated. Without this, schema
+# discovery hands the caller 30+ empty schemas and anything that then walks them
+# pays a round trip each: over a cross-region link that alone blew a catalog
+# listing past its 30s budget.
+_SYS_SCHEMA_PREFIXES = ("dbe_", "pkg_", "prvt_")
+
 
 @dataclass
 class DbTraits:
@@ -83,9 +92,32 @@ class GaussDBConnector(PostgreSQLConnector):
             "dbe_pldeveloper",
             "dbe_sql_util",
             "pkg_service",
+            "resource_manager",
             "snapshot",
             "sqladvisor",
+            # Oracle-compatibility views, present in A-compat mode.
+            "sys",
+            # Injected by Huawei Cloud's managed service, not by the kernel, so
+            # they appear on cloud instances only — and in camelCase.
+            "rdsAdmin",
+            "rdsBackup",
+            "rdsMetric",
+            "rdsRepl",
         }
+
+    def _is_sys_schema(self, schema: str) -> bool:
+        """Whether *schema* is GaussDB's rather than the user's.
+
+        Deliberately does NOT treat the login role's own schema as system:
+        openGauss auto-creates one per user, and that is exactly where an
+        ordinary user's tables land.
+        """
+        return (
+            schema in self._sys_schemas()
+            or schema.startswith(_SYS_SCHEMA_PREFIXES)
+            or schema.startswith("pg_temp_")
+            or schema.startswith("pg_toast_temp_")
+        )
 
     # ==================== Feature Probing ====================
 
@@ -155,12 +187,7 @@ class GaussDBConnector(PostgreSQLConnector):
         schemas = result["schema_name"].tolist()
 
         if not include_sys:
-            sys_schemas = self._sys_schemas()
-            schemas = [
-                s
-                for s in schemas
-                if s not in sys_schemas and not s.startswith("pg_temp_") and not s.startswith("pg_toast_temp_")
-            ]
+            schemas = [s for s in schemas if not self._is_sys_schema(s)]
         return schemas
 
     @override

--- a/datus-gaussdb/tests/unit/test_connector_unit.py
+++ b/datus-gaussdb/tests/unit/test_connector_unit.py
@@ -222,6 +222,35 @@ def test_sys_databases_matches_postgresql():
 
 
 @pytest.mark.acceptance
+def test_sys_schemas_covers_oracle_compat_and_cloud_managed():
+    """A-compat views and Huawei Cloud's managed schemas are not the user's."""
+    sys_schemas = _make_connector()._sys_schemas()
+
+    assert {"sys", "resource_manager", "rdsAdmin", "rdsBackup", "rdsMetric", "rdsRepl"}.issubset(sys_schemas)
+
+
+@pytest.mark.acceptance
+@pytest.mark.parametrize(
+    "schema",
+    ["dbe_output", "dbe_xmlparser", "pkg_util", "prvt_ilm", "pg_temp_3", "pg_toast_temp_3"],
+)
+def test_is_sys_schema_matches_reserved_package_namespaces(schema):
+    """Built-in package schemas are matched by prefix, not by enumeration."""
+    assert _make_connector()._is_sys_schema(schema) is True
+
+
+@pytest.mark.acceptance
+@pytest.mark.parametrize("schema", ["public", "root", "analytics", "dbexport", "packages"])
+def test_is_sys_schema_keeps_user_schemas(schema):
+    """A login role's own schema is where its tables live — never filtered.
+
+    ``dbexport`` / ``packages`` guard the prefix rule against matching a name
+    that merely starts with the same letters as ``dbe_`` / ``pkg_``.
+    """
+    assert _make_connector()._is_sys_schema(schema) is False
+
+
+@pytest.mark.acceptance
 def test_get_schemas_uses_pg_namespace_and_filters_internal_prefixes():
     """Schema discovery uses pg_namespace and hides system and temporary schemas."""
     connector = _make_connector()
@@ -231,12 +260,21 @@ def test_get_schemas_uses_pg_namespace_and_filters_internal_prefixes():
         "pg_catalog",
         "dbe_perf",
         "pg_temp_3",
+        # A stock instance ships ~30 of these; walking them cost a round trip each.
+        "dbe_output",
+        "dbe_xmlparser",
+        "pkg_util",
+        "prvt_ilm",
+        "rdsBackup",
+        "sys",
+        # The connecting role's own schema stays.
+        "root",
     ]
     connector._execute_pandas = MagicMock(return_value=result)
 
     schemas = connector.get_schemas(database_name="analytics")
 
-    assert schemas == ["public"]
+    assert schemas == ["public", "root"]
     sql = connector._execute_pandas.call_args.args[0]
     assert "pg_namespace" in sql
     connector._execute_pandas.assert_called_once_with(sql, database_name="analytics")


### PR DESCRIPTION
## Symptom

A SaaS project bound to a Huawei Cloud GaussDB instance could not load its catalog. The browser reported

```
Access to fetch at '.../proxy/api/v1/catalog/list' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present
```

which was a red herring — the request was being aborted, not rejected. Backend logs:

```
runtime-agent: gateway proxy error  path=/api/v1/catalog/list
  err="net/http: timeout awaiting response headers"
request_completed  path=/api/v1/catalog/list  status=200  duration_ms=30629 / 30077 / 30167
```

The same endpoint took 600–815 ms before that datasource existed. Both the endpoint's own `asyncio.wait_for(..., timeout=30.0)` and the sandbox gateway's response-header budget are 30s; the gateway won the race and killed the connection, and its abort carries no CORS headers.

## Cause

Measured against the live instance, step by step:

| step | time |
| --- | --- |
| `test_connection` | 0.3s |
| `get_schemas` | 0.1s → **32 schemas** |
| `get_tables` × 32 | **9.2s** |

Only `public` held tables (5). The other 31 were GaussDB's own reserved namespaces:

```
dbe_application_info, dbe_compression, dbe_describe, dbe_file, dbe_heat_map, dbe_ilm,
dbe_ilm_admin, dbe_lob, dbe_match, dbe_output, dbe_profiler, dbe_random, dbe_raw,
dbe_scheduler, dbe_session, dbe_sql, dbe_stats, dbe_task, dbe_utility, dbe_xml,
dbe_xmldom, dbe_xmlgen, dbe_xmlparser, pkg_util, prvt_ilm, rdsBackup, rdsMetric,
rdsRepl, resource_manager, root, sys
```

`_sys_schemas()` covered only `dbe_perf`, `dbe_pldebugger`, `dbe_pldeveloper`, `dbe_sql_util` and `pkg_service`, so the rest flowed through to the caller, which then walked them one round trip at a time. 9.2s from a laptop; from `us-east-1` to a China-region instance the per-call RTT is ~6× higher (measured: 0.26s vs 0.04s just to open the socket), which is how 32 calls became >30s.

## Fix

- Match the reserved namespaces **by prefix** (`dbe_`, `pkg_`, `prvt_`) rather than enumerating them — the roster grows between kernel versions, so an exact list goes stale on the next release.
- Add the exact ones that have no shared prefix: `sys` (A-compat Oracle views), `resource_manager`, and `rdsAdmin` / `rdsBackup` / `rdsMetric` / `rdsRepl`, which Huawei Cloud injects on managed instances (note the camelCase).
- Route `get_schemas` through a single `_is_sys_schema()` predicate, which also absorbs the `pg_temp_` / `pg_toast_temp_` checks that were inline.

On the instance above this takes discovery from 32 schemas to 2 (`public`, `root`) and the catalog listing from >30s to sub-second.

**What is deliberately *not* filtered:** the login role's own schema. openGauss auto-creates one per user, and that is exactly where an ordinary user's tables land — dropping it would hide real data. `root` survives the filter above for that reason.

`_sys_schemas()` is also consumed by `PostgreSQLConnector`'s table-listing query, which takes a `Set[str]` and so does not see the prefixes. Left as is on purpose: these package schemas contain functions, not tables, so there is nothing there to leak.

## Tests

`datus-gaussdb/tests/unit` — **169 passed**. `ruff format --check` and `ruff check` clean.

New coverage: the prefix families and both temp-schema prefixes match; `public` / `root` / `analytics` do not; `dbexport` and `packages` are pinned so the prefix rule can never swallow a user schema that merely starts with the same letters; and `get_schemas` is asserted end-to-end against a realistic 11-schema listing.

Not run against a live instance from CI — the measurements above come from the reporting deployment's own GaussDB.