### PR TITLE
[Feature] Accept the GaussDB CA certificate as inline PEM

### DIFF
--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -39,7 +39,7 @@ agent:
 | `schema` | no | Default schema; defaults to `public` |
 | `driver` | no | `gaussdb` on Linux and `pg8000` on macOS by default; `psycopg2` is an md5-only escape hatch |
 | `sslmode` | no | `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, or `verify-full`; use `verify-ca` in production |
-| `sslrootcert` | for explicit verification | CA bundle used by `verify-ca`/`verify-full`; libpq's standard certificate locations are also honored |
+| `sslrootcert` | for explicit verification | CA bundle used by `verify-ca`/`verify-full`. Accepts a path **or** the PEM content itself — pg8000 verifies straight from memory, and for the libpq drivers the adapter writes the content to a private temp file. libpq's standard certificate locations are also honored |
 
 ```python
 from datus_gaussdb import GaussDBConfig, GaussDBConnector

--- a/datus-gaussdb/datus_gaussdb/_ca_cert.py
+++ b/datus-gaussdb/datus_gaussdb/_ca_cert.py
@@ -1,0 +1,77 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Accept a CA certificate as inline PEM, not only as a path on disk.
+
+A hosted caller uploads the certificate through a browser, so what reaches the
+adapter is the file's *content*: there is no operator to drop a file on the
+server first, and on a multi-tenant runtime there is nowhere stable to drop it.
+
+pg8000 can verify straight from memory. The libpq-based drivers cannot — they
+take a filename — so inline PEM is spilled to a private temp file, once per
+distinct certificate and reused thereafter.
+"""
+
+import atexit
+import hashlib
+import os
+import tempfile
+import threading
+from typing import Dict, Optional
+
+from datus_db_core import get_logger
+
+logger = get_logger(__name__)
+
+_PEM_MARKER = "-----BEGIN CERTIFICATE-----"
+
+_lock = threading.Lock()
+_materialized: Dict[str, str] = {}
+
+
+def is_inline_pem(value: Optional[str]) -> bool:
+    """Whether *value* is certificate content rather than a path to one."""
+    return bool(value) and _PEM_MARKER in value
+
+
+def as_path(value: Optional[str]) -> Optional[str]:
+    """Return a filesystem path for *value*, writing it out if it is inline PEM.
+
+    Paths pass through untouched, so a self-hosted deployment that mounts its
+    CA file keeps working exactly as before.
+    """
+    if not is_inline_pem(value):
+        return value
+
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    with _lock:
+        path = _materialized.get(digest)
+        if path and os.path.exists(path):
+            return path
+
+        fd, path = tempfile.mkstemp(prefix=f"datus-gaussdb-ca-{digest[:12]}-", suffix=".pem")
+        try:
+            # 0600 before the bytes land: a world-readable trust anchor is an
+            # invitation to swap it.
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(value)
+        except BaseException:
+            os.unlink(path)
+            raise
+
+        _materialized[digest] = path
+        logger.debug("Materialized inline GaussDB CA certificate to %s", path)
+        return path
+
+
+@atexit.register
+def _cleanup() -> None:
+    with _lock:
+        for path in _materialized.values():
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        _materialized.clear()

--- a/datus-gaussdb/datus_gaussdb/config.py
+++ b/datus-gaussdb/datus_gaussdb/config.py
@@ -46,8 +46,10 @@ class GaussDBConfig(PostgreSQLConfig):
     sslrootcert: Optional[str] = Field(
         default=None,
         description=(
-            "Path to the CA certificate used to verify the server for sslmode "
-            "verify-ca/verify-full. Forwarded to every supported driver; the "
-            "libpq-based drivers can also use their standard certificate locations"
+            "CA certificate used to verify the server for sslmode "
+            "verify-ca/verify-full — either a path or the PEM content itself, so a "
+            "caller with no filesystem on the server can supply an uploaded "
+            "certificate. Forwarded to every supported driver; the libpq-based "
+            "drivers can also use their standard certificate locations"
         ),
     )

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -128,6 +128,7 @@ class GaussDBDialect(PGDialect_psycopg):
 
     def create_connect_args(self, url):
         args, kwargs = super().create_connect_args(url)
+        _resolve_ca_kwarg(kwargs)
         # GaussDB/openGauss silently turns binary-format bound parameters
         # (int, date, ...) into NULL. ClientCursor interpolates parameters
         # client-side (psycopg2 semantics), which is fully correct against
@@ -167,6 +168,11 @@ class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
     driver = "psycopg2"
     supports_statement_cache = True
 
+    def create_connect_args(self, url):
+        args, kwargs = super().create_connect_args(url)
+        _resolve_ca_kwarg(kwargs)
+        return args, kwargs
+
     def _get_server_version_info(self, connection):
         return _get_server_version_info(connection)
 
@@ -186,6 +192,15 @@ class GaussDBPsycopg2Dialect(PGDialect_psycopg2):
             ext.register_type(tolerant_bool, conn)
 
         return connect
+
+
+def _resolve_ca_kwarg(kwargs: dict) -> None:
+    """Point ``sslrootcert`` at a file, in place, for the libpq-based drivers."""
+    from ._ca_cert import as_path
+
+    cert = kwargs.get("sslrootcert")
+    if cert:
+        kwargs["sslrootcert"] = as_path(cert)
 
 
 def _build_pg8000_ssl_context(sslmode, sslrootcert):
@@ -208,6 +223,15 @@ def _build_pg8000_ssl_context(sslmode, sslrootcert):
     """
     import ssl as ssl_module
 
