### PR TITLE
[BugFix] Allow GaussDB and psycopg to coexist

### DIFF
--- a/datus-gaussdb/README.md
+++ b/datus-gaussdb/README.md
@@ -70,7 +70,9 @@ identifiers.
 
 GaussDB defaults to `sha256` password authentication, which vanilla PostgreSQL
 drivers do not implement. The default `gaussdb` driver speaks it natively, so a
-stock server works with no server-side changes.
+stock server works with no server-side changes. Its SQLAlchemy dialect binds
+directly to the renamed driver, so it can coexist in one process with the real
+`psycopg` package used by PostgreSQL connections and storage backends.
 
 The `pg8000` driver reaches the same result without libpq: it extends the
 pure-Python [pg8000](https://pypi.org/project/pg8000/) driver with GaussDB's

--- a/datus-gaussdb/datus_gaussdb/sa_dialect.py
+++ b/datus-gaussdb/datus_gaussdb/sa_dialect.py
@@ -5,11 +5,10 @@
 """SQLAlchemy dialects for GaussDB/openGauss client drivers.
 
 The official ``gaussdb`` driver is a psycopg3 fork with the module tree renamed
-psycopg->gaussdb. SQLAlchemy's built-in ``postgresql+psycopg`` dialect
-hard-imports ``psycopg`` submodules in ~15 places; rather than reimplementing
-the dialect, the (API-identical) ``gaussdb`` module tree is aliased into
-``sys.modules`` under the ``psycopg`` names before the dialect first touches
-them.
+psycopg->gaussdb. SQLAlchemy's built-in ``postgresql+psycopg`` dialect imports
+the concrete ``psycopg`` package from several driver-specific hooks. This
+module overrides those hooks to use ``gaussdb`` directly, so PostgreSQL's real
+``psycopg`` package and the GaussDB driver can coexist in one process.
 
 The optional psycopg2 path uses its own GaussDB-named dialect. This keeps the
 stock PostgreSQL dialect untouched while allowing PostgreSQL's macOS libpq to
@@ -26,9 +25,9 @@ URL forms::
     gaussdb+pg8000://user:password@host:port/database
 """
 
-import sys
-import types
+import importlib
 
+from sqlalchemy import util
 from sqlalchemy.dialects import registry
 from sqlalchemy.dialects.postgresql.pg8000 import PGDialect_pg8000
 from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
@@ -49,82 +48,55 @@ def _gaussdb_bool_in(data):
     return data in _BOOL_TRUE_TEXTS
 
 
-_PSYCOPG_SUBMODULES = (
-    "adapt",
-    "pq",
-    "rows",
-    "sql",
-    "types",
-    "types.array",
-    "types.datetime",
-    "types.hstore",
-    "types.json",
-    "types.multirange",
-    "types.range",
-    "types.string",
-)
-
-
-def _alias_gaussdb_as_psycopg():
-    """Alias the gaussdb module tree under the ``psycopg`` names.
-
-    The parent dialect hard-imports ``psycopg`` submodules from roughly a
-    dozen call sites, so the fork is published under those names instead of
-    the dialect being reimplemented. Since a process cannot hold two
-    different modules under one name, real psycopg and this dialect are
-    mutually exclusive within a process; the conflicting case raises instead
-    of silently mixing the two drivers' adapter registries.
-    """
-    import_gaussdb()
-    aliased = sys.modules.get("psycopg")
-    if aliased is not None:
-        if aliased is not sys.modules["gaussdb"]:
-            raise ImportError(
-                "psycopg is already imported in this process, so the GaussDB "
-                "dialect cannot alias the gaussdb driver onto it. Use the "
-                "GaussDB datasource in a process that does not import psycopg "
-                "(psycopg2 is unaffected), or set driver='psycopg2' on the "
-                "GaussDB datasource."
-            )
-        return
-    import importlib
-
-    sys.modules["psycopg"] = sys.modules["gaussdb"]
-    for name in _PSYCOPG_SUBMODULES:
-        try:
-            sys.modules[f"psycopg.{name}"] = importlib.import_module(f"gaussdb.{name}")
-        except ImportError:
-            pass
-
-
-class _GaussDBDbapiProxy(types.ModuleType):
-    """Delegate to the gaussdb module while reporting a psycopg-3.x version.
-
-    The fork versions itself 1.x; PGDialect_psycopg refuses anything below
-    psycopg 3.0.2.
-    """
-
-    def __init__(self, module):
-        super().__init__(module.__name__)
-        self._module = module
-
-    def __getattr__(self, name):
-        return getattr(self._module, name)
-
-    @property
-    def __version__(self):
-        return "3.2.0"
+def _import_gaussdb_submodule(name: str):
+    """Import a driver submodule lazily without touching ``psycopg``."""
+    return importlib.import_module(f"gaussdb.{name}")
 
 
 class GaussDBDialect(PGDialect_psycopg):
+    """SQLAlchemy's psycopg dialect bound directly to the GaussDB fork.
+
+    ``PGDialect_psycopg`` is still the correct behavioral base because the
+    official driver preserves psycopg3's DB-API and adaptation interfaces.
+    Its driver-specific hooks import the concrete ``psycopg`` package,
+    though. Each such hook is overridden here so this dialect never mutates
+    or consumes the real PostgreSQL driver's module namespace.
+    """
+
     name = "gaussdb"
     driver = "psycopg"
     supports_statement_cache = True
 
+    def __init__(self, **kwargs):
+        # PGDialect_psycopg only performs its hard-coded ``psycopg`` imports
+        # when a DB-API module is supplied. Let it initialize the common
+        # PostgreSQL state without a driver, then install the real GaussDB
+        # module and the equivalent adapter map ourselves.
+        dbapi = kwargs.pop("dbapi", None)
+        super().__init__(dbapi=None, **kwargs)
+        self.dbapi = dbapi
+
+        if dbapi is None:
+            return
+
+        adapt = _import_gaussdb_submodule("adapt")
+        adapters_map = adapt.AdaptersMap(dbapi.adapters)
+        self._psycopg_adapters_map = adapters_map
+
+        if self._native_inet_types is False:
+            string_types = _import_gaussdb_submodule("types.string")
+            adapters_map.register_loader("inet", string_types.TextLoader)
+            adapters_map.register_loader("cidr", string_types.TextLoader)
+
+        json_types = _import_gaussdb_submodule("types.json")
+        if self._json_deserializer:
+            json_types.set_json_loads(self._json_deserializer, adapters_map)
+        if self._json_serializer:
+            json_types.set_json_dumps(self._json_serializer, adapters_map)
+
     @classmethod
     def import_dbapi(cls):
-        _alias_gaussdb_as_psycopg()
-        return _GaussDBDbapiProxy(sys.modules["gaussdb"])
+        return import_gaussdb()
 
     def create_connect_args(self, url):
         args, kwargs = super().create_connect_args(url)
@@ -133,17 +105,62 @@ class GaussDBDialect(PGDialect_psycopg):
         # (int, date, ...) into NULL. ClientCursor interpolates parameters
         # client-side (psycopg2 semantics), which is fully correct against
         # this server family.
-        kwargs.setdefault("cursor_factory", sys.modules["gaussdb"].ClientCursor)
+        kwargs.setdefault("cursor_factory", self.dbapi.ClientCursor)
         return args, kwargs
+
+    def _type_info_fetch(self, connection, name):
+        types = _import_gaussdb_submodule("types")
+        return types.TypeInfo.fetch(connection.connection.driver_connection, name)
+
+    def initialize(self, connection):
+        # Skip PGDialect_psycopg.initialize(), whose HSTORE registration
+        # imports psycopg directly, while preserving its behavior with the
+        # corresponding GaussDB module.
+        super(PGDialect_psycopg, self).initialize(connection)
+
+        if not self.insert_returning:
+            self.insert_executemany_returning = False
+
+        if self.use_native_hstore:
+            info = self._type_info_fetch(connection, "hstore")
+            self._has_native_hstore = info is not None
+            if self._has_native_hstore:
+                hstore = _import_gaussdb_submodule("types.hstore")
+                hstore.register_hstore(info, self._psycopg_adapters_map)
+                hstore.register_hstore(info, connection.connection.driver_connection)
+
+    @classmethod
+    def get_async_dialect_cls(cls, url):
+        raise NotImplementedError("The official GaussDB SQLAlchemy dialect currently supports synchronous engines only")
+
+    @util.memoized_property
+    def _psycopg_Json(self):
+        return _import_gaussdb_submodule("types.json").Json
+
+    @util.memoized_property
+    def _psycopg_Jsonb(self):
+        return _import_gaussdb_submodule("types.json").Jsonb
+
+    @util.memoized_property
+    def _psycopg_TransactionStatus(self):
+        return _import_gaussdb_submodule("pq").TransactionStatus
+
+    @util.memoized_property
+    def _psycopg_Range(self):
+        return _import_gaussdb_submodule("types.range").Range
+
+    @util.memoized_property
+    def _psycopg_Multirange(self):
+        return _import_gaussdb_submodule("types.multirange").Multirange
 
     def _get_server_version_info(self, connection):
         return _get_server_version_info(connection)
 
     def on_connect(self):
         parent = super().on_connect()
-        gaussdb_mod = sys.modules["gaussdb"]
+        adapt = _import_gaussdb_submodule("adapt")
 
-        class _TolerantBoolLoader(gaussdb_mod.adapt.Loader):
+        class _TolerantBoolLoader(adapt.Loader):
             def load(self, data):
                 return bytes(data).decode("ascii") in _BOOL_TRUE_TEXTS
 

--- a/datus-gaussdb/tests/unit/test_sa_dialect.py
+++ b/datus-gaussdb/tests/unit/test_sa_dialect.py
@@ -2,99 +2,196 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""SQLAlchemy dialect tests that never touch the real ``gaussdb`` driver.
+"""SQLAlchemy dialect tests that never touch the native ``gaussdb`` driver."""
 
-The driver binds a GaussDB-specific libpq at import time and is unavailable on
-macOS, so every test here works against a stub module installed in
-``sys.modules`` for the duration of the test.
-"""
-
+import ast
+import inspect
 import sys
+import textwrap
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from sqlalchemy.dialects import registry
+from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 
 from datus_gaussdb import sa_dialect
-from datus_gaussdb.sa_dialect import GaussDBDialect, GaussDBPsycopg2Dialect, _GaussDBDbapiProxy
+from datus_gaussdb.sa_dialect import GaussDBDialect, GaussDBPsycopg2Dialect
 
 
 def _stub_gaussdb_module() -> types.ModuleType:
     """Minimal stand-in for the gaussdb driver module."""
     module = types.ModuleType("gaussdb")
     module.__version__ = "1.0.4"
+    module.adapters = object()
+    module.paramstyle = "pyformat"
     module.ClientCursor = type("ClientCursor", (), {})
     module.Error = type("Error", (Exception,), {})
     return module
 
 
-# ==================== _GaussDBDbapiProxy ====================
+def _stub_gaussdb_submodules(monkeypatch):
+    """Install API-shaped driver submodules without importing native libpq."""
+
+    class AdaptersMap:
+        def __init__(self, adapters):
+            self.source = adapters
+            self.loaders = {}
+
+        def register_loader(self, name, loader):
+            self.loaders[name] = loader
+
+    class Loader:
+        pass
+
+    modules = {
+        "adapt": types.SimpleNamespace(AdaptersMap=AdaptersMap, Loader=Loader),
+        "types": types.SimpleNamespace(TypeInfo=type("TypeInfo", (), {})),
+        "types.string": types.SimpleNamespace(TextLoader=type("TextLoader", (), {})),
+        "types.json": types.SimpleNamespace(
+            Json=type("Json", (), {}),
+            Jsonb=type("Jsonb", (), {}),
+            set_json_loads=MagicMock(),
+            set_json_dumps=MagicMock(),
+        ),
+        "types.hstore": types.SimpleNamespace(register_hstore=MagicMock()),
+        "types.range": types.SimpleNamespace(Range=type("Range", (), {})),
+        "types.multirange": types.SimpleNamespace(Multirange=type("Multirange", (), {})),
+        "pq": types.SimpleNamespace(TransactionStatus=type("TransactionStatus", (), {"IDLE": 0})),
+    }
+    monkeypatch.setattr(sa_dialect, "_import_gaussdb_submodule", modules.__getitem__)
+    return modules
+
+
+# ==================== Driver coexistence ====================
 
 
 @pytest.mark.acceptance
-def test_dbapi_proxy_reports_psycopg3_version():
-    """PGDialect_psycopg refuses anything below psycopg 3.0.2, so the 1.x fork lies."""
-    module = _stub_gaussdb_module()
-
-    proxy = _GaussDBDbapiProxy(module)
-
-    assert module.__version__ == "1.0.4"
-    assert proxy.__version__ == "3.2.0"
-
-
-@pytest.mark.acceptance
-def test_dbapi_proxy_delegates_attributes():
-    """Everything other than the version comes straight from the driver module."""
-    module = _stub_gaussdb_module()
-
-    proxy = _GaussDBDbapiProxy(module)
-
-    assert proxy.ClientCursor is module.ClientCursor
-    assert proxy.Error is module.Error
-    assert proxy.__name__ == "gaussdb"
-
-
-@pytest.mark.acceptance
-def test_dbapi_proxy_raises_for_unknown_attribute():
-    """Missing driver attributes surface as AttributeError, not None."""
-    proxy = _GaussDBDbapiProxy(_stub_gaussdb_module())
-    missing = "no_such_attribute"
-
-    with pytest.raises(AttributeError):
-        getattr(proxy, missing)
-
-
-# ==================== Driver aliasing ====================
-
-
-@pytest.mark.acceptance
-def test_import_dbapi_aliases_gaussdb_when_psycopg_is_not_loaded(monkeypatch):
-    """GaussDB-first processes install the compatible driver under psycopg."""
+def test_import_dbapi_does_not_install_a_psycopg_alias(monkeypatch):
+    """GaussDB-first processes leave the real driver's namespace untouched."""
     gaussdb = _stub_gaussdb_module()
-    monkeypatch.setitem(sys.modules, "gaussdb", gaussdb)
     monkeypatch.delitem(sys.modules, "psycopg", raising=False)
     monkeypatch.setattr(sa_dialect, "import_gaussdb", lambda: gaussdb)
 
     dbapi = GaussDBDialect.import_dbapi()
 
-    assert sys.modules["psycopg"] is gaussdb
-    assert dbapi._module is gaussdb
+    assert dbapi is gaussdb
+    assert "psycopg" not in sys.modules
 
 
 @pytest.mark.acceptance
-def test_import_dbapi_rejects_an_already_loaded_psycopg(monkeypatch):
-    """Psycopg-first processes fail clearly instead of mixing registries."""
+def test_import_dbapi_preserves_an_already_loaded_psycopg(monkeypatch):
+    """SaaS can load PostgreSQL storage before the official GaussDB driver."""
     gaussdb = _stub_gaussdb_module()
     psycopg = types.ModuleType("psycopg")
-    monkeypatch.setitem(sys.modules, "gaussdb", gaussdb)
+    psycopg_rows = types.ModuleType("psycopg.rows")
     monkeypatch.setitem(sys.modules, "psycopg", psycopg)
+    monkeypatch.setitem(sys.modules, "psycopg.rows", psycopg_rows)
     monkeypatch.setattr(sa_dialect, "import_gaussdb", lambda: gaussdb)
 
-    with pytest.raises(ImportError, match="psycopg is already imported"):
-        GaussDBDialect.import_dbapi()
+    dbapi = GaussDBDialect.import_dbapi()
+
+    assert dbapi is gaussdb
+    assert sys.modules["psycopg"] is psycopg
+    assert sys.modules["psycopg.rows"] is psycopg_rows
+
+
+@pytest.mark.acceptance
+def test_dialect_initialization_uses_gaussdb_adapters_without_touching_psycopg(monkeypatch):
+    gaussdb = _stub_gaussdb_module()
+    psycopg = types.ModuleType("psycopg")
+    monkeypatch.setitem(sys.modules, "psycopg", psycopg)
+    _stub_gaussdb_submodules(monkeypatch)
+
+    dialect = GaussDBDialect(dbapi=gaussdb)
+
+    assert dialect.dbapi is gaussdb
+    assert dialect._psycopg_adapters_map.source is gaussdb.adapters
+    assert sys.modules["psycopg"] is psycopg
+
+
+@pytest.mark.acceptance
+def test_driver_specific_type_hooks_resolve_from_gaussdb(monkeypatch):
+    gaussdb = _stub_gaussdb_module()
+    modules = _stub_gaussdb_submodules(monkeypatch)
+    dialect = GaussDBDialect(dbapi=gaussdb)
+
+    assert dialect._psycopg_Json is modules["types.json"].Json
+    assert dialect._psycopg_Jsonb is modules["types.json"].Jsonb
+    assert dialect._psycopg_TransactionStatus is modules["pq"].TransactionStatus
+    assert dialect._psycopg_Range is modules["types.range"].Range
+    assert dialect._psycopg_Multirange is modules["types.multirange"].Multirange
+
+
+@pytest.mark.acceptance
+def test_dialect_initialization_configures_gaussdb_json_and_inet(monkeypatch):
+    gaussdb = _stub_gaussdb_module()
+    modules = _stub_gaussdb_submodules(monkeypatch)
+    loads = MagicMock()
+    dumps = MagicMock()
+
+    dialect = GaussDBDialect(
+        dbapi=gaussdb,
+        native_inet_types=False,
+        json_deserializer=loads,
+        json_serializer=dumps,
+    )
+
+    adapters = dialect._psycopg_adapters_map
+    assert adapters.loaders == {
+        "inet": modules["types.string"].TextLoader,
+        "cidr": modules["types.string"].TextLoader,
+    }
+    modules["types.json"].set_json_loads.assert_called_once_with(loads, adapters)
+    modules["types.json"].set_json_dumps.assert_called_once_with(dumps, adapters)
+
+
+@pytest.mark.acceptance
+def test_initialize_registers_hstore_through_gaussdb(monkeypatch):
+    modules = _stub_gaussdb_submodules(monkeypatch)
+    dialect = GaussDBDialect.__new__(GaussDBDialect)
+    dialect.insert_returning = True
+    dialect.use_native_hstore = True
+    dialect._psycopg_adapters_map = object()
+    dialect._type_info_fetch = MagicMock(return_value="hstore-info")
+    connection = MagicMock()
+
+    with patch.object(PGDialect, "initialize", return_value=None):
+        dialect.initialize(connection)
+
+    register = modules["types.hstore"].register_hstore
+    assert register.call_args_list == [
+        call("hstore-info", dialect._psycopg_adapters_map),
+        call("hstore-info", connection.connection.driver_connection),
+    ]
+
+
+@pytest.mark.acceptance
+def test_official_driver_async_dialect_is_explicitly_unsupported():
+    with pytest.raises(NotImplementedError, match="synchronous engines only"):
+        GaussDBDialect.get_async_dialect_cls(MagicMock())
+
+
+@pytest.mark.acceptance
+def test_all_sqlalchemy_psycopg_import_hooks_are_overridden():
+    """Fail loudly if a SQLAlchemy upgrade adds a new concrete-driver import."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(PGDialect_psycopg)))
+    class_node = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    hard_import_hooks = set()
+
+    for node in class_node.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Import) and any(alias.name.startswith("psycopg") for alias in child.names):
+                hard_import_hooks.add(node.name)
+            if isinstance(child, ast.ImportFrom) and (child.module or "").startswith("psycopg"):
+                hard_import_hooks.add(node.name)
+
+    missing = hard_import_hooks - GaussDBDialect.__dict__.keys()
+    assert not missing, f"GaussDBDialect must override new psycopg-bound hooks: {sorted(missing)}"
 
 
 # ==================== _get_server_version_info ====================
@@ -150,11 +247,11 @@ def test_psycopg2_server_version_info_uses_gaussdb_parser():
 
 
 @pytest.mark.acceptance
-def test_create_connect_args_injects_client_cursor(monkeypatch):
+def test_create_connect_args_injects_client_cursor():
     """Binary-format bound parameters come back NULL, so a ClientCursor is forced."""
     module = _stub_gaussdb_module()
-    monkeypatch.setitem(sys.modules, "gaussdb", module)
     dialect = GaussDBDialect.__new__(GaussDBDialect)
+    dialect.dbapi = module
 
     with patch.object(
         PGDialect_psycopg,
@@ -169,12 +266,12 @@ def test_create_connect_args_injects_client_cursor(monkeypatch):
 
 
 @pytest.mark.acceptance
-def test_create_connect_args_keeps_explicit_cursor_factory(monkeypatch):
+def test_create_connect_args_keeps_explicit_cursor_factory():
     """An explicitly configured cursor_factory is not overwritten."""
     module = _stub_gaussdb_module()
-    monkeypatch.setitem(sys.modules, "gaussdb", module)
     custom_cursor = type("CustomCursor", (), {})
     dialect = GaussDBDialect.__new__(GaussDBDialect)
+    dialect.dbapi = module
 
     with patch.object(
         PGDialect_psycopg,
@@ -217,6 +314,12 @@ def test_stock_postgresql_psycopg2_dialect_is_unchanged():
     assert registry.load("postgresql.psycopg2") is PGDialect_psycopg2
 
 
+@pytest.mark.acceptance
+def test_stock_postgresql_psycopg_dialect_is_unchanged():
+    """The official GaussDB dialect does not replace PostgreSQL's psycopg3 dialect."""
+    assert registry.load("postgresql.psycopg") is PGDialect_psycopg
+
+
 # ==================== pg8000 dialect ====================
 
 
@@ -232,11 +335,15 @@ def test_pg8000_dialect_identity_and_registration():
     assert registry.load("gaussdb.pg8000") is GaussDBPg8000Dialect
 
 
-def test_pg8000_import_dbapi_is_gauss_module():
+def test_pg8000_import_dbapi_is_gauss_module_and_preserves_psycopg(monkeypatch):
     from datus_gaussdb import _pg8000_gauss
     from datus_gaussdb.sa_dialect import GaussDBPg8000Dialect
 
+    psycopg = types.ModuleType("psycopg")
+    monkeypatch.setitem(sys.modules, "psycopg", psycopg)
+
     assert GaussDBPg8000Dialect.import_dbapi() is _pg8000_gauss
+    assert sys.modules["psycopg"] is psycopg
 
 
 @pytest.mark.parametrize(
@@ -376,6 +483,22 @@ def test_pg8000_on_connect_registers_bool_adapter():
     hook = dialect.on_connect()
     hook(conn)
     conn.register_in_adapter.assert_called_once_with(16, _gaussdb_bool_in)
+
+
+def test_official_driver_on_connect_registers_gaussdb_bool_loader(monkeypatch):
+    modules = _stub_gaussdb_submodules(monkeypatch)
+    dialect = GaussDBDialect.__new__(GaussDBDialect)
+    conn = MagicMock()
+
+    with patch.object(PGDialect_psycopg, "on_connect", return_value=None):
+        hook = dialect.on_connect()
+    hook(conn)
+
+    name, loader = conn.adapters.register_loader.call_args.args
+    assert name == "bool"
+    assert issubclass(loader, modules["adapt"].Loader)
+    assert loader.load(object(), b"1") is True
+    assert loader.load(object(), b"0") is False
 
 
 def test_psycopg2_on_connect_registers_bool_caster():


### PR DESCRIPTION
## Summary

- bind the official GaussDB SQLAlchemy dialect directly to the renamed `gaussdb` driver instead of aliasing it into `sys.modules` as `psycopg`
- preserve the real `psycopg` package used by PostgreSQL connections and SaaS storage backends
- keep the explicit `pg8000` and `psycopg2` paths unchanged, including the macOS `pg8000` default
- add regression coverage for driver import order, adapter/type hooks, HSTORE registration, and future SQLAlchemy psycopg imports

## Root cause

The official `gaussdb` package is a renamed psycopg3 fork, while SQLAlchemy's `PGDialect_psycopg` imports concrete `psycopg` modules from several driver-specific hooks. The adapter previously worked around that by publishing `gaussdb` under the global `psycopg` module names. SaaS already imports the real `psycopg` package for PostgreSQL-backed storage, so the two drivers could not coexist and the GaussDB connection test failed.

The dialect now overrides every psycopg-bound hook and resolves the equivalent implementation from `gaussdb` directly. It continues to inherit the common psycopg dialect behavior without mutating the process-wide Python module registry.

## Impact

- `driver=gaussdb` can be used by Linux/SaaS processes that already load real psycopg
- `driver=pg8000` remains available explicitly on every platform and remains the macOS default
- `driver=psycopg2` remains the MD5-only compatibility path
- stock PostgreSQL psycopg and psycopg2 dialect registrations remain untouched

## Validation

- `uv run --all-packages --with pytest --with pandas --with pyarrow pytest datus-gaussdb/tests/unit -m 'not integration' --tb=short -q` (`178 passed`)
- `uv run ruff check datus-gaussdb`
- `uv run ruff format --check datus-gaussdb`
- `ci/run-integration-tests.sh gaussdb` (`55 passed, 3 skipped` on macOS, exercising the live pg8000 path)
- Linux/amd64 native-driver SQLAlchemy smoke test against openGauss (`SELECT 1` passed)
- coexistence smoke test with the Backend environment's real `psycopg 3.3.4`
- `uv build --package datus-gaussdb`