+    from ._ca_cert import is_inline_pem
+
+    def _context() -> "ssl_module.SSLContext":
+        # An uploaded certificate never needs to touch the disk here: pg8000
+        # takes an SSLContext, and one can be built from the PEM text itself.
+        if is_inline_pem(sslrootcert):
+            return ssl_module.create_default_context(cadata=sslrootcert)
+        return ssl_module.create_default_context(cafile=sslrootcert)
+
     mode = (sslmode or "prefer").strip().lower()
     if mode == "disable":
         return False
@@ -216,13 +240,13 @@ def _build_pg8000_ssl_context(sslmode, sslrootcert):
     if mode == "require":
         if not sslrootcert:
             return True
-        context = ssl_module.create_default_context(cafile=sslrootcert)
+        context = _context()
         context.check_hostname = False
         return context
     if mode in ("verify-ca", "verify-full"):
         if not sslrootcert:
             raise ValueError(f"sslmode={mode} requires sslrootcert to point at the CA certificate")
-        context = ssl_module.create_default_context(cafile=sslrootcert)
+        context = _context()
         context.check_hostname = mode == "verify-full"
         return context
     raise ValueError(

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -398,3 +398,60 @@ def test_psycopg2_on_connect_registers_bool_caster():
     assert parse("0", None) is False
     assert parse(None, None) is None
     reg.assert_called_once_with("caster", conn)
+
+
+# ==================== Inline CA certificate ====================
+
+
+def test_pg8000_ssl_context_accepts_inline_pem():
+    """An uploaded certificate verifies from memory — no file is written."""
+    import ssl
+
+    from datus_gaussdb.sa_dialect import _build_pg8000_ssl_context
+
+    try:
+        ctx = _build_pg8000_ssl_context("verify-ca", _STUB_CERT)
+    except ssl.SSLError:
+        pytest.skip("stub certificate rejected by this OpenSSL build")
+
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.get_ca_certs(), "the inline certificate should be loaded into the trust store"
+
+
+def test_inline_pem_is_materialized_once_and_kept_private():
+    """libpq drivers only read a filename, so inline PEM has to hit the disk."""
+    import os
+
+    from datus_gaussdb import _ca_cert
+
+    path = _ca_cert.as_path(_STUB_CERT)
+
+    assert path != _STUB_CERT
+    assert open(path, encoding="utf-8").read() == _STUB_CERT
+    # A trust anchor other users can rewrite is worse than no verification.
+    assert os.stat(path).st_mode & 0o077 == 0
+    # Reused rather than re-written on every connection.
+    assert _ca_cert.as_path(_STUB_CERT) == path
+
+
+def test_ca_path_passes_through_untouched(tmp_path):
+    """A self-hosted deployment that mounts its CA file keeps working."""
+    from datus_gaussdb import _ca_cert
+
+    ca = tmp_path / "ca.pem"
+    ca.write_text(_STUB_CERT)
+
+    assert _ca_cert.as_path(str(ca)) == str(ca)
+    assert _ca_cert.as_path(None) is None
+    assert _ca_cert.is_inline_pem(str(ca)) is False
+
+
+def test_libpq_dialects_swap_inline_pem_for_a_path():
+    """Both libpq-based dialects hand the driver a filename, never the PEM."""
+    from datus_gaussdb.sa_dialect import _resolve_ca_kwarg
+
+    kwargs = {"sslrootcert": _STUB_CERT}
+    _resolve_ca_kwarg(kwargs)
+
+    assert kwargs["sslrootcert"] != _STUB_CERT
+    assert open(kwargs["sslrootcert"], encoding="utf-8").read() == _STUB_CERT


### PR DESCRIPTION
## Why

`sslrootcert` could only name a file on the machine running the adapter:

```python
ssl.create_default_context(cafile=sslrootcert)          # pg8000
"...?sslrootcert=" + quote_plus(sslrootcert)            # libpq drivers
```

A hosted caller has no such machine. The user uploads a certificate in a browser, so what reaches the adapter is the file's **content**, and on a multi-tenant runtime there is nowhere stable to drop it first. `verify-ca` / `verify-full` were therefore only reachable in self-hosted deployments — which is exactly where TLS verification matters least.

## What

`sslrootcert` now takes **either** a path or the PEM itself, detected by the `-----BEGIN CERTIFICATE-----` marker.

- **pg8000** needs no file at all: an `SSLContext` builds from PEM text through `cadata`, so that path stays entirely in memory.
- **libpq drivers** (`gaussdb`, `psycopg2`) only read a filename, so inline PEM is written to a `0600` temp file — once per distinct certificate, cached by content hash, reused on later connections, removed at exit. `create_connect_args` on both dialects swaps the value before the driver sees it.
- A value that is already a path passes through untouched: mounted CA files keep working exactly as before.

The mode-selection logic (`prefer` → `None`, `require` + CA → verify like `verify-ca`, and so on) is unchanged; only where the certificate comes from moved.

## Tests

`datus-gaussdb/tests/unit` — **173 passed**. `ruff format --check` / `ruff check` clean.

New coverage: an inline cert lands in the pg8000 context's trust store (`get_ca_certs()` non-empty); the materialized file has the right content, is not group/other readable, and is reused rather than rewritten; a path and `None` pass through; and `_resolve_ca_kwarg` hands the libpq dialects a filename rather than the PEM.

## Consumers

Datus-saas [#791](https://github.com/Datus-ai/Datus-saas/pull/791) turns that field into a drag-and-drop upload and stores the content, and Datus-backend already forwards it verbatim — so this PR is what makes that chain work end to end. Worth releasing before the SaaS side ships, or an uploaded certificate reaches an adapter that treats it as a filename.